### PR TITLE
fix(core): Batch LangSmith agent session exports

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts
@@ -350,6 +350,35 @@ describe('AgentSessionLangSmithExportService', () => {
 		expect(batches.flat()).toHaveLength(24);
 	});
 
+	it('rejects a run larger than five megabytes before submission', async () => {
+		// NUL uses six bytes in JSON, which keeps the source fixture compact.
+		const metadataValue = '\0'.repeat(875_000);
+		const { service } = setupSession(
+			makeExecution({
+				timeline: [
+					{
+						type: 'tool-call',
+						kind: 'node',
+						name: 'large-metadata',
+						toolCallId: 'large-metadata',
+						input: {},
+						output: {},
+						startTime: 1,
+						endTime: 2,
+						success: true,
+						nodeParameters: { note: metadataValue },
+					},
+				],
+			}),
+		);
+
+		await expect(service.exportSession(input)).rejects.toMatchObject({
+			message: "Session couldn't be sent to LangSmith. Try again.",
+			httpStatusCode: 503,
+		});
+		expect(batchIngestRunsMock).not.toHaveBeenCalled();
+	});
+
 	it('truncates large run fields without truncating metadata', async () => {
 		const largeValue = '\0'.repeat(60_000);
 		const metadataValue = '\0'.repeat(60_000);

--- a/packages/cli/src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts
@@ -12,11 +12,11 @@ import type { AgentExecution } from '../entities/agent-execution.entity';
 import type { AgentExecutionThread } from '../entities/agent-execution-thread.entity';
 import type { AgentExecutionThreadRepository } from '../repositories/agent-execution-thread.repository';
 
-const createRunMock = vi.hoisted(() => vi.fn());
+const batchIngestRunsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('langsmith', () => ({
 	Client: class {
-		createRun = createRunMock;
+		batchIngestRuns = batchIngestRunsMock;
 	},
 }));
 
@@ -180,6 +180,20 @@ function setup(
 	return { service, agentExecutionService, threadRepository };
 }
 
+function setupSession(execution: AgentExecution) {
+	const result = setup();
+	result.agentExecutionService.getThreadDetail.mockResolvedValue({
+		thread: makeThread(),
+		executions: [execution],
+	});
+	result.threadRepository.findByParentThreadId.mockResolvedValue([]);
+	return result;
+}
+
+function submittedRuns() {
+	return batchIngestRunsMock.mock.calls.flatMap(([{ runCreates }]) => runCreates ?? []);
+}
+
 describe('AgentSessionLangSmithExportService', () => {
 	const input = {
 		projectId: 'project-1',
@@ -189,7 +203,7 @@ describe('AgentSessionLangSmithExportService', () => {
 	};
 
 	beforeEach(() => {
-		createRunMock.mockReset();
+		batchIngestRunsMock.mockReset();
 	});
 
 	it('exports a complete redacted session tree with stable snapshot IDs', async () => {
@@ -232,28 +246,10 @@ describe('AgentSessionLangSmithExportService', () => {
 			threadId === 'parent-thread' ? [childThread] : [],
 		);
 
-		let releaseLastRun = () => {};
-		let blockLastRun = true;
-		const lastRunBlocked = new Promise<void>((resolve) => {
-			releaseLastRun = resolve;
-		});
-		createRunMock.mockImplementation(async (run: { outputs?: Record<string, unknown> }) => {
-			if (blockLastRun && run.outputs?.text === 'Child response') {
-				await lastRunBlocked;
-			}
-		});
+		const firstResult = await service.exportSession(input);
+		const firstRuns = submittedRuns();
 
-		let resolved = false;
-		const firstExport = service.exportSession(input).then((result) => {
-			resolved = true;
-			return result;
-		});
-		await vi.waitFor(() => expect(createRunMock).toHaveBeenCalledTimes(10));
-		expect(resolved).toBe(false);
-		releaseLastRun();
-		const firstResult = await firstExport;
-		const firstRuns = createRunMock.mock.calls.map(([run]) => run);
-
+		expect(batchIngestRunsMock).toHaveBeenCalledTimes(1);
 		expect(firstRuns.map((run) => run.name)).toEqual([
 			'Agent session: Parent Agent',
 			'Agent turn',
@@ -286,11 +282,12 @@ describe('AgentSessionLangSmithExportService', () => {
 			steps: [{ toolName: 'lookup' }],
 		});
 		expect(firstRuns[7].parent_run_id).toBe(firstRuns[6].id);
+		expect(firstRuns.every((run) => run.session_name === 'n8n-user-agents-debug')).toBe(true);
+		expect(firstRuns.every((run) => !('project_name' in run))).toBe(true);
 
-		blockLastRun = false;
-		createRunMock.mockClear();
+		batchIngestRunsMock.mockClear();
 		const secondResult = await service.exportSession(input);
-		const secondRuns = createRunMock.mock.calls.map(([run]) => run);
+		const secondRuns = submittedRuns();
 		expect(secondResult.traceId).toBe(firstResult.traceId);
 		expect(secondRuns.map((run) => run.id)).toEqual(firstRuns.map((run) => run.id));
 
@@ -304,6 +301,106 @@ describe('AgentSessionLangSmithExportService', () => {
 		);
 		const changedResult = await service.exportSession(input);
 		expect(changedResult.traceId).not.toBe(firstResult.traceId);
+	});
+
+	it('sends 300 runs in three ordered batches', async () => {
+		const timeline = Array.from({ length: 298 }, (_, index) => ({
+			type: 'text' as const,
+			content: `response-${index}`,
+			timestamp: index + 1,
+			endTime: index + 1,
+		}));
+		const { service } = setupSession(makeExecution({ timeline }));
+
+		await service.exportSession(input);
+
+		const batches = batchIngestRunsMock.mock.calls.map(([{ runCreates }]) => runCreates ?? []);
+		const runs = batches.flat();
+		expect(batches.map((batch) => batch.length)).toEqual([100, 100, 100]);
+		expect(runs[99].outputs.text).toBe('response-97');
+		expect(runs[100].outputs.text).toBe('response-98');
+		expect(runs.at(-1)?.outputs.text).toBe('response-297');
+	});
+
+	it('keeps each multi-run batch below five megabytes', async () => {
+		// NUL uses six bytes in JSON, so this crosses the byte limit without a slow PII scan.
+		const output = '\0'.repeat(40_000);
+		const timeline = Array.from({ length: 22 }, (_, index) => ({
+			type: 'tool-call' as const,
+			kind: 'tool' as const,
+			name: `large-output-${index}`,
+			toolCallId: `tool-${index}`,
+			input: {},
+			output: { result: output },
+			startTime: index + 1,
+			endTime: index + 1,
+			success: true,
+		}));
+		const { service } = setupSession(makeExecution({ timeline }));
+
+		await service.exportSession(input);
+
+		const batches = batchIngestRunsMock.mock.calls.map(([{ runCreates }]) => runCreates ?? []);
+		expect(batches).toHaveLength(2);
+		for (const batch of batches) {
+			expect(Buffer.byteLength(JSON.stringify({ post: batch, patch: [] }))).toBeLessThanOrEqual(
+				5 * 1024 * 1024,
+			);
+		}
+		expect(batches.flat()).toHaveLength(24);
+	});
+
+	it('truncates large run fields without truncating metadata', async () => {
+		const largeValue = '\0'.repeat(60_000);
+		const metadataValue = '\0'.repeat(60_000);
+		const { service } = setupSession(
+			makeExecution({
+				timeline: [
+					{
+						type: 'tool-call',
+						kind: 'node',
+						name: 'large-output',
+						toolCallId: 'large-output',
+						input: { query: largeValue },
+						output: { message: largeValue },
+						startTime: 1,
+						endTime: 2,
+						success: false,
+						nodeParameters: { note: metadataValue },
+					},
+				],
+			}),
+		);
+
+		await service.exportSession(input);
+
+		const toolRun = submittedRuns().find(({ name }) => name === 'large-output');
+		const truncated = `${largeValue.slice(0, 50_000)}… [truncated 10000 chars]`;
+		expect(toolRun).toMatchObject({
+			inputs: { query: truncated },
+			outputs: { message: truncated },
+			error: truncated,
+			extra: { metadata: { nodeParameters: { note: metadataValue } } },
+		});
+	});
+
+	it('stops waiting for a stalled batch after 60 seconds', async () => {
+		vi.useFakeTimers();
+		try {
+			batchIngestRunsMock.mockImplementation(async () => await new Promise(() => {}));
+			const { service } = setupSession(makeExecution({ timeline: [] }));
+
+			const exportPromise = service.exportSession(input);
+			await vi.waitFor(() => expect(batchIngestRunsMock).toHaveBeenCalledOnce());
+			const rejection = expect(exportPromise).rejects.toMatchObject({
+				message: "Session couldn't be sent to LangSmith. Try again.",
+				httpStatusCode: 503,
+			});
+			await vi.advanceTimersByTimeAsync(60_000);
+			await rejection;
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('exports HITL response timeline events', async () => {
@@ -327,9 +424,7 @@ describe('AgentSessionLangSmithExportService', () => {
 
 		await service.exportSession(input);
 
-		const hitlRun = createRunMock.mock.calls
-			.map(([run]) => run)
-			.find(({ name }) => name === 'HITL response');
+		const hitlRun = submittedRuns().find(({ name }) => name === 'HITL response');
 		expect(hitlRun).toMatchObject({
 			inputs: { toolCallId: 'tool-approval' },
 			outputs: { approved: false, reason: 'Needs changes' },
@@ -343,14 +438,14 @@ describe('AgentSessionLangSmithExportService', () => {
 			'LangSmith debug export is not enabled',
 		);
 		expect(agentExecutionService.getThreadDetail).not.toHaveBeenCalled();
-		expect(createRunMock).not.toHaveBeenCalled();
+		expect(batchIngestRunsMock).not.toHaveBeenCalled();
 	});
 
 	it('rejects inaccessible sessions without submitting a run', async () => {
 		const { service } = setup();
 
 		await expect(service.exportSession(input)).rejects.toThrow('Thread "parent-thread" not found');
-		expect(createRunMock).not.toHaveBeenCalled();
+		expect(batchIngestRunsMock).not.toHaveBeenCalled();
 	});
 
 	it('rejects when a child session is still running', async () => {
@@ -369,7 +464,7 @@ describe('AgentSessionLangSmithExportService', () => {
 			threadId === 'parent-thread' ? [childThread] : [],
 		);
 		await expect(child.service.exportSession(input)).rejects.toThrow('Session is still running');
-		expect(createRunMock).not.toHaveBeenCalled();
+		expect(batchIngestRunsMock).not.toHaveBeenCalled();
 	});
 
 	it('rejects when blob-stored execution data is unavailable', async () => {
@@ -384,7 +479,7 @@ describe('AgentSessionLangSmithExportService', () => {
 				"Session couldn't be exported because some execution data is unavailable. Try again.",
 			httpStatusCode: 503,
 		});
-		expect(createRunMock).not.toHaveBeenCalled();
+		expect(batchIngestRunsMock).not.toHaveBeenCalled();
 	});
 
 	it('rejects cyclic child links without submitting a run', async () => {
@@ -410,7 +505,7 @@ describe('AgentSessionLangSmithExportService', () => {
 		await expect(service.exportSession(input)).rejects.toThrow(
 			'Agent session contains a cyclic child link',
 		);
-		expect(createRunMock).not.toHaveBeenCalled();
+		expect(batchIngestRunsMock).not.toHaveBeenCalled();
 	});
 
 	it('returns a retryable error when LangSmith submission fails', async () => {
@@ -420,7 +515,7 @@ describe('AgentSessionLangSmithExportService', () => {
 			executions: [makeExecution({ timeline: [] })],
 		});
 		threadRepository.findByParentThreadId.mockResolvedValue([]);
-		createRunMock.mockRejectedValueOnce(new Error('upstream unavailable'));
+		batchIngestRunsMock.mockRejectedValueOnce(new Error('upstream unavailable'));
 
 		await expect(service.exportSession(input)).rejects.toThrow(
 			"Session couldn't be sent to LangSmith. Try again.",

--- a/packages/cli/src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts
@@ -384,6 +384,36 @@ describe('AgentSessionLangSmithExportService', () => {
 		});
 	});
 
+	it('redacts run fields before applying their size limit', async () => {
+		const credential = `${'\0'.repeat(49_985)} sk-ant-${'a'.repeat(20)}`;
+		const { service } = setupSession(
+			makeExecution({
+				userMessage: credential,
+				error: credential,
+				timeline: [
+					{
+						type: 'tool-call',
+						kind: 'tool',
+						name: 'credential-output',
+						toolCallId: 'credential-output',
+						input: { value: credential },
+						output: { message: credential },
+						startTime: 1,
+						endTime: 2,
+						success: false,
+					},
+				],
+			}),
+		);
+
+		await service.exportSession(input);
+
+		const exportedRuns = JSON.stringify(submittedRuns());
+		expect(exportedRuns).not.toContain('sk-ant-');
+		expect(exportedRuns).not.toContain('[truncated');
+		expect(exportedRuns.match(/\[REDACTED\]/g)).toHaveLength(5);
+	});
+
 	it('stops waiting for a stalled batch after 60 seconds', async () => {
 		vi.useFakeTimers();
 		try {

--- a/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
+++ b/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
@@ -93,10 +93,12 @@ export class AgentSessionLangSmithExportService {
 		const traceId = uuidv5(canonicalSerialize(draft), EXPORT_NAMESPACE);
 		const { convertToDottedOrderFormat } = await import('langsmith/run_trees');
 		const runs = materializeRuns(draft, traceId, convertToDottedOrderFormat);
-		const batches = batchRuns(runs);
 		const startedAt = Date.now();
+		let batchCount = 0;
 
 		try {
+			const batches = batchRuns(runs);
+			batchCount = batches.length;
 			const client = await this.createClient(input.user);
 			await sendBatchesWithTimeout(client, batches);
 		} catch (error) {
@@ -105,7 +107,7 @@ export class AgentSessionLangSmithExportService {
 				agentId: input.agentId,
 				threadId: input.threadId,
 				runCount: runs.length,
-				batchCount: batches.length,
+				batchCount,
 				elapsedMs: Date.now() - startedAt,
 				error: error instanceof Error ? error.message : String(error),
 			});
@@ -498,11 +500,15 @@ function materializeRuns(
 function batchRuns(runs: LangSmithRun[]): LangSmithRun[][] {
 	const batches: LangSmithRun[][] = [];
 	let batch: LangSmithRun[] = [];
-	let batchSize = serializedSize({ post: [], patch: [] });
+	const emptyBatchSize = serializedSize({ post: [], patch: [] });
+	let batchSize = emptyBatchSize;
 
 	for (const run of runs) {
 		const separatorSize = batch.length > 0 ? 1 : 0;
 		const runSize = serializedSize(run);
+		if (emptyBatchSize + runSize > MAX_BATCH_SIZE_BYTES) {
+			throw new Error('LangSmith run exceeds maximum batch size');
+		}
 		if (
 			batch.length > 0 &&
 			(batch.length >= MAX_RUNS_PER_BATCH ||
@@ -510,7 +516,7 @@ function batchRuns(runs: LangSmithRun[]): LangSmithRun[][] {
 		) {
 			batches.push(batch);
 			batch = [];
-			batchSize = serializedSize({ post: [], patch: [] });
+			batchSize = emptyBatchSize;
 		}
 
 		batch.push(run);

--- a/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
+++ b/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
@@ -429,9 +429,9 @@ function toRecord(value: unknown): Record<string, unknown> {
 function truncateDraftRun(run: DraftRun): DraftRun {
 	return {
 		...run,
-		inputs: truncateRecord(run.inputs),
-		outputs: run.outputs ? truncateRecord(run.outputs) : undefined,
-		error: run.error ? truncateText(run.error) : undefined,
+		inputs: truncateRecord(sanitizeRecord(run.inputs)),
+		outputs: run.outputs ? truncateRecord(sanitizeRecord(run.outputs)) : undefined,
+		error: run.error ? truncateText(scrubText(run.error)) : undefined,
 	};
 }
 

--- a/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
+++ b/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
@@ -7,6 +7,7 @@ import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { isRecord } from '@n8n/utils/is-record';
 import type { Client } from 'langsmith';
+import { UserError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 import { v5 as uuidv5 } from 'uuid';
 
@@ -507,7 +508,7 @@ function batchRuns(runs: LangSmithRun[]): LangSmithRun[][] {
 		const separatorSize = batch.length > 0 ? 1 : 0;
 		const runSize = serializedSize(run);
 		if (emptyBatchSize + runSize > MAX_BATCH_SIZE_BYTES) {
-			throw new Error('LangSmith run exceeds maximum batch size');
+			throw new UserError('LangSmith run exceeds maximum batch size');
 		}
 		if (
 			batch.length > 0 &&

--- a/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
+++ b/packages/cli/src/modules/agents/agent-session-langsmith-export.service.ts
@@ -25,6 +25,10 @@ import { AgentExecutionService, type ThreadDetail } from './agent-execution.serv
 import { AgentExecutionThreadRepository } from './repositories/agent-execution-thread.repository';
 
 const LANGSMITH_PROJECT = 'n8n-user-agents-debug';
+const MAX_RUNS_PER_BATCH = 100;
+const MAX_BATCH_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_FIELD_CHARS = 50_000;
+const EXPORT_TIMEOUT_MS = 60_000;
 const EXPORT_NAMESPACE = uuidv5('n8n-agent-session-langsmith-export', uuidv5.URL);
 const REDACTION_OPTIONS = {
 	secrets: true,
@@ -33,7 +37,7 @@ const REDACTION_OPTIONS = {
 	redactSensitiveKeys: true,
 };
 
-type LangSmithRun = Parameters<Client['createRun']>[0];
+type LangSmithRun = NonNullable<Parameters<Client['batchIngestRuns']>[0]['runCreates']>[number];
 type DottedOrderConverter = (
 	epoch: number,
 	runId: string,
@@ -89,17 +93,20 @@ export class AgentSessionLangSmithExportService {
 		const traceId = uuidv5(canonicalSerialize(draft), EXPORT_NAMESPACE);
 		const { convertToDottedOrderFormat } = await import('langsmith/run_trees');
 		const runs = materializeRuns(draft, traceId, convertToDottedOrderFormat);
+		const batches = batchRuns(runs);
+		const startedAt = Date.now();
 
 		try {
 			const client = await this.createClient(input.user);
-			for (const run of runs) {
-				await client.createRun(run);
-			}
+			await sendBatchesWithTimeout(client, batches);
 		} catch (error) {
 			this.logger.error('Failed to export agent session to LangSmith', {
 				projectId: input.projectId,
 				agentId: input.agentId,
 				threadId: input.threadId,
+				runCount: runs.length,
+				batchCount: batches.length,
+				elapsedMs: Date.now() - startedAt,
 				error: error instanceof Error ? error.message : String(error),
 			});
 			throw new ServiceUnavailableError("Session couldn't be sent to LangSmith. Try again.");
@@ -219,7 +226,7 @@ function buildSessionRun(session: LoadedSession, path: string): DraftRun {
 		lastExecution?.updatedAt.getTime() ??
 		session.thread.updatedAt.getTime();
 
-	return {
+	return truncateDraftRun({
 		path,
 		name: `Agent session: ${session.thread.agentName}`,
 		runType: 'chain',
@@ -250,7 +257,7 @@ function buildSessionRun(session: LoadedSession, path: string): DraftRun {
 			totalDuration: session.thread.totalDuration,
 		},
 		children: [...executionRuns, ...unmatchedChildren],
-	};
+	});
 }
 
 function buildExecutionRun(
@@ -262,7 +269,7 @@ function buildExecutionRun(
 	const path = `${sessionPath}/executions/${execution.id}`;
 	const events = execution.timeline ?? [];
 	const children = events.map((event, index) => {
-		const eventRun = buildEventRun(event, execution, `${path}/events/${index}`);
+		const eventRun = truncateDraftRun(buildEventRun(event, execution, `${path}/events/${index}`));
 		const childThreadId = delegatedChildThreadId(event);
 		const childSession = childThreadId ? childSessions.get(childThreadId) : undefined;
 		if (childSession && !matchedChildren.has(childSession.thread.id)) {
@@ -276,7 +283,7 @@ function buildExecutionRun(
 	const startTime = execution.startedAt?.getTime() ?? execution.createdAt.getTime();
 	const endTime = execution.stoppedAt?.getTime() ?? execution.updatedAt.getTime();
 
-	return {
+	return truncateDraftRun({
 		path,
 		name: 'Agent turn',
 		runType: 'chain',
@@ -290,7 +297,7 @@ function buildExecutionRun(
 		error: execution.error ?? undefined,
 		metadata: executionMetadata(execution),
 		children,
-	};
+	});
 }
 
 function buildEventRun(event: TimelineEvent, execution: AgentExecution, path: string): DraftRun {
@@ -419,6 +426,31 @@ function toRecord(value: unknown): Record<string, unknown> {
 	return isRecord(value) ? value : { value };
 }
 
+function truncateDraftRun(run: DraftRun): DraftRun {
+	return {
+		...run,
+		inputs: truncateRecord(run.inputs),
+		outputs: run.outputs ? truncateRecord(run.outputs) : undefined,
+		error: run.error ? truncateText(run.error) : undefined,
+	};
+}
+
+function truncateRecord(value: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, truncateValue(item)]));
+}
+
+function truncateValue(value: unknown): unknown {
+	if (typeof value === 'string') return truncateText(value);
+	if (Array.isArray(value)) return value.map(truncateValue);
+	if (isRecord(value)) return truncateRecord(value);
+	return value;
+}
+
+function truncateText(value: string): string {
+	if (value.length <= MAX_FIELD_CHARS) return value;
+	return `${value.slice(0, MAX_FIELD_CHARS)}… [truncated ${value.length - MAX_FIELD_CHARS} chars]`;
+}
+
 function materializeRuns(
 	root: DraftRun,
 	traceId: string,
@@ -451,7 +483,7 @@ function materializeRuns(
 			run_type: draft.runType,
 			start_time: draft.startTime,
 			end_time: draft.endTime,
-			project_name: LANGSMITH_PROJECT,
+			session_name: LANGSMITH_PROJECT,
 		});
 
 		draft.children.forEach((child, index) => {
@@ -461,6 +493,60 @@ function materializeRuns(
 
 	visit(root, undefined, undefined, 1);
 	return runs;
+}
+
+function batchRuns(runs: LangSmithRun[]): LangSmithRun[][] {
+	const batches: LangSmithRun[][] = [];
+	let batch: LangSmithRun[] = [];
+	let batchSize = serializedSize({ post: [], patch: [] });
+
+	for (const run of runs) {
+		const separatorSize = batch.length > 0 ? 1 : 0;
+		const runSize = serializedSize(run);
+		if (
+			batch.length > 0 &&
+			(batch.length >= MAX_RUNS_PER_BATCH ||
+				batchSize + separatorSize + runSize > MAX_BATCH_SIZE_BYTES)
+		) {
+			batches.push(batch);
+			batch = [];
+			batchSize = serializedSize({ post: [], patch: [] });
+		}
+
+		batch.push(run);
+		batchSize += (batch.length > 1 ? 1 : 0) + runSize;
+	}
+
+	if (batch.length > 0) batches.push(batch);
+	return batches;
+}
+
+function serializedSize(value: unknown): number {
+	return Buffer.byteLength(JSON.stringify(value) ?? '');
+}
+
+async function sendBatchesWithTimeout(client: Client, batches: LangSmithRun[][]): Promise<void> {
+	let timedOut = false;
+	let timeoutId: NodeJS.Timeout | undefined;
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timeoutId = setTimeout(() => {
+			timedOut = true;
+			reject(new ServiceUnavailableError("Session couldn't be sent to LangSmith. Try again."));
+		}, EXPORT_TIMEOUT_MS);
+	});
+	const uploadPromise = (async () => {
+		for (const batch of batches) {
+			if (timedOut) return;
+			await client.batchIngestRuns({ runCreates: batch });
+		}
+	})();
+
+	try {
+		// The client cannot abort an in-flight batch; `timedOut` prevents the next one from starting.
+		await Promise.race([uploadPromise, timeoutPromise]);
+	} finally {
+		if (timeoutId) clearTimeout(timeoutId);
+	}
 }
 
 function sanitizeRecord(value: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- Send persisted agent session runs to LangSmith in sequential batches.
- Limit each batch to 100 runs or 5 MiB.
- Truncate long input, output, and error strings before redaction and export.
- Stop waiting after 60 seconds and add export size data to failure logs.

## How to test

Run the focused checks:

```bash
cd packages/cli
pnpm test src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts
pnpm typecheck
NODE_OPTIONS=--max-old-space-size=8192 pnpm exec eslint src/modules/agents/agent-session-langsmith-export.service.ts src/modules/agents/__tests__/agent-session-langsmith-export.service.test.ts --quiet
```

To test the export manually:

1. Start an instance with the Agents module and AI proxy enabled.
2. Set `localStorage.instanceAi.debugMode` to `true` in the browser.
3. Run an agent session with many tool calls.
4. Send the session to LangSmith.
5. Confirm that LangSmith contains the parent and child runs.
6. Send the session again and confirm that it keeps the same trace ID.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-693

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

