### PR TITLE
ci: Retarget PRs to bundle branches on sync

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -640,6 +640,7 @@ Workflows with `workflow_call` trigger:
 | `docker-build-push.yml`            | `n8n_version`, `release_type`, `push_enabled`, `ref`, `date_tag`, `create_attestations` | Docker build |
 | `sec-ci-reusable.yml`              | `ref`                                         | Security orchestrator |
 | `sec-poutine-reusable.yml`         | `ref`                                         | Poutine scanner       |
+| `sec-sync-retarget-prs.yml`        | none                                          | Move bundle PRs back onto `bundle/*` |
 | `security-trivy-scan-callable.yml` | `image_ref`                                   | Trivy scan            |
 | `sbom-generation-callable.yml`     | `n8n_version`, `release_tag_ref`              | SBOM generation       |
 | `test-single-instance-npm.yml`     | `scope`, `base-ref`, `base-branch`, `blocking`, `timeout-minutes` | Dependency duplication |
@@ -999,6 +1000,15 @@ merged into one (and on `workflow_dispatch`). It **merges the base into** the bu
 via [`scripts/sync-bundle-branch.mjs`](scripts/sync-bundle-branch.mjs) and pushes without
 forcing. Every push is verified to carry exactly the tree a merge of the two sides would
 produce (`git merge-tree`); a mismatch, or a conflict marker, fails the run instead of pushing.
+
+Deleting a bundle branch takes its open PRs with it: GitHub moves each one onto the deleted
+branch's own base, and re-creating the branch does not move them back. So the sync then calls
+[`sec-sync-retarget-prs.yml`](workflows/sec-sync-retarget-prs.yml), which moves every open PR
+on `master` onto `bundle/2.x` and every one on `1.x` onto `bundle/1.x`. It skips a bundle
+branch that does not exist, and skips PRs whose *head* is `bundle/*` — those are the
+`chore: Bundle/*` cut PRs, which target the base on purpose. It is also dispatchable on its
+own. `sec-sync-public-to-private.yml` only *dispatches* the bundle sync when it finds a branch
+missing; the retarget runs inside that dispatched run, once the branch exists.
 
 **`bundle/*` is append-only — never rebase it, never force-push it.** These branches receive
 PRs, and rewriting a branch that receives PRs orphans the copies of its commits that the open

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -703,7 +703,7 @@ rewrite safe.
 |----------------------------|----------------------------------------------------------------------|------------------------------------|
 | `branch-replay.mjs`        | Shared primitives: merge-tree, tree guard, marker scan               | the two scripts below              |
 | `sync-master-to-3x.mjs`    | master → `3.x`, rebased; auto-resolves mechanical files, opens a conflict PR | `util-sync-master-to-3x.yml`       |
-| `sync-bundle-branch.mjs`   | base → `bundle/*` in n8n-private, merged; fail-loud, never resolves conflicts | `sec-sync-bundle-branches.yml`   |
+| `sync-bundle-branch.mjs`   | base → `bundle/*` in n8n-private, merged; skips while the base is unpublished; fail-loud, never resolves conflicts | `sec-sync-bundle-branches.yml`   |
 
 ### Slack Scripts
 
@@ -1000,6 +1000,26 @@ merged into one (and on `workflow_dispatch`). It **merges the base into** the bu
 via [`scripts/sync-bundle-branch.mjs`](scripts/sync-bundle-branch.mjs) and pushes without
 forcing. Every push is verified to carry exactly the tree a merge of the two sides would
 produce (`git merge-tree`); a mismatch, or a conflict marker, fails the run instead of pushing.
