### PR TITLE
fix(core): Bound the wait for the workflow publication lock

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
@@ -49,7 +49,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 		instanceSettings = { isLeader: false } as InstanceSettings;
 		lifecycleLock.isLocked.mockReturnValue(false);
 		lifecycleLock.runExclusive.mockImplementation(
-			async (_workflowId, fn) => await (fn as () => Promise<unknown>)(),
+			async ({ fn }) => await (fn as () => Promise<unknown>)(),
 		);
 		activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([]);
 		activeWorkflowTriggers.remove.mockResolvedValue(true);
@@ -70,10 +70,14 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 			await createDeactivator().deactivateAllNonWebhookTriggers();
 
 			expect(outboxConsumer.stopPolling).toHaveBeenCalledTimes(1);
-			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-1', expect.any(Function), {
+			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith({
+				workflowId: 'wf-1',
+				fn: expect.any(Function),
 				signal: expect.any(AbortSignal),
 			});
-			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-2', expect.any(Function), {
+			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith({
+				workflowId: 'wf-2',
+				fn: expect.any(Function),
 				signal: expect.any(AbortSignal),
 			});
 			expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-1');
@@ -98,9 +102,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 			expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-free');
 			expect(activeWorkflowTriggers.remove).not.toHaveBeenCalledWith('wf-locked');
 			expect(lifecycleLock.runExclusive).not.toHaveBeenCalledWith(
-				'wf-locked',
-				expect.any(Function),
-				expect.anything(),
+				expect.objectContaining({ workflowId: 'wf-locked' }),
 			);
 		});
 
@@ -136,7 +138,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 
 		test('aborts the remaining teardown when promoted back to leader mid-stepdown', async () => {
 			activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-1', 'wf-2']);
-			lifecycleLock.runExclusive.mockImplementation(async (_workflowId, fn) => {
+			lifecycleLock.runExclusive.mockImplementation(async ({ fn }) => {
 				// Promotion lands while the teardown is waiting on the first lock —
 				// deactivating now would race the takeover's own re-activation.
 				instanceSettings = Object.assign(instanceSettings, { isLeader: true });
@@ -157,10 +159,14 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 				const removed = await createDeactivator().sweepGhostTriggers();
 
 				expect(removed).toBe(2);
-				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-1', expect.any(Function), {
+				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith({
+					workflowId: 'wf-1',
+					fn: expect.any(Function),
 					signal: expect.any(AbortSignal),
 				});
-				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-2', expect.any(Function), {
+				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith({
+					workflowId: 'wf-2',
+					fn: expect.any(Function),
 					signal: expect.any(AbortSignal),
 				});
 				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-1');
@@ -195,15 +201,13 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-free');
 				expect(activeWorkflowTriggers.remove).not.toHaveBeenCalledWith('wf-busy');
 				expect(lifecycleLock.runExclusive).not.toHaveBeenCalledWith(
-					'wf-busy',
-					expect.any(Function),
-					expect.anything(),
+					expect.objectContaining({ workflowId: 'wf-busy' }),
 				);
 			});
 
 			test('aborts inside the lock when promoted to leader mid-sweep', async () => {
 				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-1']);
-				lifecycleLock.runExclusive.mockImplementation(async (_workflowId, fn) => {
+				lifecycleLock.runExclusive.mockImplementation(async ({ fn }) => {
 					// Promotion lands while this sweep is waiting on the lock.
 					instanceSettings = Object.assign(instanceSettings, { isLeader: true });
 					return await (fn as () => Promise<unknown>)();

--- a/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
@@ -30,6 +30,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 		const workflowsConfig = mock<WorkflowsConfig>({
 			useWorkflowPublicationService,
 			publicationReconcileIntervalSeconds: RECONCILE_INTERVAL_SECONDS,
+			publicationOutboxLeaseSeconds: 120,
 		});
 		return new PublishedWorkflowTriggerDeactivator(
 			logger,
@@ -69,8 +70,12 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 			await createDeactivator().deactivateAllNonWebhookTriggers();
 
 			expect(outboxConsumer.stopPolling).toHaveBeenCalledTimes(1);
-			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-1', expect.any(Function));
-			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-2', expect.any(Function));
+			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-1', expect.any(Function), {
+				signal: expect.any(AbortSignal),
+			});
+			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-2', expect.any(Function), {
+				signal: expect.any(AbortSignal),
+			});
 			expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-1');
 			expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-2');
 			expect(errorReporter.error).not.toHaveBeenCalled();
@@ -95,6 +100,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 			expect(lifecycleLock.runExclusive).not.toHaveBeenCalledWith(
 				'wf-locked',
 				expect.any(Function),
+				expect.anything(),
 			);
 		});
 
@@ -151,8 +157,12 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 				const removed = await createDeactivator().sweepGhostTriggers();
 
 				expect(removed).toBe(2);
-				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-1', expect.any(Function));
-				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-2', expect.any(Function));
+				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-1', expect.any(Function), {
+					signal: expect.any(AbortSignal),
+				});
+				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-2', expect.any(Function), {
+					signal: expect.any(AbortSignal),
+				});
 				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-1');
 				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-2');
 				// A ghost on a follower is evidence of a zombie writer — loud, not debug.
@@ -187,6 +197,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 				expect(lifecycleLock.runExclusive).not.toHaveBeenCalledWith(
 					'wf-busy',
 					expect.any(Function),
+					expect.anything(),
 				);
 			});
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-lifecycle-lock.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-lifecycle-lock.test.ts
@@ -3,14 +3,16 @@ import { WorkflowPublicationLifecycleLock } from '@/workflows/publication/workfl
 const flushMacrotasks = async () => await new Promise((resolve) => setImmediate(resolve));
 
 /** A signal that never aborts, for callers that want the unbounded wait. */
