### PR TITLE
fix(core): Keep a resumed execution in the trace of the parked execution

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -532,7 +532,7 @@ describe('OtelLifecycleHandler', () => {
 			);
 		});
 
-		it('should start a new root span linked to the pre-wait origin and not overwrite the persisted origin', async () => {
+		it('should parent the resumed span on the pre-wait span and persist the new context', async () => {
 			traceContextService.get.mockResolvedValueOnce(prePauseContext);
 
 			await handler.onWorkflowResume({
@@ -547,15 +547,28 @@ describe('OtelLifecycleHandler', () => {
 			expect(tracer.startWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({
 					executionId: 'exec-resume',
+					tracingContext: prePauseContext,
 					linkTo: prePauseContext,
 				}),
 			);
-			// The post-resume call should NOT carry a parent context — it's a new root.
+			expect(traceContextService.persist).toHaveBeenCalledWith('exec-resume', resumedSpanContext);
+		});
+
+		it('should start a root span when no pre-wait context is persisted', async () => {
+			traceContextService.get.mockResolvedValueOnce(undefined);
+
+			await handler.onWorkflowResume({
+				type: 'workflowExecuteResume',
+				workflow: { id: 'wf-1', name: 'Test', versionId: 'v1', nodes: [], connections: {} },
+				workflowInstance: createWorkflowInstance(),
+				executionData: undefined as never,
+				executionId: 'exec-resume',
+			} as never);
+
 			expect(tracer.startWorkflow).toHaveBeenCalledWith(
-				expect.not.objectContaining({ tracingContext: expect.anything() }),
+				expect.objectContaining({ tracingContext: undefined, linkTo: undefined }),
 			);
-			// Origin stays authoritative; subsequent resumes should link to it too.
-			expect(traceContextService.persist).not.toHaveBeenCalled();
+			expect(traceContextService.persist).toHaveBeenCalledWith('exec-resume', resumedSpanContext);
 		});
 	});
 

--- a/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
@@ -1,9 +1,11 @@
 import { createTeamProject, createWorkflow, getPersonalProject } from '@n8n/backend-test-utils';
 import type { ExecutionRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
+import { WaitTracker } from '@/wait-tracker';
 import type { WorkflowRunner } from '@/workflow-runner';
 import { createUser } from '@test-integration/db/users';
 
@@ -12,6 +14,7 @@ import {
 	terminateOtelTestEnvironment,
 	executeWorkflow,
 	waitForExecution,
+	waitForExecutionStatus,
 	saveAndSetEnv,
 	restoreEnv,
 } from './support/otel-integration-utils';
@@ -19,6 +22,7 @@ import type { OtelTestProvider } from './support/otel-test-provider';
 import {
 	createMultiNodeWorkflowFixture,
 	createFailingWorkflowFixture,
+	createWaitWorkflowFixture,
 } from './support/otel-workflow-fixtures';
 
 let otel: OtelTestProvider;
@@ -106,6 +110,49 @@ describe('OTEL Workflow Tracing Integration', () => {
 		const workflowSpan = otel.getFinishedSpans().find((s) => s.name === 'workflow.execute')!;
 		expect(workflowSpan.status.code).toBe(SpanStatusCode.ERROR);
 		expect(workflowSpan.attributes['n8n.execution.status']).toBe('error');
+	});
+
+	it('should keep the resumed segment in the trace of the parked segment', async () => {
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createWaitWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id);
+		await waitForExecutionStatus(executionRepository, executionId, 'waiting');
+
+		await Container.get(WaitTracker).startExecution(executionId);
+		await waitForExecutionStatus(executionRepository, executionId, 'success');
+
+		const workflowSpans = otel.getFinishedSpans().filter((s) => s.name === 'workflow.execute');
+		expect(workflowSpans).toHaveLength(2);
+
+		const parked = workflowSpans.find((s) => s.attributes['n8n.execution.status'] === 'waiting')!;
+		const resumed = workflowSpans.find((s) => s.attributes['n8n.execution.status'] === 'success')!;
+		expect(parked).toBeDefined();
+		expect(resumed).toBeDefined();
+
+		expect(resumed.spanContext().traceId).toBe(parked.spanContext().traceId);
+		expect(resumed.parentSpanContext?.spanId).toBe(parked.spanContext().spanId);
+		expect(resumed.links[0]?.attributes?.['n8n.continuation.reason']).toBe('resume');
+	});
+
+	it('should advance the persisted tracing context to the resumed segment', async () => {
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createWaitWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id);
+		await waitForExecutionStatus(executionRepository, executionId, 'waiting');
+
+		const parkedContext = (await executionRepository.findOneBy({ id: executionId }))
+			?.tracingContext;
+
+		await Container.get(WaitTracker).startExecution(executionId);
+		await waitForExecutionStatus(executionRepository, executionId, 'success');
+
+		const resumedContext = (await executionRepository.findOneBy({ id: executionId }))
+			?.tracingContext;
+
+		const [, parkedTraceId, parkedSpanId] = parkedContext!.traceparent.split('-');
+		const [, resumedTraceId, resumedSpanId] = resumedContext!.traceparent.split('-');
+		expect(resumedTraceId).toBe(parkedTraceId);
+		expect(resumedSpanId).not.toBe(parkedSpanId);
 	});
 
 	it('should inherit traceId from inbound HTTP traceparent', async () => {

--- a/packages/cli/src/modules/otel/__tests__/support/otel-integration-utils.ts
+++ b/packages/cli/src/modules/otel/__tests__/support/otel-integration-utils.ts
@@ -8,8 +8,14 @@ import { readFileSync } from 'fs';
 import { InstanceSettings, UnrecognizedNodeTypeError } from 'n8n-core';
 import { DebugHelper } from 'n8n-nodes-base/nodes/DebugHelper/DebugHelper.node';
 import { ManualTrigger } from 'n8n-nodes-base/nodes/ManualTrigger/ManualTrigger.node';
-import { createRunExecutionData } from 'n8n-workflow';
-import type { IDataObject, INodeType, INodeTypeData, NodeLoadingDetails } from 'n8n-workflow';
+import { createRunExecutionData, UnexpectedError } from 'n8n-workflow';
+import type {
+	ExecutionStatus,
+	IDataObject,
+	INodeType,
+	INodeTypeData,
+	NodeLoadingDetails,
+} from 'n8n-workflow';
 import path from 'path';
 
 import { WorkflowRunner } from '@/workflow-runner';
@@ -53,6 +59,7 @@ export async function initOtelTestEnvironment() {
 	const distNodes = loadNodesFromDist([
 		'n8n-nodes-base.executeWorkflow',
 		'n8n-nodes-base.executeWorkflowTrigger',
+		'n8n-nodes-base.wait',
 	]);
 	await utils.initNodeTypes({
 		'n8n-nodes-base.manualTrigger': { type: new ManualTrigger(), sourcePath: '' },
@@ -152,4 +159,24 @@ export async function waitForExecution(
 		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
 	throw new Error(`Execution ${executionId} did not complete within ${timeout}ms`);
+}
+
+/** `waitForExecution` is unusable for parked executions: `stoppedAt` is already set. */
+export async function waitForExecutionStatus(
+	executionRepository: ExecutionRepository,
+	executionId: string,
+	status: ExecutionStatus,
+	timeout = 10_000,
+): Promise<void> {
+	const start = Date.now();
+	let lastSeen: ExecutionStatus | undefined;
+	while (Date.now() - start < timeout) {
+		const execution = await executionRepository.findOneBy({ id: executionId });
+		lastSeen = execution?.status;
+		if (lastSeen === status) return;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	throw new UnexpectedError(
+		`Execution ${executionId} did not reach status "${status}" within ${timeout}ms (last status: ${lastSeen})`,
+	);
 }

--- a/packages/cli/src/modules/otel/__tests__/support/otel-workflow-fixtures.ts
+++ b/packages/cli/src/modules/otel/__tests__/support/otel-workflow-fixtures.ts
@@ -38,6 +38,47 @@ export function createMultiNodeWorkflowFixture() {
 	};
 }
 
+/** The wait is over the Wait node's 65-second threshold, so the execution always suspends. */
+export function createWaitWorkflowFixture() {
+	return {
+		nodes: [
+			{
+				parameters: {},
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0] as [number, number],
+				id: uuid(),
+				name: 'Trigger',
+			},
+			{
+				parameters: { resume: 'timeInterval', amount: 10, unit: 'minutes' },
+				type: 'n8n-nodes-base.wait',
+				typeVersion: 1.1,
+				position: [200, 0] as [number, number],
+				id: uuid(),
+				name: 'Wait',
+			},
+			{
+				parameters: { category: 'doNothing' },
+				type: 'n8n-nodes-base.debugHelper',
+				typeVersion: 1,
+				position: [400, 0] as [number, number],
+				id: uuid(),
+				name: 'After Wait',
+			},
+		],
+		connections: {
+			Trigger: {
+				main: [[{ node: 'Wait', type: NodeConnectionTypes.Main, index: 0 }]],
+			},
+			Wait: {
+				main: [[{ node: 'After Wait', type: NodeConnectionTypes.Main, index: 0 }]],
+			},
+		},
+		pinData: {},
+	};
+}
+
 export function createFailingWorkflowFixture() {
 	return {
 		nodes: [

--- a/packages/cli/src/modules/otel/execution-level-tracer.types.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.types.ts
@@ -17,12 +17,9 @@ type WorkflowContext = {
 
 export type StartWorkflowParams = {
 	executionId: string;
-	/** Parent context — incoming webhook traceparent or parent sub-workflow span. */
+	/** Parent context — webhook traceparent, parent sub-workflow span, or the parked span on a resume. */
 	tracingContext?: TracingContext;
-	/**
-	 * Link this workflow to a different workflow. Used by `workflowExecuteResume` when a
-	 * workflow is resumed after a pause.
-	 */
+	/** Adds a `n8n.continuation.reason` link. Set alongside `tracingContext` on a resume. */
 	linkTo?: TracingContext;
 	workflow: WorkflowContext;
 	project?: ProjectContext;

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -126,8 +126,11 @@ export class OtelLifecycleHandler {
 				return undefined;
 			});
 
-		this.tracer.startWorkflow({
+		const spanContext = this.tracer.startWorkflow({
 			executionId: ctx.executionId,
+			// Parent keeps the execution in one trace; the link is kept for consumers of
+			// `n8n.continuation.reason`.
+			tracingContext: previousWorkflowExecution,
 			linkTo: previousWorkflowExecution,
 			project: project
 				? {
@@ -143,6 +146,9 @@ export class OtelLifecycleHandler {
 				customAttributes: this.buildWorkflowCustomAttributes(ctx),
 			},
 		});
+
+		// A second wait must parent on this segment, not on the origin.
+		await this.traceContextService.persist(ctx.executionId, spanContext);
 	}
 
 	@OnLifecycleEvent('workflowExecuteAfter')


### PR DESCRIPTION
## Summary

A workflow that parks on a Wait node produced **two separate traces** for one execution.

When the Wait node suspends an execution, `workflowExecuteAfter` ends the `workflow.execute` span. On resume, `onWorkflowResume` read the persisted trace context from `execution.tracingContext` but passed it as `linkTo` only, never as `tracingContext`. With no parent context, `startSpan` created a **new trace root** with a fresh trace id. The two halves were joined only by an OTel span link.

A span link is optional in the OTLP consumer contract. Jaeger renders it, so the split is easy to miss; other backends — including the on-prem tracing product used by the customer who reported this — do not render links at all, so an operator sees two unrelated traces and cannot follow one execution end to end.

This PR passes the persisted context as the **parent** as well as keeping the link, and persists the new span context so a second Wait node continues from the last segment instead of jumping back to the origin.

### Before

```mermaid
graph TD
    subgraph TA["Trace A"]
        A1["workflow.execute<br/>status=waiting"]
        A2["node.execute<br/>Webhook"]
        A3["node.execute<br/>Wait"]
        A1 --> A2
        A1 --> A3
    end
    subgraph TB["Trace B — separate trace id"]
        B1["workflow.execute<br/>status=success"]
        B2["node.execute<br/>Wait"]
        B3["node.execute<br/>After Wait"]
        B1 --> B2
        B1 --> B3
    end
    B1 -. "span link only<br/>(not rendered by all backends)" .-> A1
```

### After

```mermaid
graph TD
    R["workflow.execute<br/>status=waiting"]
    N1["node.execute<br/>Webhook"]
    N2["node.execute<br/>Wait"]
    S2["workflow.execute<br/>status=success<br/>parent + retained link"]
    N3["node.execute<br/>Wait"]
    N4["node.execute<br/>After Wait"]
    R --> N1
    R --> N2
    R --> S2
    S2 --> N3
    S2 --> N4
```

The link and its `n8n.continuation.reason` attribute are kept, so anything that already reads them keeps working. The parent edge is added on top.

One trace id also fixes sampling: the SDK samples on the trace id, so the two halves used to be sampled independently and could produce an orphan half below a sample rate of 1.

## How to test

Run n8n with OTel on, pointed at any OTLP collector (`N8N_OTEL_ENABLED=true`, `N8N_OTEL_EXPORTER_OTLP_ENDPOINT=...`, and `N8N_OTEL_TRACES_PRODUCTION_ONLY=false` if you want to trigger it manually).

Paste this onto the canvas and publish it:

<details>
<summary>Test workflow — Webhook → Wait → NoOp</summary>

```json
{
  "name": "LIGO-745 Wait node trace",
  "nodes": [
    {
      "parameters": {
        "httpMethod": "POST",
        "path": "ligo745",
        "responseMode": "onReceived",
        "options": {}
      },
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 2,
      "position": [
        0,
        0
      ],
      "id": "807fc517-d418-43d0-8d25-d0cc408e8757",
      "name": "Webhook",
      "webhookId": "e12abb62-3b73-41b5-99f8-2b7f3bac3ff6"
    },
    {
      "parameters": {
        "resume": "webhook",
        "options": {}
      },
      "type": "n8n-nodes-base.wait",
      "typeVersion": 1.1,
      "position": [
        220,
        0
      ],
      "id": "06f28dde-07c2-4f32-9520-38fe458080c7",
      "name": "Wait",
      "webhookId": "5931b556-6de1-47de-8adb-185c8cfe8f52"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [
        440,
        0
      ],
      "id": "892bac7f-3d0a-4b2b-a425-32726ca96f30",
      "name": "After Wait"
    }
  ],
  "connections": {
    "Webhook": {
      "main": [
        [
          {
            "node": "Wait",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Wait": {
      "main": [
        [
          {
            "node": "After Wait",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "settings": {
    "executionOrder": "v1"
  },
  "pinData": {}
}
```

</details>

The Wait node is set to **On webhook call**, which always suspends, so the split happens on every run. (A time interval of 65 seconds or more takes the same code path.)

1. Call the production webhook. The execution parks in `waiting`.
2. Open the execution and call the resume URL shown on the Wait node.
3. Search your backend for tag `n8n.execution.id=<id>`.

**Before this PR:** 2 traces. **After:** 1 trace, with the resumed `workflow.execute` nested under the parked one. That tag search is the whole check — it is what an operator does when they want one execution.

### Automated coverage (no Jaeger required)

These capture spans in memory, so they run on a bare checkout:

```bash
cd packages/cli
pnpm test src/modules/otel
pnpm test:integration src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
```

The three new integration tests drive a real Wait node through `WaitTracker` and assert on exported spans. All three fail on `master` and pass here.

## Known caveat: the Wait node appears twice

In the "after" diagram the `Wait` node has a `node.execute` span in **both** segments. This is not new — it happened before this PR as well, but the two spans sat in different traces, so nobody saw them together. Putting the execution in one trace makes the duplicate visible.

It is faithful to what the engine does. `handleWaitingState` re-enters the Wait node on resume in pass-through mode so the wait does not start again, and pops the pre-wait run out of `runData` so the executions UI shows one run. Our node spans come from `nodeExecuteBefore`/`nodeExecuteAfter`, which fire on both passes, so tracing keeps both while the UI keeps one. The durations tell them apart: the first span covers the real run, the second is under a millisecond.

Deduplicating needs an engine-side signal rather than an OTel change, so it is left out of this PR. Follow-up ticket to come. Three other observations are also out of scope and ticketed separately:

- The parked segment ends with `n8n.execution.status=waiting` and `otel.status_code=OK`.
- `n8n.workflow.version_id` is empty on the resumed segment, because `toWorkflowSnapshot` drops `versionId`.
- The parked wall-clock time appears in no span.

## Note for reviewers

This reverses a decision made in #28720, which deliberately chose a linked root so each half was a self-contained trace. The trade-off has not held up: `n8n.execution.id` should identify one trace, and span links are not rendered everywhere. A resumed segment parented on an already-ended span is the standard OTel async-continuation pattern. The unit test that asserted the old behaviour is rewritten accordingly.

One consequence worth naming: an execution parked for days now yields a trace whose root ended long before its child. Every OTel backend accepts this, but some UIs draw the child as extending past the parent.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-745

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
