### PR TITLE
feat(core): Share the parent workspace sandbox with background sub-agents

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
@@ -925,4 +925,52 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — backg
 
 		expect(getInjectedToolNames()).toEqual(expect.arrayContaining(BACKGROUND_TOOL_NAMES));
 	});
+
+	function getInjectedSpawnBackgroundTool() {
+		for (const call of builtAgent.tool.mock.calls) {
+			for (const item of Array.isArray(call[0]) ? call[0] : [call[0]]) {
+				const tool = item as BuiltTool;
+				if (tool.name === 'spawn_background_subagent') return tool;
+			}
+		}
+		return undefined;
+	}
+
+	it('forwards the parent workspace handle to a background spawn', async () => {
+		Container.get(AgentsConfig).backgroundTasksEnabled = true;
+		const principalHash = hashAgentSandboxPrincipal({ type: 'n8n-user', userId: 'user-1' });
+		const handle = mock<AgentSandboxRuntime>();
+		const agentWorkspaceService = mock<AgentWorkspaceService>();
+		agentWorkspaceService.getAgentWorkspace.mockResolvedValue({
+			workspace: new Workspace({}),
+			handle,
+		});
+		const backgroundRunner = mock<SubAgentBackgroundRunner>();
+		backgroundRunner.spawn.mockResolvedValue({ status: 'started', jobId: 'job-1' });
+		Container.set(SubAgentBackgroundRunner, backgroundRunner);
+		const service = makeReconstructionService({
+			agentSandboxRuntimeService: mock<AgentSandboxRuntimeService>({ isEnabled: () => true }),
+			agentWorkspaceService,
+		});
+
+		await service.reconstructFromAgentEntity(
+			makeAgentEntity(),
+			mock<CredentialProvider>(),
+			'production',
+			undefined,
+			undefined,
+			undefined,
+			'manual',
+			principalHash,
+		);
+
+		const spawnTool = getInjectedSpawnBackgroundTool();
+		if (!spawnTool?.handler) throw new Error('Expected spawn_background_subagent handler');
+		await spawnTool.handler(
+			{ subAgentId: 'inline', taskName: 'research', goal: 'find things' },
+			{ persistence: { threadId: 'thread-1', resourceId: 'resource-1' } },
+		);
+
+		expect(backgroundRunner.spawn.mock.calls[0][1].parentWorkspaceHandle).toBe(handle);
+	});
 });

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -958,6 +958,7 @@ export class AgentRuntimeReconstructionService {
 					delegation: subAgentDelegation,
 					user,
 					instrumentation,
+					...(parentWorkspaceHandle !== undefined ? { parentWorkspaceHandle } : {}),
 				});
 			}
 		}