-const never = () => ({ signal: new AbortController().signal });
+const never = () => new AbortController().signal;
 
 describe('WorkflowPublicationLifecycleLock', () => {
 	describe('runExclusive', () => {
 		test('returns the result of the wrapped function', async () => {
 			const lock = new WorkflowPublicationLifecycleLock();
 
-			await expect(lock.runExclusive('wf-1', async () => 42, never())).resolves.toBe(42);
+			await expect(
+				lock.runExclusive({ workflowId: 'wf-1', fn: async () => 42, signal: never() }),
+			).resolves.toBe(42);
 		});
 
 		test('serializes concurrent callers for the same workflow in FIFO order', async () => {
@@ -18,24 +20,24 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			const events: string[] = [];
 			let releaseFirst!: () => void;
 
-			const first = lock.runExclusive(
-				'wf-1',
-				async () => {
+			const first = lock.runExclusive({
+				workflowId: 'wf-1',
+				fn: async () => {
 					events.push('first-acquired');
 					await new Promise<void>((resolve) => {
 						releaseFirst = resolve;
 					});
 					events.push('first-released');
 				},
-				never(),
-			);
-			const second = lock.runExclusive(
-				'wf-1',
-				async () => {
+				signal: never(),
+			});
+			const second = lock.runExclusive({
+				workflowId: 'wf-1',
+				fn: async () => {
 					events.push('second-acquired');
 				},
-				never(),
-			);
+				signal: never(),
+			});
 
 			await flushMacrotasks();
 			// The second caller cannot enter while the first holds the same lock.
@@ -52,18 +54,18 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			const events: string[] = [];
 
 			// Hold wf-1 indefinitely; wf-2 must still run.
-			const held = lock.runExclusive(
-				'wf-1',
-				async () => await new Promise<void>(() => {}),
-				never(),
-			);
-			await lock.runExclusive(
-				'wf-2',
-				async () => {
+			const held = lock.runExclusive({
+				workflowId: 'wf-1',
+				fn: async () => await new Promise<void>(() => {}),
+				signal: never(),
+			});
+			await lock.runExclusive({
+				workflowId: 'wf-2',
+				fn: async () => {
 					events.push('wf-2-ran');
 				},
-				never(),
-			);
+				signal: never(),
+			});
 
 			expect(events).toEqual(['wf-2-ran']);
 			void held;
@@ -73,17 +75,19 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			const lock = new WorkflowPublicationLifecycleLock();
 
 			await expect(
-				lock.runExclusive(
-					'wf-1',
-					async () => {
+				lock.runExclusive({
+					workflowId: 'wf-1',
+					fn: async () => {
 						throw new Error('boom');
 					},
-					never(),
-				),
+					signal: never(),
+				}),
 			).rejects.toThrow('boom');
 
 			// A subsequent caller can still acquire the same workflow's lock.
-			await expect(lock.runExclusive('wf-1', async () => 'ok', never())).resolves.toBe('ok');
+			await expect(
+				lock.runExclusive({ workflowId: 'wf-1', fn: async () => 'ok', signal: never() }),
+			).resolves.toBe('ok');
 		});
 
 		describe('abort signal', () => {
@@ -94,14 +98,18 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				let ran = false;
 
 				// Hold wf-1 indefinitely, then queue an abortable waiter behind it.
-				void lock.runExclusive('wf-1', async () => await new Promise<void>(() => {}), never());
-				const waiting = lock.runExclusive(
-					'wf-1',
-					async () => {
+				void lock.runExclusive({
+					workflowId: 'wf-1',
+					fn: async () => await new Promise<void>(() => {}),
+					signal: never(),
+				});
+				const waiting = lock.runExclusive({
+					workflowId: 'wf-1',
+					fn: async () => {
 						ran = true;
 					},
-					{ signal: controller.signal },
-				);
+					signal: controller.signal,
+				});
 				await flushMacrotasks();
 
 				controller.abort(reason);
@@ -117,7 +125,11 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				controller.abort(reason);
 
 				await expect(
-					lock.runExclusive('wf-1', async () => 'unreachable', { signal: controller.signal }),
+					lock.runExclusive({
+						workflowId: 'wf-1',
+						fn: async () => 'unreachable',
+						signal: controller.signal,
+					}),
 				).rejects.toBe(reason);
 				// Nothing was acquired, so nothing is held.
 				expect(lock.isLocked('wf-1')).toBe(false);
@@ -129,29 +141,29 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				const controller = new AbortController();
 				let releaseFirst!: () => void;
 
-				const first = lock.runExclusive(
-					'wf-1',
-					async () => {
+				const first = lock.runExclusive({
+					workflowId: 'wf-1',
+					fn: async () => {
 						await new Promise<void>((resolve) => {
 							releaseFirst = resolve;
 						});
 					},
-					never(),
-				);
-				const aborted = lock.runExclusive(
-					'wf-1',
-					async () => {
+					signal: never(),
+				});
+				const aborted = lock.runExclusive({
+					workflowId: 'wf-1',
+					fn: async () => {
 						events.push('aborted-ran');
 					},
-					{ signal: controller.signal },
-				);
-				const third = lock.runExclusive(
-					'wf-1',
-					async () => {
+					signal: controller.signal,
+				});
+				const third = lock.runExclusive({
+					workflowId: 'wf-1',
+					fn: async () => {
 						events.push('third-ran');
 					},
-					never(),
-				);
+					signal: never(),
+				});
 				await flushMacrotasks();
 
 				controller.abort(new Error('deadline'));
@@ -170,13 +182,17 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				const controller = new AbortController();
 
 				await expect(
-					lock.runExclusive('wf-1', async () => 'ok', { signal: controller.signal }),
+					lock.runExclusive({
+						workflowId: 'wf-1',
+						fn: async () => 'ok',
+						signal: controller.signal,
+					}),
 				).resolves.toBe('ok');
 				// Aborting after the fact must be a no-op.
 				controller.abort(new Error('late'));
-				await expect(lock.runExclusive('wf-1', async () => 'still ok', never())).resolves.toBe(
-					'still ok',
-				);
+				await expect(
+					lock.runExclusive({ workflowId: 'wf-1', fn: async () => 'still ok', signal: never() }),
+				).resolves.toBe('still ok');
 			});
 		});
 	});
@@ -187,15 +203,15 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			expect(lock.isLocked('wf-1')).toBe(false);
 
 			let release!: () => void;
-			const held = lock.runExclusive(
-				'wf-1',
-				async () => {
+			const held = lock.runExclusive({
+				workflowId: 'wf-1',
+				fn: async () => {
 					await new Promise<void>((resolve) => {
 						release = resolve;
 					});
 				},
-				never(),
-			);
+				signal: never(),
+			});
 			// Let the wrapped function start so `release` is assigned.
 			await flushMacrotasks();
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-lifecycle-lock.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-lifecycle-lock.test.ts
@@ -2,12 +2,15 @@ import { WorkflowPublicationLifecycleLock } from '@/workflows/publication/workfl
 
 const flushMacrotasks = async () => await new Promise((resolve) => setImmediate(resolve));
 
+/** A signal that never aborts, for callers that want the unbounded wait. */
+const never = () => ({ signal: new AbortController().signal });
+
 describe('WorkflowPublicationLifecycleLock', () => {
 	describe('runExclusive', () => {
 		test('returns the result of the wrapped function', async () => {
 			const lock = new WorkflowPublicationLifecycleLock();
 
-			await expect(lock.runExclusive('wf-1', async () => 42)).resolves.toBe(42);
+			await expect(lock.runExclusive('wf-1', async () => 42, never())).resolves.toBe(42);
 		});
 
 		test('serializes concurrent callers for the same workflow in FIFO order', async () => {
@@ -15,16 +18,24 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			const events: string[] = [];
 			let releaseFirst!: () => void;
 
-			const first = lock.runExclusive('wf-1', async () => {
-				events.push('first-acquired');
-				await new Promise<void>((resolve) => {
-					releaseFirst = resolve;
-				});
-				events.push('first-released');
-			});
-			const second = lock.runExclusive('wf-1', async () => {
-				events.push('second-acquired');
-			});
+			const first = lock.runExclusive(
+				'wf-1',
+				async () => {
+					events.push('first-acquired');
+					await new Promise<void>((resolve) => {
+						releaseFirst = resolve;
+					});
+					events.push('first-released');
+				},
+				never(),
+			);
+			const second = lock.runExclusive(
+				'wf-1',
+				async () => {
+					events.push('second-acquired');
+				},
+				never(),
+			);
 
 			await flushMacrotasks();
 			// The second caller cannot enter while the first holds the same lock.
@@ -41,10 +52,18 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			const events: string[] = [];
 
 			// Hold wf-1 indefinitely; wf-2 must still run.
-			const held = lock.runExclusive('wf-1', async () => await new Promise<void>(() => {}));
-			await lock.runExclusive('wf-2', async () => {
-				events.push('wf-2-ran');
-			});
+			const held = lock.runExclusive(
+				'wf-1',
+				async () => await new Promise<void>(() => {}),
+				never(),
+			);
+			await lock.runExclusive(
+				'wf-2',
+				async () => {
+					events.push('wf-2-ran');
+				},
+				never(),
+			);
 
 			expect(events).toEqual(['wf-2-ran']);
 			void held;
@@ -54,16 +73,20 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			const lock = new WorkflowPublicationLifecycleLock();
 
 			await expect(
-				lock.runExclusive('wf-1', async () => {
-					throw new Error('boom');
-				}),
+				lock.runExclusive(
+					'wf-1',
+					async () => {
+						throw new Error('boom');
+					},
+					never(),
+				),
 			).rejects.toThrow('boom');
 
 			// A subsequent caller can still acquire the same workflow's lock.
-			await expect(lock.runExclusive('wf-1', async () => 'ok')).resolves.toBe('ok');
+			await expect(lock.runExclusive('wf-1', async () => 'ok', never())).resolves.toBe('ok');
 		});
 
-		describe('with an abort signal', () => {
+		describe('abort signal', () => {
 			test('rejects with the abort reason when aborted while waiting, without running the function', async () => {
 				const lock = new WorkflowPublicationLifecycleLock();
 				const reason = new Error('deadline');
@@ -71,13 +94,13 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				let ran = false;
 
 				// Hold wf-1 indefinitely, then queue an abortable waiter behind it.
-				void lock.runExclusive('wf-1', async () => await new Promise<void>(() => {}));
+				void lock.runExclusive('wf-1', async () => await new Promise<void>(() => {}), never());
 				const waiting = lock.runExclusive(
 					'wf-1',
 					async () => {
 						ran = true;
 					},
-					controller.signal,
+					{ signal: controller.signal },
 				);
 				await flushMacrotasks();
 
@@ -94,7 +117,7 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				controller.abort(reason);
 
 				await expect(
-					lock.runExclusive('wf-1', async () => 'unreachable', controller.signal),
+					lock.runExclusive('wf-1', async () => 'unreachable', { signal: controller.signal }),
 				).rejects.toBe(reason);
 				// Nothing was acquired, so nothing is held.
 				expect(lock.isLocked('wf-1')).toBe(false);
@@ -106,21 +129,29 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				const controller = new AbortController();
 				let releaseFirst!: () => void;
 
-				const first = lock.runExclusive('wf-1', async () => {
-					await new Promise<void>((resolve) => {
-						releaseFirst = resolve;
-					});
-				});
+				const first = lock.runExclusive(
+					'wf-1',
+					async () => {
+						await new Promise<void>((resolve) => {
+							releaseFirst = resolve;
+						});
+					},
+					never(),
+				);
 				const aborted = lock.runExclusive(
 					'wf-1',
 					async () => {
 						events.push('aborted-ran');
 					},
-					controller.signal,
+					{ signal: controller.signal },
 				);
-				const third = lock.runExclusive('wf-1', async () => {
-					events.push('third-ran');
-				});
+				const third = lock.runExclusive(
+					'wf-1',
+					async () => {
+						events.push('third-ran');
+					},
+					never(),
+				);
 				await flushMacrotasks();
 
 				controller.abort(new Error('deadline'));
@@ -134,16 +165,18 @@ describe('WorkflowPublicationLifecycleLock', () => {
 				expect(lock.isLocked('wf-1')).toBe(false);
 			});
 
-			test('acquiring normally with a signal that never fires leaves no dangling listener', async () => {
+			test('acquiring normally leaves no dangling listener', async () => {
 				const lock = new WorkflowPublicationLifecycleLock();
 				const controller = new AbortController();
 
-				await expect(lock.runExclusive('wf-1', async () => 'ok', controller.signal)).resolves.toBe(
-					'ok',
-				);
+				await expect(
+					lock.runExclusive('wf-1', async () => 'ok', { signal: controller.signal }),
+				).resolves.toBe('ok');
 				// Aborting after the fact must be a no-op.
 				controller.abort(new Error('late'));
-				await expect(lock.runExclusive('wf-1', async () => 'still ok')).resolves.toBe('still ok');
+				await expect(lock.runExclusive('wf-1', async () => 'still ok', never())).resolves.toBe(
+					'still ok',
+				);
 			});
 		});
 	});
@@ -154,11 +187,15 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			expect(lock.isLocked('wf-1')).toBe(false);
 
 			let release!: () => void;
-			const held = lock.runExclusive('wf-1', async () => {
-				await new Promise<void>((resolve) => {
-					release = resolve;
-				});
-			});
+			const held = lock.runExclusive(
+				'wf-1',
+				async () => {
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					});
+				},
+				never(),
+			);
 			// Let the wrapped function start so `release` is assigned.
 			await flushMacrotasks();
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-lifecycle-lock.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-lifecycle-lock.test.ts
@@ -62,6 +62,90 @@ describe('WorkflowPublicationLifecycleLock', () => {
 			// A subsequent caller can still acquire the same workflow's lock.
 			await expect(lock.runExclusive('wf-1', async () => 'ok')).resolves.toBe('ok');
 		});
+
+		describe('with an abort signal', () => {
+			test('rejects with the abort reason when aborted while waiting, without running the function', async () => {
+				const lock = new WorkflowPublicationLifecycleLock();
+				const reason = new Error('deadline');
+				const controller = new AbortController();
+				let ran = false;
+
+				// Hold wf-1 indefinitely, then queue an abortable waiter behind it.
+				void lock.runExclusive('wf-1', async () => await new Promise<void>(() => {}));
+				const waiting = lock.runExclusive(
+					'wf-1',
+					async () => {
+						ran = true;
+					},
+					controller.signal,
+				);
+				await flushMacrotasks();
+
+				controller.abort(reason);
+
+				await expect(waiting).rejects.toBe(reason);
+				expect(ran).toBe(false);
+			});
+
+			test('rejects immediately when the signal is already aborted', async () => {
+				const lock = new WorkflowPublicationLifecycleLock();
+				const reason = new Error('deadline');
+				const controller = new AbortController();
+				controller.abort(reason);
+
+				await expect(
+					lock.runExclusive('wf-1', async () => 'unreachable', controller.signal),
+				).rejects.toBe(reason);
+				// Nothing was acquired, so nothing is held.
+				expect(lock.isLocked('wf-1')).toBe(false);
+			});
+
+			test('an aborted waiter is skipped over when the lock is released', async () => {
+				const lock = new WorkflowPublicationLifecycleLock();
+				const events: string[] = [];
+				const controller = new AbortController();
+				let releaseFirst!: () => void;
+
+				const first = lock.runExclusive('wf-1', async () => {
+					await new Promise<void>((resolve) => {
+						releaseFirst = resolve;
+					});
+				});
+				const aborted = lock.runExclusive(
+					'wf-1',
+					async () => {
+						events.push('aborted-ran');
+					},
+					controller.signal,
+				);
+				const third = lock.runExclusive('wf-1', async () => {
+					events.push('third-ran');
+				});
+				await flushMacrotasks();
+
+				controller.abort(new Error('deadline'));
+				await expect(aborted).rejects.toThrow('deadline');
+
+				releaseFirst();
+				await Promise.all([first, third]);
+
+				expect(events).toEqual(['third-ran']);
+				// The entry is dropped once released with no remaining waiters.
+				expect(lock.isLocked('wf-1')).toBe(false);
+			});
+
+			test('acquiring normally with a signal that never fires leaves no dangling listener', async () => {
+				const lock = new WorkflowPublicationLifecycleLock();
+				const controller = new AbortController();
+
+				await expect(lock.runExclusive('wf-1', async () => 'ok', controller.signal)).resolves.toBe(
+					'ok',
+				);
+				// Aborting after the fact must be a no-op.
+				controller.abort(new Error('late'));
+				await expect(lock.runExclusive('wf-1', async () => 'still ok')).resolves.toBe('still ok');
+			});
+		});
 	});
 
 	describe('isLocked', () => {

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -33,6 +33,7 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 	const ABANDON_GRACE_MS = 10_000;
 
 	let lifecycleLock: WorkflowPublicationLifecycleLock;
+	let instanceSettings: InstanceSettings;
 
 	function createConsumer(
 		useWorkflowPublicationService = true,
@@ -47,6 +48,7 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			publicationOutboxLeaseSeconds: leaseSeconds,
 		});
 		lifecycleLock = new WorkflowPublicationLifecycleLock();
+		instanceSettings = mock<InstanceSettings>({ isLeader });
 		return new WorkflowPublicationOutboxConsumer(
 			logger,
 			workflowsConfig,
@@ -54,7 +56,7 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			outboxRepository,
 			applier,
 			reporter,
-			mock<InstanceSettings>({ isLeader }),
+			instanceSettings,
 			lifecycleLock,
 			tracing,
 			eventService,
@@ -485,6 +487,28 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			expect(outboxRepository.returnToPending).toHaveBeenCalledWith(7);
 			expect(applier.apply).not.toHaveBeenCalled();
 			expect(reporter.report).not.toHaveBeenCalled();
+		});
+
+		test('returns the record to the queue when leadership is lost while waiting for the lock', async () => {
+			const record = makeRecord({ id: 8, workflowId: 'wf-held' });
+			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}));
+			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(record).mockResolvedValue(null);
+			consumer.startPolling();
+
+			const drain = consumer.drainPending();
+			await vi.advanceTimersByTimeAsync(0);
+			// Stepdown while queued on the lock; the abort then fires on a former leader.
+			Object.assign(instanceSettings, { isLeader: false });
+			await vi.advanceTimersByTimeAsync(ABORT_AFTER_MS);
+			await drain;
+
+			// The new leader reprocesses it: not failed here, no outcome emitted.
+			expect(outboxRepository.returnToPending).toHaveBeenCalledWith(8);
+			expect(reporter.report).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalledWith(
+				'workflow-publication-outbox-record-processed',
+				expect.anything(),
+			);
 		});
 	});
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -598,18 +598,89 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			expect(lifecycleLock.isLocked('wf-1')).toBe(false);
 		});
 
-		test('leaves an aborted record in progress for lease reclaim instead of applying it', async () => {
+		test('fails a record whose abort fires before it could start applying', async () => {
 			const record = makeRecord({ id: 7, workflowId: 'wf-7' });
 			const controller = new AbortController();
-			controller.abort();
+			const reason = new Error('deadline');
+			controller.abort(reason);
 
 			await consumer.processRecord(record, controller.signal);
 
-			// Not returned to pending: the wait for the lock may have outlived the
-			// lease, and flipping the row would release a newer claimant's claim.
+			// The abort fires well inside the lease, so the claim is still ours and
+			// the terminal status is safe to write; nothing was applied.
 			expect(outboxRepository.returnToPending).not.toHaveBeenCalled();
 			expect(applier.apply).not.toHaveBeenCalled();
+			expect(reporter.report).toHaveBeenCalledWith(
+				record,
+				expect.objectContaining({
+					type: 'failed',
+					error: expect.objectContaining({ cause: reason }),
+				}),
+			);
+		});
+
+		test('fails a record that times out waiting for the workflow lock, instead of leaving it in progress', async () => {
+			const record = makeRecord({ id: 1, workflowId: 'wf-held' });
+			// Another holder (e.g. an abandoned earlier record) never releases the lock.
+			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}));
+			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(record).mockResolvedValue(null);
+			consumer.startPolling();
+
+			const drain = consumer.drainPending();
+			await vi.advanceTimersByTimeAsync(ABORT_AFTER_MS);
+			await drain;
+
+			expect(applier.apply).not.toHaveBeenCalled();
+			expect(reporter.report).toHaveBeenCalledWith(
+				record,
+				expect.objectContaining({
+					type: 'failed',
+					error: expect.objectContaining({
+						message: expect.stringContaining('previous publication of this workflow'),
+					}),
+				}),
+			);
+			// Settled at the deadline: never abandoned, and the metric reflects the failure.
+			expect(errorReporter.error).not.toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: expect.stringContaining('Abandoned workflow publication outbox record'),
+				}),
+				expect.anything(),
+			);
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-publication-outbox-record-processed',
+				expect.objectContaining({ result: 'failed' }),
+			);
+		});
+
+		test('a reclaimed record whose earlier attempt still holds the workflow lock reaches a terminal status', async () => {
+			const stuck = makeRecord({ id: 1, workflowId: 'wf-stuck' });
+			// The first apply never settles and ignores the abort signal (e.g. a hang
+			// before any abort race, such as a cache or DB call).
+			applier.apply.mockImplementationOnce(async () => await new Promise(() => {}));
+			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(stuck).mockResolvedValue(null);
+			consumer.startPolling();
+
+			let drain = consumer.drainPending();
+			await vi.advanceTimersByTimeAsync(ABORT_AFTER_MS + ABANDON_GRACE_MS);
+			await drain;
 			expect(reporter.report).not.toHaveBeenCalled();
+			expect(lifecycleLock.isLocked('wf-stuck')).toBe(true);
+
+			// The lease expires and the claim query re-leases the same in_progress row.
+			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(stuck).mockResolvedValue(null);
+			drain = consumer.drainPending();
+			await vi.advanceTimersByTimeAsync(ABORT_AFTER_MS);
+			await drain;
+
+			// The retry cannot get the lock, so it fails the record rather than
+			// leaving it in progress to be reclaimed and abandoned forever.
+			expect(applier.apply).toHaveBeenCalledTimes(1);
+			expect(reporter.report).toHaveBeenCalledTimes(1);
+			expect(reporter.report).toHaveBeenCalledWith(
+				stuck,
+				expect.objectContaining({ type: 'failed' }),
+			);
 		});
 
 		test('scales the abandon grace down for short leases so abandonment stays within the lease', async () => {

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -491,7 +491,9 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 
 		test('returns the record to the queue when leadership is lost while waiting for the lock', async () => {
 			const record = makeRecord({ id: 8, workflowId: 'wf-held' });
-			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}));
+			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}), {
+				signal: new AbortController().signal,
+			});
 			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(record).mockResolvedValue(null);
 			consumer.startPolling();
 
