### PR TITLE
fix(Azure OpenAI Chat Model Node): Resolve the proxy against the Azure endpoint so NO_PROXY applies

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -152,10 +152,16 @@ export class LmChatAzureOpenAi implements INodeType {
 				callbacks: [new N8nLlmTracing(this)],
 				configuration: {
 					fetchOptions: {
-						dispatcher: getProxyAgent(undefined, {
-							headersTimeout: timeout,
-							bodyTimeout: timeout,
-						}),
+						// Resolve the proxy against the host LangChain dials so NO_PROXY applies to it.
+						// `||` rather than `??`: the Entra handler yields '' for a missing endpoint.
+						dispatcher: getProxyAgent(
+							modelConfig.azureOpenAIEndpoint ||
+								`https://${modelConfig.azureOpenAIApiInstanceName}.openai.azure.com`,
+							{
+								headersTimeout: timeout,
+								bodyTimeout: timeout,
+							},
+						),
 					},
 				},
 				modelKwargs: options.responseFormat

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/__tests__/LmChatAzureOpenAi.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/__tests__/LmChatAzureOpenAi.node.test.ts
@@ -1,0 +1,80 @@
+import { getProxyAgent } from '@n8n/ai-utilities';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+
+import { LmChatAzureOpenAi } from '../LmChatAzureOpenAi.node';
+
+vi.mock('@langchain/openai');
+vi.mock('@n8n/ai-utilities');
+
+const mockNode: INode = {
+	id: '1',
+	name: 'Azure OpenAI Chat Model',
+	typeVersion: 1,
+	type: '@n8n/n8n-nodes-langchain.lmChatAzureOpenAi',
+	position: [0, 0],
+	parameters: {},
+};
+
+const apiKeyCredential = {
+	apiKey: 'test-key',
+	resourceName: 'my-resource',
+	apiVersion: '2024-08-01-preview',
+};
+
+const entraCredential = {
+	resourceName: 'my-resource',
+	apiVersion: '2024-08-01-preview',
+	oauthTokenData: { access_token: 'test-token' },
+};
+
+const setupMockContext = (authentication: string, credential: object) => {
+	const ctx = createMockExecuteFunction<ISupplyDataFunctions>({}, mockNode);
+	ctx.getCredentials = vi.fn().mockResolvedValue(credential);
+	ctx.getNode = vi.fn().mockReturnValue(mockNode);
+	ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+		if (paramName === 'authentication') return authentication;
+		if (paramName === 'model') return 'gpt-4o';
+		if (paramName === 'options') return {};
+		return undefined;
+	});
+	ctx.logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+	return ctx;
+};
+
+describe('LmChatAzureOpenAi', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it.each([
+		[
+			'API key with custom endpoint',
+			'azureOpenAiApi',
+			{ ...apiKeyCredential, endpoint: 'https://custom.openai.azure.com' },
+			'https://custom.openai.azure.com',
+		],
+		[
+			'API key without endpoint',
+			'azureOpenAiApi',
+			apiKeyCredential,
+			'https://my-resource.openai.azure.com',
+		],
+		// The Entra handler turns a missing endpoint into '' rather than undefined
+		[
+			'Entra ID without endpoint',
+			'azureEntraCognitiveServicesOAuth2Api',
+			entraCredential,
+			'https://my-resource.openai.azure.com',
+		],
+	])(
+		'resolves the proxy against the Azure host it dials (%s)',
+		async (_, authentication, credential, expectedUrl) => {
+			const ctx = setupMockContext(authentication, credential);
+
+			await new LmChatAzureOpenAi().supplyData.call(ctx, 0);
+
+			expect(vi.mocked(getProxyAgent)).toHaveBeenCalledWith(expectedUrl, expect.any(Object));
+		},
+	);
+});


### PR DESCRIPTION
## Summary

The Azure OpenAI Chat Model node built its fetch dispatcher with `getProxyAgent(undefined, …)`. Without a target URL, `getProxyAgent` resolves the proxy against a placeholder URL, not the Azure host. `NO_PROXY` entries for the Azure host have no effect, and every request goes through `HTTPS_PROXY`. Behind a corporate proxy that has no route to a private-endpoint Azure OpenAI resource, the node fails while the HTTP Request node reaches the same host.

This PR passes the Azure endpoint to `getProxyAgent`: the credential's custom `endpoint`, or `https://<resourceName>.openai.azure.com`. This is the URL LangChain dials, and it matches the Embeddings Azure OpenAI node. The fix covers both API key and Entra ID authentication.