+
+**A bundle branch is only ever built on published history.** Before it creates or merges
+anything, the sync fetches the same-named branch from `https://github.com/n8n-io/n8n.git`
+(anonymously — its token is scoped to the private repo) and checks that the private base tip is
+contained in it. This matters because the `chore: Bundle/*` squash on private `master` is
+*private-only*: the mirror above discards it in favour of the public cherry-pick of the same
+changes. A sync in that window would root the branch on a commit that is about to disappear,
+leaving it carrying two commits for one set of fixes — and every fix PR cut from it inherits the
+dead one. The window is real: this workflow's daily cron and the mirror's hourly cron both fire
+at `:00` with nothing ordering them, which is why the check lives in the script rather than in
+step ordering.
+
+An unpublished cut is a **skip**, not a failure: the mirror discards that commit every hour
+regardless, so the run exits green with the reason in the log and the next one proceeds. A
+missing branch also self-heals, because the mirror re-dispatches this workflow while one is
+absent. A base ahead of public for **any other reason** fails the run — the mirror is stuck and
+will not clear it on its own, so fix that first (remove the commit, or dispatch **Security: Sync
+from Public** with `force`) and re-run. To sync a bundle branch immediately, dispatch the mirror
+and then this workflow. The blocking commits are listed in the run log; the failure annotation
+carries only a count, since a subject hints at the fix.
 
 Deleting a bundle branch takes its open PRs with it: GitHub moves each one onto the deleted
 branch's own base, and re-creating the branch does not move them back. So the sync then calls

--- a/.github/scripts/sync-bundle-branch.mjs
+++ b/.github/scripts/sync-bundle-branch.mjs
@@ -26,9 +26,17 @@
  * of being re-litigated on every later run. Contrast `sync-master-to-3x.mjs`, which
  * auto-resolves mechanical files and opens a conflict PR.
  *
+ * PUBLISHED HISTORY ONLY: the base is synced in only once the public repo already has it. A cut
+ * squash-merges the bundle branch into private master as `chore: Bundle …`, and the hourly
+ * public→private mirror then DISCARDS that commit in favour of the public cherry-pick of the same
+ * changes. Building on it would strand the discarded commit on a branch that fix PRs are cut
+ * from, and the replacement gets merged in on top of it later. An unpublished cut is a SKIP (the
+ * mirror clears it within the hour, whatever the cut is, so waiting cannot deadlock); a base
+ * ahead of public for any other reason is a FAILURE, because the mirror will not clear it.
+ *
  * Runs from a full checkout (fetch-depth 0) of any branch. Assumes credentials are NOT
- * persisted by checkout — every fetch and the push go through an explicit token URL, which
- * matters because the repository is private.
+ * persisted by checkout — every private fetch and the push go through an explicit token URL,
+ * which matters because the repository is private. The public fetch is anonymous.
  *
  * Env: BUNDLE_BRANCH (e.g. bundle/2.x), BASE_BRANCH (e.g. master),
  *      GH_TOKEN (installation token with contents:write),