@@ -646,7 +648,9 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		test('fails a record that times out waiting for the workflow lock, instead of leaving it in progress', async () => {
 			const record = makeRecord({ id: 1, workflowId: 'wf-held' });
 			// Another holder (e.g. an abandoned earlier record) never releases the lock.
-			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}));
+			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}), {
+				signal: new AbortController().signal,
+			});
 			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(record).mockResolvedValue(null);
 			consumer.startPolling();
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -491,7 +491,9 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 
 		test('returns the record to the queue when leadership is lost while waiting for the lock', async () => {
 			const record = makeRecord({ id: 8, workflowId: 'wf-held' });
-			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}), {
+			void lifecycleLock.runExclusive({
+				workflowId: 'wf-held',
+				fn: async () => await new Promise<void>(() => {}),
 				signal: new AbortController().signal,
 			});
 			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(record).mockResolvedValue(null);
@@ -648,7 +650,9 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		test('fails a record that times out waiting for the workflow lock, instead of leaving it in progress', async () => {
 			const record = makeRecord({ id: 1, workflowId: 'wf-held' });
 			// Another holder (e.g. an abandoned earlier record) never releases the lock.
-			void lifecycleLock.runExclusive('wf-held', async () => await new Promise<void>(() => {}), {
+			void lifecycleLock.runExclusive({
+				workflowId: 'wf-held',
+				fn: async () => await new Promise<void>(() => {}),
 				signal: new AbortController().signal,
 			});
 			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(record).mockResolvedValue(null);

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
@@ -74,7 +74,7 @@ beforeEach(() => {
 	activeWorkflowTriggers.remove.mockResolvedValue(true);
 	workflowRepository.getActiveIds.mockResolvedValue([]);
 	workflowRepository.findOneBy.mockResolvedValue(null);
-	lifecycleLock.runExclusive.mockImplementation(async (_workflowId, fn) => await fn());
+	lifecycleLock.runExclusive.mockImplementation(async ({ fn }) => await fn());
 	lifecycleLock.isLocked.mockReturnValue(false);
 	triggerDeactivator.sweepGhostTriggers.mockResolvedValue(0);
 	service = new WorkflowPublicationReconciler(
@@ -375,7 +375,9 @@ describe('WorkflowPublicationReconciler', () => {
 
 			await service.reconcile('reconcile');
 
-			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-ghost', expect.any(Function), {
+			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith({
+				workflowId: 'wf-ghost',
+				fn: expect.any(Function),
 				signal: expect.any(AbortSignal),
 			});
 			expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-ghost');

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
@@ -28,6 +28,7 @@ const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
 const config = mock<WorkflowsConfig>({
 	useWorkflowPublicationService: true,
 	publicationReconcileIntervalSeconds: 5,
+	publicationOutboxLeaseSeconds: 120,
 });
 const triggerStatusRepository = mock<WorkflowPublicationTriggerStatusRepository>();
 const outboxRepository = mock<WorkflowPublicationOutboxRepository>();
@@ -59,6 +60,7 @@ beforeEach(() => {
 	Object.assign(config, {
 		useWorkflowPublicationService: true,
 		publicationReconcileIntervalSeconds: 5,
+		publicationOutboxLeaseSeconds: 120,
 	});
 	triggerStatusRepository.findActivatedInMemoryTriggers.mockResolvedValue([]);
 	outboxRepository.enqueueByWorkflowIds.mockResolvedValue();
@@ -373,7 +375,9 @@ describe('WorkflowPublicationReconciler', () => {
 
 			await service.reconcile('reconcile');
 
-			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-ghost', expect.any(Function));
+			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-ghost', expect.any(Function), {
+				signal: expect.any(AbortSignal),
+			});
 			expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-ghost');
 			expect(eventService.emit).toHaveBeenCalledWith(
 				'workflow-publication-reconciliation',

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
@@ -73,6 +73,7 @@ beforeEach(() => {
 	workflowRepository.getActiveIds.mockResolvedValue([]);
 	workflowRepository.findOneBy.mockResolvedValue(null);
 	lifecycleLock.runExclusive.mockImplementation(async (_workflowId, fn) => await fn());
+	lifecycleLock.isLocked.mockReturnValue(false);
 	triggerDeactivator.sweepGhostTriggers.mockResolvedValue(0);
 	service = new WorkflowPublicationReconciler(
 		logger,
@@ -390,6 +391,24 @@ describe('WorkflowPublicationReconciler', () => {
 			expect(eventService.emit).toHaveBeenCalledWith(
 				'workflow-publication-reconciliation',
 				expect.objectContaining({ surplusCount: 0 }),
+			);
+		});
+
+		it('skips a ghost whose workflow lock is held rather than queueing on it', async () => {
+			// A record (or an abandoned one) holds the lock: queueing would wedge this
+			// pass, and every later tick, behind it. The next tick retries.
+			setGhost('wf-ghost');
+			lifecycleLock.isLocked.mockReturnValue(true);
+
+			await service.reconcile('reconcile');
+
+			expect(lifecycleLock.runExclusive).not.toHaveBeenCalled();
+			expect(activeWorkflowTriggers.remove).not.toHaveBeenCalled();
+			// The pass carried on into the later detections.
+			expect(triggerStatusRepository.findActivatedInMemoryTriggers).toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-publication-reconciliation',
+				expect.objectContaining({ result: 'success', surplusCount: 0 }),
 			);
 		});
 

--- a/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
+++ b/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
@@ -122,16 +122,16 @@ export class PublishedWorkflowTriggerDeactivator {
 					continue;
 				}
 				this.consecutiveLockSkipsByWorkflowId.delete(workflowId);
-				const result = await this.lifecycleLock.runExclusive(
+				const result = await this.lifecycleLock.runExclusive({
 					workflowId,
-					async () => {
+					fn: async () => {
 						if (this.instanceSettings.isLeader && !this.isShuttingDown) return false;
 						return await this.activeWorkflowTriggers.remove(workflowId);
 					},
 					// The lock was free a moment ago; a holder that took it since is a
 					// record in flight, which settles within its lease.
-					{ signal: AbortSignal.timeout(this.leaseMs) },
-				);
+					signal: AbortSignal.timeout(this.leaseMs),
+				});
 				if (result) {
 					deactivatedWorkflows.push(workflowId);
 				}

--- a/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
+++ b/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { WorkflowsConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
 import { OnLeaderStepdown, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { ActiveWorkflowTriggers, ErrorReporter, InstanceSettings } from 'n8n-core';
@@ -49,6 +50,10 @@ export class PublishedWorkflowTriggerDeactivator {
 		private readonly eventService: EventService,
 	) {
 		this.logger = this.logger.scoped('workflow-publication');
+	}
+
+	private get leaseMs(): number {
+		return this.workflowsConfig.publicationOutboxLeaseSeconds * Time.seconds.toMilliseconds;
 	}
 
 	/**
@@ -117,10 +122,16 @@ export class PublishedWorkflowTriggerDeactivator {
 					continue;
 				}
 				this.consecutiveLockSkipsByWorkflowId.delete(workflowId);
-				const result = await this.lifecycleLock.runExclusive(workflowId, async () => {
-					if (this.instanceSettings.isLeader && !this.isShuttingDown) return false;
-					return await this.activeWorkflowTriggers.remove(workflowId);
-				});
+				const result = await this.lifecycleLock.runExclusive(
+					workflowId,
+					async () => {
+						if (this.instanceSettings.isLeader && !this.isShuttingDown) return false;
+						return await this.activeWorkflowTriggers.remove(workflowId);
+					},
+					// The lock was free a moment ago; a holder that took it since is a
+					// record in flight, which settles within its lease.
+					{ signal: AbortSignal.timeout(this.leaseMs) },
+				);
 				if (result) {
 					deactivatedWorkflows.push(workflowId);
 				}

--- a/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
@@ -34,12 +34,7 @@ export class WorkflowPublicationLifecycleLock {
 		return this.stateByWorkflowId.has(workflowId);
 	}
 
-	/**
-	 * Runs `fn` under the workflow's lock. Without `signal` the wait to acquire is
-	 * unbounded; with one, an abort while still waiting rejects with the abort
-	 * reason and `fn` never runs. A holder that never releases (an abandoned
-	 * record's orphaned work) would otherwise pin every later caller forever.
-	 */
+	/** Runs `fn` under the workflow's lock. Waits indefinitely, or until the abort signal fires. */
 	async runExclusive<T>(
 		workflowId: string,
 		fn: () => Promise<T>,

--- a/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
@@ -1,9 +1,13 @@
 import { Service } from '@n8n/di';
-import { ensureError } from '@n8n/utils/errors/ensure-error';
 
 interface WorkflowLockState {
 	locked: boolean;
 	waiters: Array<() => void>;
+}
+
+interface RunExclusiveOptions {
+	/** Bounds the wait for the lock: an abort while waiting rejects with its reason. */
+	signal: AbortSignal;
 }
 
 /**
@@ -34,11 +38,11 @@ export class WorkflowPublicationLifecycleLock {
 		return this.stateByWorkflowId.has(workflowId);
 	}
 
-	/** Runs `fn` under the workflow's lock. Waits indefinitely, or until the abort signal fires. */
+	/** Runs `fn` under the workflow's lock, waiting until the lock is free or `signal` aborts. */
 	async runExclusive<T>(
 		workflowId: string,
 		fn: () => Promise<T>,
-		signal?: AbortSignal,
+		{ signal }: RunExclusiveOptions,
 	): Promise<T> {
 		await this.acquire(workflowId, signal);
 		try {
@@ -57,8 +61,8 @@ export class WorkflowPublicationLifecycleLock {
 		return state;
 	}
 
-	private async acquire(workflowId: string, signal?: AbortSignal): Promise<void> {
-		if (signal?.aborted) throw ensureError(signal.reason);
+	private async acquire(workflowId: string, signal: AbortSignal): Promise<void> {
+		signal.throwIfAborted();
 
 		const state = this.getOrCreateState(workflowId);
 		if (!state.locked) {
@@ -68,7 +72,7 @@ export class WorkflowPublicationLifecycleLock {
 
 		await new Promise<void>((resolve, reject) => {
 			const waiter = () => {
-				signal?.removeEventListener('abort', onAbort);
+				signal.removeEventListener('abort', onAbort);
 				resolve();
 			};
 			// Drop the waiter so a later release hands the lock to the next live
@@ -76,10 +80,10 @@ export class WorkflowPublicationLifecycleLock {
 			const onAbort = () => {
 				const index = state.waiters.indexOf(waiter);
 				if (index !== -1) state.waiters.splice(index, 1);
-				reject(ensureError(signal?.reason));
+				reject(signal.reason);
 			};
 			state.waiters.push(waiter);
-			signal?.addEventListener('abort', onAbort, { once: true });
+			signal.addEventListener('abort', onAbort, { once: true });
 		});
 	}
 

--- a/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
 
 interface WorkflowLockState {
 	locked: boolean;
@@ -33,9 +34,18 @@ export class WorkflowPublicationLifecycleLock {
 		return this.stateByWorkflowId.has(workflowId);
 	}
 
-	/** Runs `fn` under the workflow's lock, waiting indefinitely to acquire it. */
-	async runExclusive<T>(workflowId: string, fn: () => Promise<T>): Promise<T> {
-		await this.acquire(workflowId);
+	/**
+	 * Runs `fn` under the workflow's lock. Without `signal` the wait to acquire is
+	 * unbounded; with one, an abort while still waiting rejects with the abort
+	 * reason and `fn` never runs. A holder that never releases (an abandoned
+	 * record's orphaned work) would otherwise pin every later caller forever.
+	 */
+	async runExclusive<T>(
+		workflowId: string,
+		fn: () => Promise<T>,
+		signal?: AbortSignal,
+	): Promise<T> {
+		await this.acquire(workflowId, signal);
 		try {
 			return await fn();
 		} finally {
@@ -52,14 +62,30 @@ export class WorkflowPublicationLifecycleLock {
 		return state;
 	}
 
-	private async acquire(workflowId: string): Promise<void> {
+	private async acquire(workflowId: string, signal?: AbortSignal): Promise<void> {
+		if (signal?.aborted) throw ensureError(signal.reason);
+
 		const state = this.getOrCreateState(workflowId);
 		if (!state.locked) {
 			state.locked = true;
 			return;
 		}
 
-		await new Promise<void>((resolve) => state.waiters.push(resolve));
+		await new Promise<void>((resolve, reject) => {
+			const waiter = () => {
+				signal?.removeEventListener('abort', onAbort);
+				resolve();
+			};
+			// Drop the waiter so a later release hands the lock to the next live
+			// one instead of to a caller that has already given up.
+			const onAbort = () => {
+				const index = state.waiters.indexOf(waiter);
+				if (index !== -1) state.waiters.splice(index, 1);
+				reject(ensureError(signal?.reason));
+			};
+			state.waiters.push(waiter);
+			signal?.addEventListener('abort', onAbort, { once: true });
+		});
 	}
 
 	/** Hands ownership to the next waiter, or drops the entry when none are waiting. */

--- a/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-lifecycle-lock.ts
@@ -5,7 +5,9 @@ interface WorkflowLockState {
 	waiters: Array<() => void>;
 }
 
-interface RunExclusiveOptions {
+interface RunExclusiveOptions<T> {
+	workflowId: string;
+	fn: () => Promise<T>;
 	/** Bounds the wait for the lock: an abort while waiting rejects with its reason. */
 	signal: AbortSignal;
 }
@@ -39,11 +41,7 @@ export class WorkflowPublicationLifecycleLock {
 	}
 
 	/** Runs `fn` under the workflow's lock, waiting until the lock is free or `signal` aborts. */
-	async runExclusive<T>(
-		workflowId: string,
-		fn: () => Promise<T>,
-		{ signal }: RunExclusiveOptions,
-	): Promise<T> {
+	async runExclusive<T>({ workflowId, fn, signal }: RunExclusiveOptions<T>): Promise<T> {
 		await this.acquire(workflowId, signal);
 		try {
 			return await fn();

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -4,7 +4,7 @@ import { Time } from '@n8n/constants';
 import { WorkflowPublicationOutbox, WorkflowPublicationOutboxRepository } from '@n8n/db';
 import { OnLeaderTakeover, OnPubSubEvent, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { ErrorReporter, InstanceSettings, SpanStatus, Tracing } from 'n8n-core';
+import { ErrorReporter, InstanceSettings, SpanStatus, Tracing, type Span } from 'n8n-core';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { OperationalError, UnexpectedError, UserError } from 'n8n-workflow';
 
@@ -308,6 +308,14 @@ export class WorkflowPublicationOutboxConsumer {
 	 * terminal-status write always lands before teardown proceeds. If leadership was lost
 	 * between claiming the record and entering the critical section, the record is returned
 	 * to the queue (so the new leader reprocesses it) and nothing is applied here.
+	 *
+	 * The wait for the lock is bounded by `signal`: a record whose deadline fires
+	 * before it could start applying is failed (outside the lock, since nothing was
+	 * applied) rather than left `in_progress`. The abort fires well inside the lease,
+	 * so the claim is still this worker's and the terminal write is safe. Leaving the
+	 * row would have it reclaimed once the lease expires, only to queue on the same
+	 * lock again — a record never reaching a terminal status while the lock holder
+	 * (e.g. an abandoned record's orphaned trigger operation) never releases.
 	 */
 	async processRecord(record: WorkflowPublicationOutbox, signal: AbortSignal): Promise<void> {
 		await this.tracing.startSpan(
@@ -321,101 +329,161 @@ export class WorkflowPublicationOutboxConsumer {
 				},
 			},
 			async (span) => {
-				await this.lifecycleLock.runExclusive(record.workflowId, async () => {
-					// A record claimed while leader can reach here after stepdown (e.g. while
-					// waiting on the lock during teardown). Activating triggers now would leave
-					// them running on a demoted instance, so hand the record back to the queue.
-					if (!this.instanceSettings.isLeader) {
-						await this.outboxRepository.returnToPending(record.id);
-						this.logger.debug('Returned publication outbox record to queue: no longer leader', {
-							outboxId: record.id,
-							workflowId: record.workflowId,
-						});
-						return;
-					}
+				const startedAt = Date.now();
+				let entered = false;
 
-					// The worker may have aborted this record while it queued on the lock;
-					// starting now would apply work long after it was abandoned. The row is
-					// left `in_progress` for lease reclaim rather than returned to pending:
-					// the wait may have outlived the lease, and flipping the row here would
-					// release the claim of whichever worker has since reclaimed it.
-					if (signal.aborted) {
-						this.logger.debug('Skipped applying publication outbox record: aborted', {
-							outboxId: record.id,
-							workflowId: record.workflowId,
-						});
-						return;
-					}
-
-					this.logger.debug('Started processing workflow publication outbox record', {
-						outboxId: record.id,
-						workflowId: record.workflowId,
-						publishedVersionId: record.publishedVersionId,
-					});
-
-					const startedAt = Date.now();
-					let result: PublicationResult;
-
-					// An aborted per-node operation is abandoned, not cancelled; collect
-					// every orphan so the lock outlives whatever may still mutate this
-					// workflow's registrations.
-					const detachedWork: Array<Promise<unknown>> = [];
-					const abort: TriggerOperationAbort = {
+				try {
+					await this.lifecycleLock.runExclusive(
+						record.workflowId,
+						async () => {
+							entered = true;
+							await this.processRecordUnderLock(record, signal, startedAt, span);
+						},
 						signal,
-						onDetached: (work) => detachedWork.push(work),
-					};
-
-					try {
-						result = await this.applier.apply(record, abort);
-					} catch (error) {
-						const cause = ensureError(error);
-						result = {
-							type: 'failed',
-							// An abort is our own doing and a UserError is a known cause (e.g.
-							// a missing credential), not an unexpected applier failure.
-							error:
-								signal.aborted || cause instanceof UserError
-									? cause
-									: new UnexpectedError(`Unexpected: ${cause.message}`, { cause }),
-						};
-					}
-
-					let reporterFailed = false;
-					try {
-						await this.reporter.report(record, result);
-					} catch (reportError) {
-						reporterFailed = true;
-						this.errorReporter.error(reportError, { shouldBeLogged: true });
-					}
-
-					this.eventService.emit('workflow-publication-outbox-record-processed', {
-						...this.toOutcomeLabels(result, reporterFailed),
-						durationMs: Date.now() - startedAt,
-					});
-
-					this.logger.debug('Finished processing workflow publication outbox record', {
-						outboxId: record.id,
-						workflowId: record.workflowId,
-						result: result.type,
-					});
-
-					span.setAttribute('n8n.publication.result', result.type);
-
-					// The terminal status is already written; keep the lock until the
-					// abandoned operations settle so the next record for this workflow
-					// can never run concurrently with them.
-					if (detachedWork.length > 0) {
-						this.logger.warn(
-							'Keeping workflow publication lock held until abandoned trigger operations settle',
-							{ outboxId: record.id, workflowId: record.workflowId },
-						);
-						await Promise.allSettled(detachedWork);
-					}
-				});
+					);
+				} catch (error) {
+					// Only an abort while still queued on the lock is expected here; the
+					// critical section reports its own failures and never throws them.
+					if (entered || !signal.aborted) throw error;
+					await this.failBeforeApply(record, signal, startedAt, span);
+				}
 
 				span.setStatus({ code: SpanStatus.ok });
 			},
 		);
+	}
+
+	private async processRecordUnderLock(
+		record: WorkflowPublicationOutbox,
+		signal: AbortSignal,
+		startedAt: number,
+		span: Span,
+	): Promise<void> {
+		// A record claimed while leader can reach here after stepdown (e.g. while
+		// waiting on the lock during teardown). Activating triggers now would leave
+		// them running on a demoted instance, so hand the record back to the queue.
+		if (!this.instanceSettings.isLeader) {
+			await this.outboxRepository.returnToPending(record.id);
+			this.logger.debug('Returned publication outbox record to queue: no longer leader', {
+				outboxId: record.id,
+				workflowId: record.workflowId,
+			});
+			return;
+		}
+
+		// The abort and the lock hand-off can land in the same tick; starting now
+		// would apply work the worker is about to abandon.
+		if (signal.aborted) {
+			await this.failBeforeApply(record, signal, startedAt, span);
+			return;
+		}
+
+		this.logger.debug('Started processing workflow publication outbox record', {
+			outboxId: record.id,
+			workflowId: record.workflowId,
+			publishedVersionId: record.publishedVersionId,
+		});
+
+		let result: PublicationResult;
+
+		// An aborted per-node operation is abandoned, not cancelled; collect
+		// every orphan so the lock outlives whatever may still mutate this
+		// workflow's registrations.
+		const detachedWork: Array<Promise<unknown>> = [];
+		const abort: TriggerOperationAbort = {
+			signal,
+			onDetached: (work) => detachedWork.push(work),
+		};
+
+		try {
+			result = await this.applier.apply(record, abort);
+		} catch (error) {
+			const cause = ensureError(error);
+			result = {
+				type: 'failed',
+				// An abort is our own doing and a UserError is a known cause (e.g.
+				// a missing credential), not an unexpected applier failure.
+				error:
+					signal.aborted || cause instanceof UserError
+						? cause
+						: new UnexpectedError(`Unexpected: ${cause.message}`, { cause }),
+			};
+		}
+
+		await this.finishRecord(record, result, startedAt, span);
+
+		// The terminal status is already written; keep the lock until the
+		// abandoned operations settle so the next record for this workflow
+		// can never run concurrently with them.
+		if (detachedWork.length > 0) {
+			this.logger.warn(
+				'Keeping workflow publication lock held until abandoned trigger operations settle',
+				{ outboxId: record.id, workflowId: record.workflowId },
+			);
+			await Promise.allSettled(detachedWork);
+		}
+	}
+
+	/**
+	 * Fails a record whose deadline fired before it could start applying. In
+	 * practice that means it spent the deadline queued on the workflow's lock
+	 * behind an earlier record, which the message tells the user.
+	 */
+	private async failBeforeApply(
+		record: WorkflowPublicationOutbox,
+		signal: AbortSignal,
+		startedAt: number,
+		span: Span,
+	): Promise<void> {
+		this.logger.warn('Failing publication outbox record: aborted before it could start applying', {
+			outboxId: record.id,
+			workflowId: record.workflowId,
+		});
+		await this.finishRecord(
+			record,
+			{
+				type: 'failed',
+				error: new OperationalError(
+					'Workflow publication timed out waiting for a previous publication of this workflow to finish',
+					{ cause: ensureError(signal.reason) },
+				),
+			},
+			startedAt,
+			span,
+		);
+	}
+
+	/**
+	 * Writes the record's terminal status via the reporter and emits the
+	 * outcome metric. A reporter failure can only be logged: the record stays
+	 * `in_progress` for a later poll cycle to retry.
+	 */
+	private async finishRecord(
+		record: WorkflowPublicationOutbox,
+		result: PublicationResult,
+		startedAt: number,
+		span: Span,
+	): Promise<void> {
+		let reporterFailed = false;
+		try {
+			await this.reporter.report(record, result);
+		} catch (reportError) {
+			reporterFailed = true;
+			this.errorReporter.error(reportError, { shouldBeLogged: true });
+		}
+
+		this.eventService.emit('workflow-publication-outbox-record-processed', {
+			...this.toOutcomeLabels(result, reporterFailed),
+			durationMs: Date.now() - startedAt,
+		});
+
+		this.logger.debug('Finished processing workflow publication outbox record', {
+			outboxId: record.id,
+			workflowId: record.workflowId,
+			result: result.type,
+		});
+
+		span.setAttribute('n8n.publication.result', result.type);
 	}
 
 	/**

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -422,7 +422,7 @@ export class WorkflowPublicationOutboxConsumer {
 				};
 
 				try {
-					await this.lifecycleLock.runExclusive(record.workflowId, process, signal);
+					await this.lifecycleLock.runExclusive(record.workflowId, process, { signal });
 				} catch (error) {
 					// Aborted while still queued on the lock. `process` then only settles the
 					// record (back to the queue, or failed) and applies nothing, so it needs

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -4,7 +4,7 @@ import { Time } from '@n8n/constants';
 import { WorkflowPublicationOutbox, WorkflowPublicationOutboxRepository } from '@n8n/db';
 import { OnLeaderTakeover, OnPubSubEvent, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { ErrorReporter, InstanceSettings, SpanStatus, Tracing, type Span } from 'n8n-core';
+import { ErrorReporter, InstanceSettings, SpanStatus, Tracing } from 'n8n-core';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { OperationalError, UnexpectedError, UserError } from 'n8n-workflow';
 
@@ -324,158 +324,116 @@ export class WorkflowPublicationOutboxConsumer {
 				const startedAt = Date.now();
 				let entered = false;
 
+				const process = async () => {
+					entered = true;
+
+					// A record claimed while leader can reach here after stepdown (e.g. while
+					// waiting on the lock during teardown). Activating triggers now would leave
+					// them running on a demoted instance, so hand the record back to the queue.
+					if (!this.instanceSettings.isLeader) {
+						await this.outboxRepository.returnToPending(record.id);
+						this.logger.debug('Returned publication outbox record to queue: no longer leader', {
+							outboxId: record.id,
+							workflowId: record.workflowId,
+						});
+						return;
+					}
+
+					let result: PublicationResult;
+
+					// An aborted per-node operation is abandoned, not cancelled; collect
+					// every orphan so the lock outlives whatever may still mutate this
+					// workflow's registrations.
+					const detachedWork: Array<Promise<unknown>> = [];
+
+					if (signal.aborted) {
+						// The deadline fired before applying could start, i.e. while this
+						// record queued on the lock behind an earlier one for the workflow.
+						this.logger.warn('Failing publication outbox record: aborted before applying', {
+							outboxId: record.id,
+							workflowId: record.workflowId,
+						});
+						result = {
+							type: 'failed',
+							error: new OperationalError(
+								'Workflow publication timed out waiting for a previous publication of this workflow to finish',
+								{ cause: ensureError(signal.reason) },
+							),
+						};
+					} else {
+						this.logger.debug('Started processing workflow publication outbox record', {
+							outboxId: record.id,
+							workflowId: record.workflowId,
+							publishedVersionId: record.publishedVersionId,
+						});
+
+						const abort: TriggerOperationAbort = {
+							signal,
+							onDetached: (work) => detachedWork.push(work),
+						};
+
+						try {
+							result = await this.applier.apply(record, abort);
+						} catch (error) {
+							const cause = ensureError(error);
+							result = {
+								type: 'failed',
+								// An abort is our own doing and a UserError is a known cause (e.g.
+								// a missing credential), not an unexpected applier failure.
+								error:
+									signal.aborted || cause instanceof UserError
+										? cause
+										: new UnexpectedError(`Unexpected: ${cause.message}`, { cause }),
+							};
+						}
+					}
+
+					let reporterFailed = false;
+					try {
+						await this.reporter.report(record, result);
+					} catch (reportError) {
+						reporterFailed = true;
+						this.errorReporter.error(reportError, { shouldBeLogged: true });
+					}
+
+					this.eventService.emit('workflow-publication-outbox-record-processed', {
+						...this.toOutcomeLabels(result, reporterFailed),
+						durationMs: Date.now() - startedAt,
+					});
+
+					this.logger.debug('Finished processing workflow publication outbox record', {
+						outboxId: record.id,
+						workflowId: record.workflowId,
+						result: result.type,
+					});
+
+					span.setAttribute('n8n.publication.result', result.type);
+
+					// The terminal status is already written; keep the lock until the
+					// abandoned operations settle so the next record for this workflow
+					// can never run concurrently with them.
+					if (detachedWork.length > 0) {
+						this.logger.warn(
+							'Keeping workflow publication lock held until abandoned trigger operations settle',
+							{ outboxId: record.id, workflowId: record.workflowId },
+						);
+						await Promise.allSettled(detachedWork);
+					}
+				};
+
 				try {
-					await this.lifecycleLock.runExclusive(
-						record.workflowId,
-						async () => {
-							entered = true;
-							await this.processRecordUnderLock(record, signal, startedAt, span);
-						},
-						signal,
-					);
+					await this.lifecycleLock.runExclusive(record.workflowId, process, signal);
 				} catch (error) {
-					// Only an abort while still queued on the lock is expected here; the
-					// critical section reports its own failures and never throws them.
+					// Aborted while still queued on the lock. `process` then only settles the
+					// record (back to the queue, or failed) and applies nothing, so it needs
+					// no lock.
 					if (entered || !signal.aborted) throw error;
-					await this.failBeforeApply(record, signal, startedAt, span);
+					await process();
 				}
 
 				span.setStatus({ code: SpanStatus.ok });
 			},
 		);
-	}
-
-	private async processRecordUnderLock(
-		record: WorkflowPublicationOutbox,
-		signal: AbortSignal,
-		startedAt: number,
-		span: Span,
-	): Promise<void> {
-		// A record claimed while leader can reach here after stepdown (e.g. while
-		// waiting on the lock during teardown). Activating triggers now would leave
-		// them running on a demoted instance, so hand the record back to the queue.
-		if (!this.instanceSettings.isLeader) {
-			await this.outboxRepository.returnToPending(record.id);
-			this.logger.debug('Returned publication outbox record to queue: no longer leader', {
-				outboxId: record.id,
-				workflowId: record.workflowId,
-			});
-			return;
-		}
-
-		// The abort and the lock hand-off can land in the same tick; starting now
-		// would apply work the worker is about to abandon.
-		if (signal.aborted) {
-			await this.failBeforeApply(record, signal, startedAt, span);
-			return;
-		}
-
-		this.logger.debug('Started processing workflow publication outbox record', {
-			outboxId: record.id,
-			workflowId: record.workflowId,
-			publishedVersionId: record.publishedVersionId,
-		});
-
-		let result: PublicationResult;
-
-		// An aborted per-node operation is abandoned, not cancelled; collect
-		// every orphan so the lock outlives whatever may still mutate this
-		// workflow's registrations.
-		const detachedWork: Array<Promise<unknown>> = [];
-		const abort: TriggerOperationAbort = {
-			signal,
-			onDetached: (work) => detachedWork.push(work),
-		};
-
-		try {
-			result = await this.applier.apply(record, abort);
-		} catch (error) {
-			const cause = ensureError(error);
-			result = {
-				type: 'failed',
-				// An abort is our own doing and a UserError is a known cause (e.g.
-				// a missing credential), not an unexpected applier failure.
-				error:
-					signal.aborted || cause instanceof UserError
-						? cause
-						: new UnexpectedError(`Unexpected: ${cause.message}`, { cause }),
-			};
-		}
-
-		await this.finishRecord(record, result, startedAt, span);
-
-		// The terminal status is already written; keep the lock until the
-		// abandoned operations settle so the next record for this workflow
-		// can never run concurrently with them.
-		if (detachedWork.length > 0) {
-			this.logger.warn(
-				'Keeping workflow publication lock held until abandoned trigger operations settle',
-				{ outboxId: record.id, workflowId: record.workflowId },
-			);
-			await Promise.allSettled(detachedWork);
-		}
-	}
-
-	/**
-	 * Fails a record whose deadline fired before it could start applying. In
-	 * practice that means it spent the deadline queued on the workflow's lock
-	 * behind an earlier record, which the message tells the user.
-	 */
-	private async failBeforeApply(
-		record: WorkflowPublicationOutbox,
-		signal: AbortSignal,
-		startedAt: number,
-		span: Span,
-	): Promise<void> {
-		this.logger.warn('Failing publication outbox record: aborted before it could start applying', {
-			outboxId: record.id,
-			workflowId: record.workflowId,
-		});
-		await this.finishRecord(
-			record,
-			{
-				type: 'failed',
-				error: new OperationalError(
-					'Workflow publication timed out waiting for a previous publication of this workflow to finish',
-					{ cause: ensureError(signal.reason) },
-				),
-			},
-			startedAt,
-			span,
-		);
-	}
-
-	/**
-	 * Writes the record's terminal status via the reporter and emits the
-	 * outcome metric. A reporter failure can only be logged: the record stays
-	 * `in_progress` for a later poll cycle to retry.
-	 */
-	private async finishRecord(
-		record: WorkflowPublicationOutbox,
-		result: PublicationResult,
-		startedAt: number,
-		span: Span,
-	): Promise<void> {
-		let reporterFailed = false;
-		try {
-			await this.reporter.report(record, result);
-		} catch (reportError) {
-			reporterFailed = true;
-			this.errorReporter.error(reportError, { shouldBeLogged: true });
-		}
-
-		this.eventService.emit('workflow-publication-outbox-record-processed', {
-			...this.toOutcomeLabels(result, reporterFailed),
-			durationMs: Date.now() - startedAt,
-		});
-
-		this.logger.debug('Finished processing workflow publication outbox record', {
-			outboxId: record.id,
-			workflowId: record.workflowId,
-			result: result.type,
-		});
-
-		span.setAttribute('n8n.publication.result', result.type);
 	}
 
 	/**

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -422,7 +422,11 @@ export class WorkflowPublicationOutboxConsumer {
 				};
 
 				try {
-					await this.lifecycleLock.runExclusive(record.workflowId, process, { signal });
+					await this.lifecycleLock.runExclusive({
+						workflowId: record.workflowId,
+						fn: process,
+						signal,
+					});
 				} catch (error) {
 					// Aborted while still queued on the lock. `process` then only settles the
 					// record (back to the queue, or failed) and applies nothing, so it needs

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -308,14 +308,6 @@ export class WorkflowPublicationOutboxConsumer {
 	 * terminal-status write always lands before teardown proceeds. If leadership was lost
 	 * between claiming the record and entering the critical section, the record is returned
 	 * to the queue (so the new leader reprocesses it) and nothing is applied here.
-	 *
-	 * The wait for the lock is bounded by `signal`: a record whose deadline fires
-	 * before it could start applying is failed (outside the lock, since nothing was
-	 * applied) rather than left `in_progress`. The abort fires well inside the lease,
-	 * so the claim is still this worker's and the terminal write is safe. Leaving the
-	 * row would have it reclaimed once the lease expires, only to queue on the same
-	 * lock again — a record never reaching a terminal status while the lock holder
-	 * (e.g. an abandoned record's orphaned trigger operation) never releases.
 	 */
 	async processRecord(record: WorkflowPublicationOutbox, signal: AbortSignal): Promise<void> {
 		await this.tracing.startSpan(

--- a/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
@@ -245,9 +245,9 @@ export class WorkflowPublicationReconciler {
 			}
 
 			try {
-				await this.lifecycleLock.runExclusive(
+				await this.lifecycleLock.runExclusive({
 					workflowId,
-					async () => {
+					fn: async () => {
 						const workflow = await this.workflowRepository.findOneBy({ id: workflowId });
 
 						if (workflow?.activeVersionId) return;
@@ -258,8 +258,8 @@ export class WorkflowPublicationReconciler {
 					},
 					// The lock was free a moment ago; a holder that took it since is a
 					// record in flight, which settles within its lease.
-					{ signal: AbortSignal.timeout(this.leaseMs) },
-				);
+					signal: AbortSignal.timeout(this.leaseMs),
+				});
 			} catch (error) {
 				this.errorReporter.error(error, { shouldBeLogged: true });
 			}

--- a/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
@@ -229,6 +229,17 @@ export class WorkflowPublicationReconciler {
 	private async removeGhostTriggers(workflowIds: WorkflowId[]): Promise<number> {
 		let surplusRepairs = 0;
 		for (const workflowId of workflowIds) {
+			// Never queue on a held lock: a holder that does not release (an
+			// abandoned record's orphaned work) would wedge this pass and every
+			// later tick behind it. Like the stepdown teardown, skip and let the
+			// next tick retry once the lock is free.
+			if (this.lifecycleLock.isLocked(workflowId)) {
+				this.logger.debug('Skipped ghost trigger teardown: workflow publication lock is held', {
+					workflowId,
+				});
+				continue;
+			}
+
 			try {
 				await this.lifecycleLock.runExclusive(workflowId, async () => {
 					const workflow = await this.workflowRepository.findOneBy({ id: workflowId });

--- a/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
@@ -116,6 +116,10 @@ export class WorkflowPublicationReconciler {
 		this.reconcileInterval = undefined;
 	}
 
+	private get leaseMs(): number {
+		return this.workflowsConfig.publicationOutboxLeaseSeconds * Time.seconds.toMilliseconds;
+	}
+
 	/**
 	 * One tick of the loop, gated by the instance's role at this moment. On the
 	 * leader: diff the triggers that should be active in memory against what is
@@ -241,15 +245,21 @@ export class WorkflowPublicationReconciler {
 			}
 
 			try {
-				await this.lifecycleLock.runExclusive(workflowId, async () => {
-					const workflow = await this.workflowRepository.findOneBy({ id: workflowId });
+				await this.lifecycleLock.runExclusive(
+					workflowId,
+					async () => {
+						const workflow = await this.workflowRepository.findOneBy({ id: workflowId });
 
-					if (workflow?.activeVersionId) return;
-					if (await this.outboxRepository.findInFlightByWorkflowId(workflowId)) return;
+						if (workflow?.activeVersionId) return;
+						if (await this.outboxRepository.findInFlightByWorkflowId(workflowId)) return;
 
-					await this.activeWorkflowTriggers.remove(workflowId);
-					surplusRepairs++;
-				});
+						await this.activeWorkflowTriggers.remove(workflowId);
+						surplusRepairs++;
+					},
+					// The lock was free a moment ago; a holder that took it since is a
+					// record in flight, which settles within its lease.
+					{ signal: AbortSignal.timeout(this.leaseMs) },
+				);
 			} catch (error) {
 				this.errorReporter.error(error, { shouldBeLogged: true });
 			}

--- a/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
@@ -338,6 +338,7 @@ describe('leader stepdown (integration)', () => {
 				await new Promise<void>((resolve) => {
 					releaseHolder = resolve;
 				}),
+			{ signal: new AbortController().signal },
 		);
 
 		// The instance was demoted; the stepdown teardown must neither wait on the

--- a/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
@@ -332,14 +332,14 @@ describe('leader stepdown (integration)', () => {
 
 		// Hold the workflow's lock to stand in for an in-flight record being processed.
 		let releaseHolder!: () => void;
-		const holder = lifecycleLock.runExclusive(
-			workflow.id,
-			async () =>
+		const holder = lifecycleLock.runExclusive({
+			workflowId: workflow.id,
+			fn: async () =>
 				await new Promise<void>((resolve) => {
 					releaseHolder = resolve;
 				}),
-			{ signal: new AbortController().signal },
-		);
+			signal: new AbortController().signal,
+		});
 
 		// The instance was demoted; the stepdown teardown must neither wait on the
 		// held lock nor tear the workflow down without it — it skips.


### PR DESCRIPTION
## Summary

Avoid records stuck in `in_progress` indefinitely.

A hung publication holds the workflow's lifecycle lock forever, and nothing can take the lock away from it. This means that record stays publishing.

This PR stops waiting for the lock when the deadline hits, and marks it failed.

May follow up with an attempt to recover.

## How to test

Requires `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

1. Publish a workflow with a trigger whose activation hangs and wait for the record to fail with "exceeded its deadline".
2. Publish the same workflow again.
3. Before: the new record stays `in_progress` forever. After: it fails after ~84s with the message above, and the editor shows the failure.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4043

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)