### PR TITLE
ci: Report a missing required review as pending, not failure

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -766,7 +766,10 @@ An entry with the `required` option makes team approval mandatory: when a PR
 changes a file whose winning entry carries `required`, a member of each listed
 team must approve the PR. `ci-owners-required-reviews.yml` evaluates this on
 PR changes and review events, and reports a commit status
-named **Required Reviews** on the head SHA. The ruleset for `master` must list
+named **Required Reviews** on the head SHA. A missing approval reports
+`pending` ("Waiting for approval from: …"), not `failure`, so an unreviewed PR
+does not show red CI; any non-success state blocks the merge equally. The
+ruleset for `master` must list
 that status as a required check for the block to take effect. Merge-queue runs
 report success on the queue head without re-evaluating: a PR cannot enter the
 queue unless the status is green on its head, and the queue does not change

--- a/.github/scripts/owners/required-reviews.mjs
+++ b/.github/scripts/owners/required-reviews.mjs
@@ -91,7 +91,7 @@ export function collectApprovers(reviews) {
 /**
  * @param { string[] } missingTeams Team handles without an approving member.
  * @param { number } requiredCount Total number of required teams.
- * @returns {{ state: 'success' | 'failure', description: string }}
+ * @returns {{ state: 'success' | 'pending', description: string }}
  */
 export function buildStatus(missingTeams, requiredCount) {
 	if (requiredCount === 0) {
@@ -105,9 +105,11 @@ export function buildStatus(missingTeams, requiredCount) {
 		};
 	}
 
+	// Pending, not failure: an unreviewed PR waits, it is not broken. Anything
+	// other than success still blocks the merge.
 	return {
-		state: 'failure',
-		description: `Missing approval from: ${missingTeams.map(teamHandleToSlug).join(', ')}`,
+		state: 'pending',
+		description: `Waiting for approval from: ${missingTeams.map(teamHandleToSlug).join(', ')}`,
 	};
 }
 
@@ -119,7 +121,7 @@ function statusTargetUrl() {
 
 /**
  * @param { number } pullRequestNumber
- * @returns { Promise<{ state: 'success' | 'failure', description: string }> }
+ * @returns { Promise<{ state: 'success' | 'pending', description: string }> }
  */
 async function evaluateRequiredReviews(pullRequestNumber) {
 	const changedFiles = await getChangedFiles(pullRequestNumber);
@@ -182,7 +184,7 @@ export async function run() {
 		targetUrl,
 	});
 
-	/** @type { { state: 'success' | 'failure', description: string } } */
+	/** @type { { state: 'success' | 'pending', description: string } } */
 	let status;
 	try {
 		status = await evaluateRequiredReviews(pullRequestNumber);

--- a/.github/scripts/owners/required-reviews.test.mjs
+++ b/.github/scripts/owners/required-reviews.test.mjs
@@ -135,11 +135,11 @@ describe('buildStatus', () => {
 		assert.match(status.description, /2 teams/);
 	});
 
-	it('fails with the missing team slugs', () => {
+	it('stays pending with the missing team slugs', () => {
 		const status = buildStatus(['@n8n-io/qa-dx', '@n8n-io/migrations-review'], 2);
 
-		assert.equal(status.state, 'failure');
-		assert.equal(status.description, 'Missing approval from: qa-dx, migrations-review');
+		assert.equal(status.state, 'pending');
+		assert.equal(status.description, 'Waiting for approval from: qa-dx, migrations-review');
 	});
 });
 
@@ -181,7 +181,7 @@ describe('run', () => {
 		assert.equal(status.state, 'success');
 	});
 
-	it('sets a failure status when a required team has not approved', async () => {
+	it('sets a pending status when a required team has not approved', async () => {
 		resolveRequiredTeamsImpl = () => new Map([['@n8n-io/qa-dx', ['a.ts']]]);
 		getPrReviewsImpl = async () => [
 			{ user: { login: 'outsider' }, state: 'APPROVED', submitted_at: '2026-01-01T00:00:00Z' },
@@ -191,8 +191,8 @@ describe('run', () => {
 		await run();
 
 		const [, status] = setCommitStatus.mock.calls.at(-1).arguments;
-		assert.equal(status.state, 'failure');
-		assert.match(status.description, /Missing approval from: qa-dx/);
+		assert.equal(status.state, 'pending');
+		assert.match(status.description, /Waiting for approval from: qa-dx/);
 	});
 
 	it('sets an error status and rethrows when the evaluation fails', async () => {
@@ -250,7 +250,7 @@ describe('run', () => {
 
 		assert.equal(isTeamMember.mock.calls.length, 0);
 		const [, status] = setCommitStatus.mock.calls.at(-1).arguments;
-		assert.equal(status.state, 'failure');
+		assert.equal(status.state, 'pending');
 	});
 
 	it('does not count an approval that was later dismissed', async () => {
@@ -264,7 +264,7 @@ describe('run', () => {
 		await run();
 
 		const [, status] = setCommitStatus.mock.calls.at(-1).arguments;
-		assert.equal(status.state, 'failure');
+		assert.equal(status.state, 'pending');
 	});
 
 	it('skips PRs that do not target master without setting a status', async () => {

--- a/.github/workflows/ci-owners-required-reviews.yml
+++ b/.github/workflows/ci-owners-required-reviews.yml
@@ -29,9 +29,11 @@ run-name: "${{ github.event_name == 'workflow_dispatch' && format('CI: Owners Re
 # Output
 #   - A commit status named "Required Reviews" on the PR head SHA (or
 #     merge-group head SHA). Add this name to a ruleset's required-checks list
-#     to gate merges on it. The first job step sets the status to pending, so
-#     a run that crashes at any later point cannot leave a stale verdict in
-#     effect. The job itself only fails on errors.
+#     to gate merges on it. A missing approval reports "pending", not
+#     "failure": the PR waits for a reviewer, it is not broken, and anything
+#     other than success blocks the merge. The first job step sets the status
+#     to pending, so a run that crashes at any later point cannot leave a
+#     stale verdict in effect. The job itself only fails on errors.
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

The "Required Reviews" commit status reported `failure` when a required team had not approved yet. Every PR that touches owned files opened with red CI, although the PR only waits for a reviewer.

The status now reports `pending` with the description "Waiting for approval from: <teams>". Any non-success state blocks the merge, so the gate keeps the same strength. The `error` state stays for evaluation crashes, so real breakage still shows red. The behavior takes effect for a PR when its status re-evaluates (a push or a review event) after this lands on `master`.

## How to test

- Run `pnpm test` in `.github/scripts` — the `owners/required-reviews.test.mjs` suite covers the new verdict.
- Open a PR that changes a file with a `required` OWNERS entry. The "Required Reviews" status shows a yellow pending state, not a red failure. Approve as a member of the team; the status turns green.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://linear.app/n8n/issue/DEVP-887

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (WORKFLOWS.md)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

