### PR TITLE
fix(core): Release the workflow publication lock after a bounded wait for abandoned trigger operations (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -626,6 +626,61 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			expect(lifecycleLock.isLocked('wf-1')).toBe(false);
 		});
 
+		test('releases the workflow lock after the lease when abandoned trigger operations never settle', async () => {
+			const record = makeRecord({ id: 1, workflowId: 'wf-1' });
+			applier.apply.mockImplementationOnce(async (_record, abort) => {
+				abort?.onDetached(new Promise(() => {}));
+				return { type: 'failed', error: new Error('deadline') };
+			});
+			const controller = new AbortController();
+
+			const processing = consumer.processRecord(record, controller.signal);
+			await vi.advanceTimersByTimeAsync(0);
+			expect(lifecycleLock.isLocked('wf-1')).toBe(true);
+
+			// Just short of the bound the lock is still held...
+			await vi.advanceTimersByTimeAsync(LEASE_SECONDS * 1000 - 1);
+			expect(lifecycleLock.isLocked('wf-1')).toBe(true);
+
+			// ...and at the bound it is released, with the orphan reported.
+			await vi.advanceTimersByTimeAsync(1);
+			await processing;
+			expect(lifecycleLock.isLocked('wf-1')).toBe(false);
+			expect(errorReporter.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: expect.stringContaining('trigger operations still pending'),
+				}),
+				{ shouldBeLogged: true },
+			);
+		});
+
+		test('a later record for a workflow whose abandoned trigger operation never settles is applied once the lock is released', async () => {
+			const first = makeRecord({ id: 1, workflowId: 'wf-1' });
+			applier.apply.mockImplementationOnce(async (_record, abort) => {
+				abort?.onDetached(new Promise(() => {}));
+				return { type: 'failed', error: new Error('deadline') };
+			});
+			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(first).mockResolvedValue(null);
+			consumer.startPolling();
+
+			// The first drain settles once the lock is released at the bound.
+			const firstDrain = consumer.drainPending();
+			await vi.advanceTimersByTimeAsync(LEASE_SECONDS * 1000);
+			await firstDrain;
+			expect(lifecycleLock.isLocked('wf-1')).toBe(false);
+
+			// The user republishes wf-1: the record applies normally.
+			const second = makeRecord({ id: 2, workflowId: 'wf-1' });
+			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(second).mockResolvedValue(null);
+			await consumer.drainPending();
+
+			expect(applier.apply).toHaveBeenCalledTimes(2);
+			expect(reporter.report).toHaveBeenCalledWith(
+				second,
+				expect.objectContaining({ type: 'completed' }),
+			);
+		});
+
 		test('fails a record whose abort fires before it could start applying', async () => {
 			const record = makeRecord({ id: 7, workflowId: 'wf-7' });
 			const controller = new AbortController();

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -411,6 +411,7 @@ export class WorkflowPublicationOutboxConsumer {
 					// The terminal status is already written; keep the lock until the
 					// abandoned operations settle so the next record for this workflow
 					// can never run concurrently with them.
+					// The detached work has already been signaled to be aborted at this point.
 					if (detachedWork.length > 0) {
 						this.logger.warn(
 							'Keeping workflow publication lock held until abandoned trigger operations settle',

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -411,7 +411,10 @@ export class WorkflowPublicationOutboxConsumer {
 					// The terminal status is already written; keep the lock until the
 					// abandoned operations settle so the next record for this workflow
 					// can never run concurrently with them.
-					// The detached work has already been signaled to be aborted at this point.
+					//
+					// The detached work is populated when the abort signal fires while
+					// a promise is still pending; so we know that we've aborted if there
+					// is any detached work.
 					if (detachedWork.length > 0) {
 						this.logger.warn(
 							'Keeping workflow publication lock held until abandoned trigger operations settle',

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -455,6 +455,8 @@ export class WorkflowPublicationOutboxConsumer {
 		record: WorkflowPublicationOutbox,
 		detachedWork: Array<Promise<unknown>>,
 	): Promise<void> {
+		// Note: detachedWork has already been signaled to abort, so we give it the remaining
+		// lease before we release the lock.
 		const settled = await this.raceTimeout(Promise.allSettled(detachedWork), this.leaseMs);
 		if (settled !== TIMED_OUT) return;
 

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -250,8 +250,7 @@ export class WorkflowPublicationOutboxConsumer {
 	 * Returns whether the record settled in time.
 	 */
 	private async processRecordWithAbort(record: WorkflowPublicationOutbox): Promise<boolean> {
-		const leaseMs =
-			this.workflowsConfig.publicationOutboxLeaseSeconds * Time.seconds.toMilliseconds;
+		const { leaseMs } = this;
 		const abortAfterMs = leaseMs * ABORT_AFTER_LEASE_FRACTION;
 		const abandonGraceMs = Math.min(ABANDON_GRACE_MS, leaseMs * ABANDON_GRACE_LEASE_FRACTION);
 
@@ -417,7 +416,7 @@ export class WorkflowPublicationOutboxConsumer {
 							'Keeping workflow publication lock held until abandoned trigger operations settle',
 							{ outboxId: record.id, workflowId: record.workflowId },
 						);
-						await Promise.allSettled(detachedWork);
+						await this.awaitDetachedWork(record, detachedWork);
 					}
 				};
 
@@ -438,6 +437,44 @@ export class WorkflowPublicationOutboxConsumer {
 				span.setStatus({ code: SpanStatus.ok });
 			},
 		);
+	}
+
+	/**
+	 * Waits for abandoned trigger operations, but not forever: an operation that
+	 * never settles (node code that hangs) would otherwise hold this workflow's
+	 * lock for the rest of the process's life, failing every later publication
+	 * of the workflow. The bound is one lease: past it the lock is released and
+	 * the orphan reported. An orphan still running after release is the same
+	 * state a crashed leader can leave, which reconciliation already handles.
+	 */
+	private async awaitDetachedWork(
+		record: WorkflowPublicationOutbox,
+		detachedWork: Array<Promise<unknown>>,
+	): Promise<void> {
+		const settled = await this.raceTimeout(Promise.allSettled(detachedWork), this.leaseMs);
+		if (settled !== TIMED_OUT) return;
+
+		// `level: 'error'`: nothing else reports this hang — the record itself
+		// settled at its deadline — and `OperationalError` defaults to a
+		// warning, which the error reporter filters from Sentry.
+		this.errorReporter.error(
+			new OperationalError(
+				'Released workflow publication lock with abandoned trigger operations still pending',
+				{
+					level: 'error',
+					extra: {
+						outboxId: record.id,
+						workflowId: record.workflowId,
+						pendingOperations: detachedWork.length,
+					},
+				},
+			),
+			{ shouldBeLogged: true },
+		);
+	}
+
+	private get leaseMs(): number {
+		return this.workflowsConfig.publicationOutboxLeaseSeconds * Time.seconds.toMilliseconds;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Release the workflow publication lock when the lease expires.

#38019 generated a useful error message, but the workflow remained stuck. By releasing the lock, we give the user the chance to retry the failed operation. This should recover cases where there's a hung operation that will never complete, which we've observed with the IMAP trigger.

The downside is that we are open to an operation that takes longer than the lease but eventually finishes - we could end up with some inconsistent state. Eventually we should move to a lease+fencing model, but for now we should prefer availability to consistency, especially since we see known cases of permanently hung operations.

## How to test

Requires `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

1. Publish a workflow with a trigger whose activation hangs and wait for the record to fail with "exceeded its deadline".
2. Wait one lease (default 2 minutes). An error "Released workflow publication lock with abandoned trigger operations still pending" is reported.
3. Publish the same workflow again. It applies normally.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4043

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)