@@ -48,6 +56,14 @@ import {
 const BOT_NAME = 'n8n-assistant[bot]';
 const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
 
+// Hard-coded like the mirror in sec-sync-public-to-private.yml, and fetched anonymously: the
+// installation token this script holds is scoped to the private repo.
+const PUBLIC_REMOTE = 'https://github.com/n8n-io/n8n.git';
+
+// What a cut lands on private base before it is published. Anything else ahead of public means
+// the mirror is stuck, not that a cut is in flight.
+const BUNDLE_SUBJECT = /^chore: Bundle/;
+
 function required(env, name) {
 	const value = env[name];
 	if (!value) throw new Error(`${name} env var is required`);
@@ -60,6 +76,47 @@ export function annotation(title, message) {
 	return `::error title=${title}::${message.replace(/\n/g, '%0A')}`;
 }
 
+/**
+ * Whether the base tip is still private-only, and what to do about it.
+ *
+ * `null` means the public repo already has it, so the sync may proceed. The predicate is
+ * containment in public rather than "is not a bundle commit", so a direct push that bypassed
+ * ci-restrict-private-merges.yml is caught too; the subjects only decide how to react.
+ */
+function unconvergedBase({ git, log, bundle, base, baseSha, publicSha }) {
+	if (isAncestor(git, baseSha, publicSha)) return null;
+
+	const ahead = git(['log', '--format=%h %s', `${publicSha}..${baseSha}`])
+		.split('\n')
+		.filter(Boolean);
+	const subjects = ahead.map((line) => line.slice(line.indexOf(' ') + 1));
+
+	// All-or-nothing: one unexplained commit means the mirror will not clear the base on its own.
+	// An empty range here means unrelated histories, which `every` treats as a skip — the safe
+	// direction, since forcing past an ancestry check we could not evaluate is never right.
+	if (subjects.every((subject) => BUNDLE_SUBJECT.test(subject))) {
+		log(
+			`${base} ${baseSha} has not reached public ${base} ${publicSha} yet; leaving ${bundle} ` +
+				'untouched. The hourly public → private sync clears this.',
+		);
+		return { status: 'unconverged' };
+	}
+
+	// Subjects go to the run log, which is private. The annotation stays a count: it is the
+	// headline of a failed run, and a subject hints at the fix.
+	log(ahead.join('\n'));
+	log(
+		annotation(
+			`${base} is ahead of public`,
+			`${base} carries ${ahead.length} commit(s) that public does not have and that are not ` +
+				`bundle cuts, so the mirror cannot clear them. Fix the mirror, then re-run this workflow.`,
+		),
+	);
+	throw new Error(`${base} is ahead of public by commits that are not bundle cuts.`);
+}
+
+// Takes `baseSha` explicitly. This path never fetches the bundle branch, so FETCH_HEAD still
+// holds the PUBLIC tip here, not the base — never swap the argument for FETCH_HEAD.
 function createBundleBranch({ git, log, bundle, base, baseSha, remote }) {
 	log(`${bundle} does not exist yet; creating it at ${base} ${baseSha}.`);
 	git(['checkout', '--force', '-B', bundle, baseSha]);
@@ -75,13 +132,28 @@ function createBundleBranch({ git, log, bundle, base, baseSha, remote }) {
 
 /**
  * One fetch-merge-push cycle. `status: 'rejected'` means the branch moved under us — the
- * caller re-runs from a fresh fetch rather than forcing anything.
+ * caller re-runs from a fresh fetch rather than forcing anything. `status: 'unconverged'` means
+ * the base is not published yet and nothing was touched.
  */
 function mergeBaseIntoBundle({ git, log, bundle, base, remote }) {
-	// Pin both sides to the fetched SHAs — fetching by URL never updates the origin/* tracking
-	// refs, so FETCH_HEAD is the only handle. Base first: the second fetch overwrites it.
+	// Pin every side to the SHA fetched for it — fetching by URL never updates the origin/*
+	// tracking refs, so FETCH_HEAD is the only handle, and each of the three fetches below
+	// overwrites the last. Read FETCH_HEAD on the line after its own fetch; never separate a
+	// fetch from the read that consumes it.
 	git(['fetch', remote, base]);
 	const baseSha = git(['rev-parse', 'FETCH_HEAD']);
+
+	// The base branch is named the same on both sides (master, 1.x). If that ever stops being
+	// true, map it here rather than at the call site.
+	const publicFetch = attempt(git, ['fetch', PUBLIC_REMOTE, base]);
+	if (!publicFetch.ok) {
+		// A guard that cannot be evaluated must stop the run, not be assumed satisfied.
+		throw new Error(`Could not fetch ${base} from the public repo:\n${publicFetch.out}`);
+	}
+	const publicSha = git(['rev-parse', 'FETCH_HEAD']);
+
+	const unconverged = unconvergedBase({ git, log, bundle, base, baseSha, publicSha });
+	if (unconverged) return unconverged;
 
 	const listed = attempt(git, ['ls-remote', '--heads', remote, `refs/heads/${bundle}`]);
 	if (!listed.ok) {

--- a/.github/scripts/sync-bundle-branch.test.mjs
+++ b/.github/scripts/sync-bundle-branch.test.mjs
@@ -3,13 +3,14 @@ import { test } from 'node:test';
 
 import { annotation, syncBundleBranch } from './sync-bundle-branch.mjs';
 
-// A git stub: routes calls by a matcher, records every invocation.
+// A git stub: routes calls by a matcher, records every invocation. Route results also receive
+// the calls so far, which is how FETCH_HEAD is modelled — see `fetchHead`.
 function makeStub(routes = []) {
 	const calls = [];
 	const fn = (args) => {
 		calls.push(args);
 		for (const [match, result] of routes) {
-			if (match(args)) return typeof result === 'function' ? result(args) : result;
+			if (match(args)) return typeof result === 'function' ? result(args, calls) : result;
 		}
 		return '';
 	};
@@ -28,8 +29,12 @@ const fail =
 
 const PRE_HEAD = 'PREHEAD';
 const BASE = 'BASESHA';
+const PUBLIC = 'PUBLICSHA';
 const MERGE_TREE = 'MERGETREEOID';
 const REMOTE = 'https://x-access-token:tok@github.com/n8n-io/n8n-private.git';
+// Spelled out rather than imported: a duplicated literal is what makes the "the private token
+// never reaches the public repo" assertion below a real one.
+const PUBLIC_REMOTE = 'https://github.com/n8n-io/n8n.git';
 
 const env = {
 	BUNDLE_BRANCH: 'bundle/2.x',
@@ -46,17 +51,36 @@ const isPush = (a) => a[0] === 'push';
 const conflictedMergeTree = (...paths) =>
 	fail(`${MERGE_TREE}\n${paths.join('\n')}\n\nCONFLICT (content): Merge conflict in ${paths[0]}`);
 
-// Routes shared by every path: base fetched, the bundle branch hasn't absorbed it yet, the
-// merge tree is computable, and the merge lands on exactly that tree. git grep exits
-// non-zero => no markers.
+// FETCH_HEAD is one slot holding whatever the last fetch brought down, so the stub has to answer
+// by looking back at that fetch. Resolving both fetches to the same SHA would let the
+// convergence guard pass by accident and assert nothing.
+const fetchHead = (_args, calls) => {
+	const [, url, ref] = [...calls].reverse().find((a) => a[0] === 'fetch') ?? [];
+	if (url === PUBLIC_REMOTE) return PUBLIC;
+	if (ref?.startsWith('bundle/')) return PRE_HEAD;
+	return BASE;
+};
+
+// Routes shared by every path: base fetched and already published, the bundle branch hasn't
+// absorbed it yet, the merge tree is computable, and the merge lands on exactly that tree. git
+// grep exits non-zero => no markers.
 const baseGitRoutes = [
 	[(a) => a[0] === 'ls-remote', `${PRE_HEAD}\trefs/heads/bundle/2.x`],
-	[(a) => a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD', BASE],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD', fetchHead],
 	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', PRE_HEAD],
-	[(a) => a[0] === 'merge-base', fail()],
+	// Split by descendant: the base has reached public, but the bundle branch has not absorbed
+	// it. One `merge-base` matcher would answer both and decide convergence by accident.
+	[(a) => a[0] === 'merge-base' && a[3] === PUBLIC, ''],
+	[(a) => a[0] === 'merge-base' && a[3] === PRE_HEAD, fail()],
 	[(a) => a[0] === 'merge-tree', MERGE_TREE],
 	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', MERGE_TREE],
 	[(a) => a[0] === 'grep', fail()],
+];
+
+// A base that is ahead of public by the commits given, so the guard trips.
+const unpublishedRoutes = (...lines) => [
+	[(a) => a[0] === 'merge-base' && a[3] === PUBLIC, fail()],
+	[(a) => a[0] === 'log' && a[1] === '--format=%h %s', lines.join('\n')],
 ];
 
 const silent = () => {};
@@ -90,14 +114,41 @@ test('a clean sync merges the base in and pushes without forcing', () => {
 	assert.deepEqual(git.calls.find(isPush), ['push', REMOTE, 'HEAD:refs/heads/bundle/2.x']);
 });
 
-test('both fetches are authenticated — the private repo rejects an anonymous origin fetch', () => {
+test('the private fetches are authenticated and the public one is not', () => {
 	const git = makeStub(baseGitRoutes);
 	syncBundleBranch({ git, env, log: silent });
 
+	// The private repo rejects an anonymous fetch; the public repo needs no credential.
 	assert.deepEqual(
 		git.calls.filter((a) => a[0] === 'fetch'),
 		[
 			['fetch', REMOTE, 'master'],
+			['fetch', PUBLIC_REMOTE, 'master'],
+			['fetch', REMOTE, 'bundle/2.x'],
+		],
+	);
+
+	// The token is scoped to the private repo, so it must never be sent to the public one.
+	assert.equal(
+		git.calls.some((a) =>
+			a.some((arg) => String(arg).includes('x-access-token') && String(arg).includes('/n8n.git')),
+		),
+		false,
+	);
+});
+
+test('the public tip is read straight after its own fetch', () => {
+	const git = makeStub(baseGitRoutes);
+	syncBundleBranch({ git, env, log: silent });
+
+	// Separating a fetch from the read that consumes it would silently pin the wrong SHA.
+	assert.deepEqual(
+		git.calls.filter((a) => a[0] === 'fetch' || (a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD')),
+		[
+			['fetch', REMOTE, 'master'],
+			['rev-parse', 'FETCH_HEAD'],
+			['fetch', PUBLIC_REMOTE, 'master'],
+			['rev-parse', 'FETCH_HEAD'],
 			['fetch', REMOTE, 'bundle/2.x'],
 		],
 	);
@@ -105,7 +156,9 @@ test('both fetches are authenticated — the private repo rejects an anonymous o
 
 test('a bundle branch that already contains its base is left alone', () => {
 	const git = makeStub([
-		[(a) => a[0] === 'merge-base', ''], // --is-ancestor succeeds
+		// Only the bundle-branch ancestry is overridden; the convergence probe keeps its own
+		// answer from baseGitRoutes, or this would pass without the guard being exercised.
+		[(a) => a[0] === 'merge-base' && a[3] === PRE_HEAD, ''], // --is-ancestor succeeds
 		...baseGitRoutes,
 	]);
 	const result = syncBundleBranch({ git, env, log: silent });
@@ -173,8 +226,10 @@ test('a fix landing mid-run is retried from a fresh fetch, never forced', () => 
 
 	assert.deepEqual(result, { status: 'merged' });
 	assert.equal(pushes, 2);
-	// The retry re-fetches rather than reusing the tip it already merged onto.
-	assert.equal(git.calls.filter((a) => a[0] === 'fetch').length, 4);
+	// The retry re-fetches rather than reusing the tip it already merged onto — including the
+	// public tip, so the convergence guard is re-evaluated instead of carried over.
+	assert.equal(git.calls.filter((a) => a[0] === 'fetch').length, 6);
+	assert.equal(git.calls.filter((a) => a[1] === PUBLIC_REMOTE).length, 2);
 	assert.equal(
 		git.calls.every((a) => !a.some((arg) => String(arg).includes('force-with-lease'))),
 		true,
@@ -201,7 +256,10 @@ test('a bundle branch that does not exist yet is created at its base', () => {
 	assert.equal(git.calls.some(isMerge), false);
 	assert.deepEqual(
 		git.calls.filter((a) => a[0] === 'fetch'),
-		[['fetch', REMOTE, 'master']],
+		[
+			['fetch', REMOTE, 'master'],
+			['fetch', PUBLIC_REMOTE, 'master'],
+		],
 	);
 	assert.deepEqual(git.calls.find(isPush), ['push', REMOTE, 'HEAD:refs/heads/bundle/2.x']);
 });
@@ -241,4 +299,133 @@ test('a branch created under us mid-run is merged into on the retry', () => {
 
 test('annotation keeps a multi-line message on one line', () => {
 	assert.equal(annotation('t', 'a\nb'), '::error title=t::a%0Ab');
+});
+
+test('a base that has not reached the public repo is left alone', () => {
+	const git = makeStub([
+		...unpublishedRoutes('abc1234 chore: Bundle 2.x (#123)'),
+		...baseGitRoutes,
+	]);
+	const logs = [];
+
+	const result = syncBundleBranch({ git, env, log: (m) => logs.push(m) });
+
+	assert.deepEqual(result, { status: 'unconverged' });
+	// Nothing about the bundle branch is even asked: no existence probe, no fetch, no checkout.
+	assert.equal(
+		git.calls.some((a) => a[0] === 'ls-remote'),
+		false,
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'checkout'),
+		false,
+	);
+	assert.equal(git.calls.some(isMerge), false);
+	assert.equal(git.calls.some(isPush), false);
+	assert.equal(git.calls.filter((a) => a[0] === 'fetch').length, 2);
+	assert.match(logs.join('\n'), /has not reached public master/);
+});
+
+test('a missing bundle branch is not created from an unpublished base', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'ls-remote', ''],
+		...unpublishedRoutes('abc1234 chore: Bundle/1.x'),
+		...baseGitRoutes,
+	]);
+
+	// One guard covers both paths: the branch must not be conjured onto a doomed commit either.
+	assert.deepEqual(syncBundleBranch({ git, env, log: silent }), { status: 'unconverged' });
+	assert.equal(
+		git.calls.some((a) => a[0] === 'checkout'),
+		false,
+	);
+	assert.equal(git.calls.some(isPush), false);
+});
+
+test('a base ahead of public by a non-bundle commit fails loudly', () => {
+	const git = makeStub([
+		...unpublishedRoutes('abc1234 fix(core): Something a human pushed directly'),
+		...baseGitRoutes,
+	]);
+	const logs = [];
+
+	assert.throws(() => syncBundleBranch({ git, env, log: (m) => logs.push(m) }), {
+		message: /master is ahead of public by commits that are not bundle cuts/,
+	});
+	assert.equal(git.calls.some(isPush), false);
+
+	// The annotation is the headline of a failed run: a count, never a subject.
+	const annotations = logs.filter((m) => m.startsWith('::error'));
+	assert.match(annotations.join('\n'), /carries 1 commit\(s\)/);
+	assert.doesNotMatch(annotations.join('\n'), /Something a human pushed directly/);
+});
+
+test('one stray commit among bundle cuts still fails', () => {
+	const git = makeStub([
+		...unpublishedRoutes('abc1234 chore: Bundle 2.x (#123)', 'def5678 fix(core): Stray'),
+		...baseGitRoutes,
+	]);
+
+	// All-or-nothing: a single unexplained commit means the mirror cannot clear the base.
+	assert.throws(() => syncBundleBranch({ git, env, log: silent }), {
+		message: /not bundle cuts/,
+	});
+});
+
+test('an unrelated history skips rather than forcing anything', () => {
+	const git = makeStub([...unpublishedRoutes(), ...baseGitRoutes]);
+
+	// Ancestry fails but the range is empty, so there is nothing to classify. Skipping is the
+	// only safe default here.
+	assert.deepEqual(syncBundleBranch({ git, env, log: silent }), { status: 'unconverged' });
+	assert.equal(git.calls.some(isPush), false);
+});
+
+test('an unconverged base is not retried as a push race', () => {
+	const git = makeStub([...unpublishedRoutes('abc1234 chore: Bundle 2.x'), ...baseGitRoutes]);
+	const logs = [];
+
+	syncBundleBranch({ git, env, log: (m) => logs.push(m) });
+
+	// Only 'rejected' earns a second attempt; the mirror runs hourly, not within this run.
+	assert.equal(git.calls.filter((a) => a[0] === 'fetch').length, 2);
+	assert.doesNotMatch(logs.join('\n'), /retrying/);
+});
+
+test('a public fetch that fails stops the run instead of guessing', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'fetch' && a[1] === PUBLIC_REMOTE, fail('could not read from remote')],
+		...baseGitRoutes,
+	]);
+
+	assert.throws(() => syncBundleBranch({ git, env, log: silent }), {
+		message: /Could not fetch master from the public repo/,
+	});
+	assert.equal(
+		git.calls.some((a) => a[0] === 'checkout'),
+		false,
+	);
+	assert.equal(git.calls.some(isPush), false);
+});
+
+test('the 1.x bundle branch is checked against public 1.x', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'ls-remote', `${PRE_HEAD}\trefs/heads/bundle/1.x`],
+		...baseGitRoutes,
+	]);
+	syncBundleBranch({
+		git,
+		env: { ...env, BUNDLE_BRANCH: 'bundle/1.x', BASE_BRANCH: '1.x' },
+		log: silent,
+	});
+
+	// The base branch name carries over to the public side unchanged.
+	assert.deepEqual(
+		git.calls.filter((a) => a[0] === 'fetch'),
+		[
+			['fetch', REMOTE, '1.x'],
+			['fetch', PUBLIC_REMOTE, '1.x'],
+			['fetch', REMOTE, 'bundle/1.x'],
+		],
+	);
 });

--- a/.github/workflows/sec-sync-bundle-branches.yml
+++ b/.github/workflows/sec-sync-bundle-branches.yml
@@ -17,6 +17,11 @@
 # head is the bundle branch). A merged fix and a manual dispatch before a cut are the moments
 # that matter.
 #
+# Only published history is synced in. A cut leaves a private-only `chore: Bundle/*` commit on
+# private master that the hourly public→private mirror later discards for the public copy, so a
+# run in that window skips instead of building the branch on it — a dispatch or a merged fix PR
+# right after a cut can legitimately do nothing. See sync-bundle-branch.mjs.
+#
 # One job per bundle branch: a conflict on one FAILS THAT JOB and leaves its branch untouched,
 # while the other still syncs. Recovery is manual and deliberate — merge the base in locally,
 # resolve, push, then re-run this workflow. That resolution then lives in the merge commit,

--- a/.github/workflows/sec-sync-bundle-branches.yml
+++ b/.github/workflows/sec-sync-bundle-branches.yml
@@ -87,10 +87,21 @@ jobs:
           BASE_BRANCH: ${{ matrix.base }}
         run: node .github/scripts/sync-bundle-branch.mjs
 
+  # A deleted bundle branch takes its open PRs with it: GitHub moves them onto the base. The
+  # sync re-creates the branch, so this runs after it — a conflict on one branch does not
+  # change where PRs point, so run even then.
+  retarget:
+    name: Retarget bundle PRs
+    needs: [sync]
+    if: ${{ !cancelled() && needs.sync.result != 'skipped' }}
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/sec-sync-retarget-prs.yml
+
   notify-on-failure:
     name: Notify Slack on failure
-    needs: [sync]
-    if: ${{ always() && needs.sync.result == 'failure' }}
+    needs: [sync, retarget]
+    if: ${{ always() && (needs.sync.result == 'failure' || needs.retarget.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout the slack scripts
@@ -100,7 +111,7 @@ jobs:
           sparse-checkout: .github/scripts/slack
           sparse-checkout-cone-mode: false
           persist-credentials: false
-      # Branch names and a run link only: conflicted paths and commit subjects hint at the
+      # A run link only: conflicted paths, commit subjects and PR titles all hint at the
       # vulnerability, and Slack reaches a wider audience than the private repo.
       - name: Notify Slack
         env:
@@ -109,4 +120,4 @@ jobs:
         run: |
           node .github/scripts/slack/notify.mjs \
             --channel '#alerts-security' \
-            --text "<${RUN_URL}|A bundle branch could not be synced with its base>. The branch is untouched; see the run for which one and why."
+            --text "<${RUN_URL}|Bundle branch maintenance failed>: a branch could not be synced with its base, or its PRs could not be retargeted. Nothing was rewritten; see the run for which one and why."

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -8,7 +8,9 @@
 #
 # A skipped branch or a hard failure is reported to #alerts-build.
 #
-# The bundle/* integration branches are kept current by sec-sync-bundle-branches.yml.
+# The bundle/* integration branches are kept current by sec-sync-bundle-branches.yml, which
+# depends on this mirror: it refuses to build a bundle branch on a base commit the public repo
+# does not have yet. So while this workflow is stuck, bundle syncing is stuck too.
 
 name: 'Security: Sync from Public'
 run-name: "${{ github.event_name == 'workflow_dispatch' && format('Security: Sync from Public (force={0})', inputs.force) || '' }}"

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -102,7 +102,8 @@ jobs:
           git reset --hard public-1.x
           git push origin 1.x --force-with-lease
 
-      - name: Re-create missing bundle branches
+      # Dispatch only: the bundle sync creates the branch and moves its PRs back onto it.
+      - name: Dispatch re-creation of missing bundle branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/sec-sync-retarget-prs.yml
+++ b/.github/workflows/sec-sync-retarget-prs.yml
@@ -27,6 +27,7 @@ jobs:
     if: github.repository == 'n8n-io/n8n-private'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write # move a PR's base branch
     strategy:
       fail-fast: false # one branch failing must not hold back the other

--- a/.github/workflows/sec-sync-retarget-prs.yml
+++ b/.github/workflows/sec-sync-retarget-prs.yml
@@ -1,0 +1,77 @@
+# Moves open PRs in n8n-io/n8n-private off a bundle branch's base and back onto the bundle
+# branch: master -> bundle/2.x, 1.x -> bundle/1.x.
+#
+# When a bundle branch is deleted, GitHub retargets every open PR that pointed at it to that
+# branch's own base. Re-creating the branch does not undo this, so the fixes sit on master
+# until they are moved back by hand.
+#
+# Called by sec-sync-bundle-branches.yml once its sync has run, so the bundle branch is known
+# to exist by the time the PRs are moved. Also dispatchable on its own.
+#
+# Every open PR on a bundle branch's base is treated as a fix that belongs on the bundle
+# branch. The one exception is the bundle cut PR itself (bundle/2.x -> master), which is
+# excluded by its head branch — it must keep pointing at the base.
+
+name: 'Security: Retarget bundle PRs'
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+# Least privilege by default; the retarget job opts into exactly what it needs.
+permissions: {}
+
+jobs:
+  retarget:
+    name: Retarget onto ${{ matrix.bundle }}
+    if: github.repository == 'n8n-io/n8n-private'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # move a PR's base branch
+    strategy:
+      fail-fast: false # one branch failing must not hold back the other
+      matrix:
+        include:
+          - base: 'master'
+            bundle: 'bundle/2.x'
+          - base: '1.x'
+            bundle: 'bundle/1.x'
+    steps:
+      - name: Move open PRs from ${{ matrix.base }} onto ${{ matrix.bundle }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ matrix.base }}
+          BUNDLE: ${{ matrix.bundle }}
+        run: |
+          # Nothing to move onto a branch that is not there; the sync re-creates it.
+          if ! gh api "repos/$REPO/git/ref/heads/$BUNDLE" --silent 2>/dev/null; then
+            echo "$BUNDLE does not exist; nothing to retarget."
+            exit 0
+          fi
+
+          # `bundle/*` heads are the cut PRs, which target the base on purpose.
+          PRS=$(gh pr list --repo "$REPO" --base "$BASE" --state open --limit 200 \
+            --json number,headRefName \
+            -q '.[] | select(.headRefName | startswith("bundle/") | not) | .number')
+
+          if [ -z "$PRS" ]; then
+            echo "No PRs on $BASE to move onto $BUNDLE."
+            exit 0
+          fi
+
+          FAILED=0
+          for PR in $PRS; do
+            if gh pr edit "$PR" --repo "$REPO" --base "$BUNDLE"; then
+              echo "ok   #$PR -> $BUNDLE"
+            else
+              echo "FAIL #$PR" >&2
+              FAILED=$((FAILED + 1))
+            fi
+          done
+
+          # PR numbers only: a title or branch name hints at the vulnerability.
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error title=Retarget incomplete::$FAILED PR(s) could not be moved onto $BUNDLE."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Once a bundle branch is merged, the outstanding PRs targeting it are moved to re-target master. This workflow will automatically re-target the newly created bundle branch during the next sync event, ensuring we have our PRs targeted at the correct intended branches.

Also reworks parts of the post-bundle sync process to ensure our synced master and new bundle branches are up to date with everything we'd expect before re-creating the bundle branches.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