@@ -1068,6 +1069,7 @@ export class AgentRuntimeReconstructionService {
 		delegation: SubAgentDelegationConfig;
 		user?: User;
 		instrumentation?: AgentRuntimeInstrumentation;
+		parentWorkspaceHandle?: AgentSandboxRuntime;
 	}): Promise<void> {
 		const { agent, parentAgentId, projectId, delegation, ...runContext } = params;
 		const {

--- a/packages/cli/src/modules/agents/background/__tests__/sub-agent-background-runner.test.ts
+++ b/packages/cli/src/modules/agents/background/__tests__/sub-agent-background-runner.test.ts
@@ -3,6 +3,7 @@ import type { Logger } from '@n8n/backend-common';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import type { AgentSandboxRuntime } from '../../agent-sandbox-runtime.service';
 import type { SubAgentRunner, SubAgentRunResult } from '../../sub-agents/sub-agent-runner';
 import type { AgentBackgroundJobService } from '../agent-background-job.service';
 import { SUB_AGENT_BACKGROUND_TIMEOUT_MS } from '../agent-background-job.service';
@@ -115,6 +116,19 @@ describe('spawn', () => {
 		await flushDetachedRun();
 
 		expect(runner.run.mock.calls[0][1].selfDelegationDifficulty).toBe('high');
+	});
+
+	it('forwards a parent workspace handle to the run and omits the key when none is supplied', async () => {
+		const { backgroundRunner, runner, context } = setup();
+		const parentWorkspaceHandle = mock<AgentSandboxRuntime>();
+
+		await backgroundRunner.spawn(request, { ...context, parentWorkspaceHandle });
+		await flushDetachedRun();
+		expect(runner.run.mock.calls[0][1].parentWorkspaceHandle).toBe(parentWorkspaceHandle);
+
+		await backgroundRunner.spawn(request, context);
+		await flushDetachedRun();
+		expect(runner.run.mock.calls[1][1]).not.toHaveProperty('parentWorkspaceHandle');
 	});
 
 	it('does not start a run when the receipt is limit-reached', async () => {

--- a/packages/cli/src/modules/agents/background/background-job-tools.ts
+++ b/packages/cli/src/modules/agents/background/background-job-tools.ts
@@ -19,9 +19,16 @@ export interface BackgroundJobToolsOptions {
 	availableSubAgents: Array<{ id: string; name: string; useWhen?: string }>;
 	projectId: string;
 	parentAgentId: string;
+	// The workspace handle is principal-scoped, not thread-scoped. The sandbox
+	// outlives the parent turn, so capture it when the tool is built.
 	runContext: Pick<
 		SubAgentRunContext,
-		'credentialProvider' | 'runType' | 'workflowToolExecutionMode' | 'user' | 'instrumentation'
+		| 'credentialProvider'
+		| 'runType'
+		| 'workflowToolExecutionMode'
+		| 'user'
+		| 'instrumentation'
+		| 'parentWorkspaceHandle'
 	>;
 }
 

--- a/packages/cli/src/modules/agents/background/sub-agent-background-runner.ts
+++ b/packages/cli/src/modules/agents/background/sub-agent-background-runner.ts
@@ -57,7 +57,12 @@ export class SubAgentBackgroundRunner {
 			parentAgentId: string;
 		} & Pick<
 			SubAgentRunContext,
-			'credentialProvider' | 'runType' | 'workflowToolExecutionMode' | 'user' | 'instrumentation'
+			| 'credentialProvider'
+			| 'runType'
+			| 'workflowToolExecutionMode'
+			| 'user'
+			| 'instrumentation'
+			| 'parentWorkspaceHandle'
 		>,
 	): Promise<BackgroundJobReceipt> {
 		// Throws on an unusable task name — before the job row exists, so a bad
@@ -127,6 +132,9 @@ export class SubAgentBackgroundRunner {
 					abortSignal: abortController.signal,
 					...(request.difficulty !== undefined
 						? { selfDelegationDifficulty: request.difficulty }
+						: {}),
+					...(context.parentWorkspaceHandle !== undefined
+						? { parentWorkspaceHandle: context.parentWorkspaceHandle }
 						: {}),
 				},
 			)


### PR DESCRIPTION
## Summary

Background sub-agents currently start without workspace tools. `SubAgentBackgroundRunner` receives only the parent sandbox principal hash, so the child runtime is reconstructed with no workspace. Foreground sub-agents already share the parent run's workspace sandbox (#37242).

This PR forwards the parent run's live workspace handle (`parentWorkspaceHandle`) through the background path, the same way the foreground `delegate_subagent` tool does:

- `injectRuntimeDependencies` → `attachBackgroundJobTools` (top-level runtime reconstruction)
- `createSpawnBackgroundSubAgentTool` options (`runContext`)
- `SubAgentBackgroundRunner.spawn()` context
- `SubAgentRunner.run()` context

Everything downstream is unchanged: `SubAgentRunner` already scopes a child into `<workspaceRoot>/subagents/<childThreadId>` and never acquires an own sandbox for the sub-agent profile. The handle stays in memory only. It is not written to the job row, a checkpoint, or any JSON.

Capturing the handle when the tool is built is safe. The runtime cache key includes the sandbox principal hash, so a cached runtime and its tool closures are per principal. The workspace sandbox is deterministic, lazy, and persistent, and it has no release step tied to the parent turn, so a detached child can keep using it after the parent's turn ends.

### Scope note

The ticket also covers reacquiring the parent workspace when a background child resumes after HITL. Background HITL resume does not exist on `master` yet (a suspended background child is settled as `failed`). It is implemented in the draft PR #37665 (AGENT-701). The resume part of this ticket is a follow-up on top of that PR: `SubAgentBackgroundRunner.resume()` reacquires the handle with `agentWorkspaceService.getAgentWorkspace(projectId, job.parentAgentId, principalHash)` and passes it to `resumeForeground()`. The principal hash is already in the child checkpoint's host metadata, so no new column is needed.

## How to test

Env: `N8N_AGENTS_BACKGROUND_TASKS_ENABLED=true` and `N8N_AGENTS_AI_SANDBOX_ENABLED=true` with a configured sandbox provider.

1. Open a top-level agent in the agent preview.
2. Ask it to write a file to its workspace, for example `notes.md`.
3. Ask it to use `spawn_background_subagent` (subAgentId `inline`) with the goal: "Read notes.md from the parent workspace at ../../notes.md, then write summary.md in your workspace."
4. Wait for the job to finish and call `check_background_jobs`.
5. Expected: the job completes and the child had workspace tools. In the parent sandbox, `subagents/<childThreadId>/summary.md` exists. No second workspace sandbox was created.
6. Compare with `master`: the child reports that it has no workspace tools.

Unit tests:

```bash
cd packages/cli
pnpm test src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
pnpm test src/modules/agents/background/__tests__/sub-agent-background-runner.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-781

Related: #37665 (background HITL resume; the resume half of AGENT-781 follows it), #37242 (foreground workspace sharing).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