The node uses `||`, not `??`. The Entra ID credential handler returns `''` for a missing endpoint, and `??` would pass that empty string on.

A unit test checks the URL that reaches `getProxyAgent` for API key with a custom endpoint, API key with the default endpoint, and Entra ID with the default endpoint.

## How to test

Unit test:

```bash
cd packages/@n8n/nodes-langchain
pnpm test nodes/llms/LmChatAzureOpenAi/__tests__/LmChatAzureOpenAi.node.test.ts
```

Manual test with a proxy that cannot reach your Azure resource:

1. Start a local forward proxy that refuses `CONNECT` to `*.openai.azure.com`. Any proxy without a route to your Azure resource also works.
2. Start n8n with the proxy environment:
   ```bash
   HTTP_PROXY=http://127.0.0.1:8899 HTTPS_PROXY=http://127.0.0.1:8899 NO_PROXY=127.0.0.1,localhost,<resource>.openai.azure.com pnpm start
   ```
3. Import the workflow below. Select your Azure OpenAI credential on both Azure nodes. Set `model` to a deployment that exists on your resource.
4. Run the workflow.

Expected result on `master`: the Azure OpenAI Chat Model node fails with the proxy's error. The proxy log shows `CONNECT <resource>.openai.azure.com:443`. The HTTP Request control reaches Azure directly and returns 200.

Expected result on this branch: the Azure OpenAI Chat Model node returns `e2e-ai-2753-ok`. The proxy log shows no `CONNECT` for the Azure host. The GitHub control still goes through the proxy.

<details>
<summary>Example workflow</summary>

```json
{
  "name": "Azure OpenAI Chat Model - NO_PROXY check",
  "nodes": [
    {
      "name": "Run repro",
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        192
      ],
      "parameters": {}
    },
    {
      "name": "Control: GitHub via proxy",
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        288,
        0
      ],
      "parameters": {
        "method": "GET",
        "url": "https://api.github.com/",
        "options": {
          "response": {
            "response": {
              "fullResponse": true,
              "neverError": true
            }
          }
        }
      }
    },
    {
      "name": "Control: Azure via HTTP Request",
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        288,
        192
      ],
      "parameters": {
        "method": "GET",
        "url": "https://<resource>.openai.azure.com/openai/deployments?api-version=2023-03-15-preview",
        "authentication": "predefinedCredentialType",
        "nodeCredentialType": "azureOpenAiApi",
        "options": {
          "response": {
            "response": {
              "fullResponse": true,
              "neverError": true
            }
          }
        }
      },
      "credentials": {
        "azureOpenAiApi": {
          "name": "Azure OpenAI account"
        }
      }
    },
    {
      "name": "Basic LLM Chain (Azure)",
      "type": "@n8n/n8n-nodes-langchain.chainLlm",
      "typeVersion": 1.9,
      "position": [
        224,
        496
      ],
      "parameters": {
        "promptType": "define",
        "text": "Reply with exactly: e2e-ai-2753-ok"
      }
    },
    {
      "name": "Azure OpenAI Chat Model",
      "type": "@n8n/n8n-nodes-langchain.lmChatAzureOpenAi",
      "typeVersion": 1,
      "position": [
        304,
        720
      ],
      "parameters": {
        "authentication": "azureOpenAiApi",
        "model": "gpt-4o-mini",
        "options": {
          "maxRetries": 0,
          "timeout": 30000
        }
      },
      "credentials": {
        "azureOpenAiApi": {
          "name": "Azure OpenAI account"
        }
      }
    }
  ],
  "connections": {
    "Run repro": {
      "main": [
        [
          {
            "node": "Control: GitHub via proxy",
            "type": "main",
            "index": 0
          },
          {
            "node": "Control: Azure via HTTP Request",
            "type": "main",
            "index": 0
          },
          {
            "node": "Basic LLM Chain (Azure)",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Azure OpenAI Chat Model": {
      "ai_languageModel": [
        [
          {
            "node": "Basic LLM Chain (Azure)",
            "type": "ai_languageModel",
            "index": 0
          }
        ]
      ]
    }
  },
  "settings": {
    "executionOrder": "v1"
  }
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2753
- Related: #16149 reports the same symptom. It was closed by #16778, which added the proxy agent to this node with an `undefined` target URL.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

