### PR TITLE
test(editor): Add an e2e guard for the $env expression preview

### DIFF
--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/env-access.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/env-access.spec.ts
@@ -2,8 +2,8 @@ import { HTTP_REQUEST_NODE_NAME, MANUAL_TRIGGER_NODE_NAME } from '../../../../..
 import { test, expect } from '../../../../../fixtures/base';
 
 const URL_PARAMETER_NAME = 'url';
-const UNRESOLVED_PREVIEW_PLACEHOLDER = '[empty]';
 const ENV_ACCESS_DENIED_MESSAGE = 'access to env vars denied';
+const RUN_NODE_TO_RESOLVE_MESSAGE = '[not accessible via UI, please run node]';
 
 test.use({
 	capability: {
@@ -39,7 +39,7 @@ test.describe(
 			await n8n.ndv.typeInExpressionEditor('{{ $env.E2E_ENV_PREVIEW_PROBE', URL_PARAMETER_NAME);
 
 			const output = n8n.ndv.getInlineExpressionEditorOutput();
-			await expect(output).not.toHaveText(UNRESOLVED_PREVIEW_PLACEHOLDER);
+			await expect(output).toHaveText(RUN_NODE_TO_RESOLVE_MESSAGE);
 			await expect(output).not.toContainText(ENV_ACCESS_DENIED_MESSAGE);
 		});
 	},

--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/env-access.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/env-access.spec.ts
@@ -1,0 +1,46 @@
+import { HTTP_REQUEST_NODE_NAME, MANUAL_TRIGGER_NODE_NAME } from '../../../../../config/constants';
+import { test, expect } from '../../../../../fixtures/base';
+
+const URL_PARAMETER_NAME = 'url';
+const UNRESOLVED_PREVIEW_PLACEHOLDER = '[empty]';
+const ENV_ACCESS_DENIED_MESSAGE = 'access to env vars denied';
+
+test.use({
+	capability: {
+		env: {
+			TEST_ISOLATION: 'expression-env-access',
+			N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
+			E2E_ENV_PREVIEW_PROBE: 'probe-value',
+		},
+	},
+});
+
+test.describe(
+	'$env in the inline expression preview',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test.beforeEach(async ({ n8n, n8nContainer }) => {
+			test.skip(
+				!n8nContainer,
+				'container-only: the backend must start with N8N_BLOCK_ENV_ACCESS_IN_NODE set',
+			);
+			await n8n.start.fromBlankCanvas();
+		});
+
+		test('does not report env access as denied when the instance allows it', async ({ n8n }) => {
+			await n8n.canvas.addNode(MANUAL_TRIGGER_NODE_NAME);
+			await n8n.canvas.addNode(HTTP_REQUEST_NODE_NAME, { closeNDV: false });
+
+			await n8n.ndv.activateParameterExpressionEditor(URL_PARAMETER_NAME);
+			await n8n.ndv.getInlineExpressionEditorInput(URL_PARAMETER_NAME).click();
+			await n8n.ndv.clearExpressionEditor(URL_PARAMETER_NAME);
+			await n8n.ndv.typeInExpressionEditor('{{ $env.E2E_ENV_PREVIEW_PROBE', URL_PARAMETER_NAME);
+
+			const output = n8n.ndv.getInlineExpressionEditorOutput();
+			await expect(output).not.toHaveText(UNRESOLVED_PREVIEW_PLACEHOLDER);
+			await expect(output).not.toContainText(ENV_ACCESS_DENIED_MESSAGE);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

`$env` in an expression preview used to report `access to env vars denied` on instances that had set `N8N_BLOCK_ENV_ACCESS_IN_NODE=false`. Execution was correct; only the editor made the false claim.

The editor evaluates expressions in the browser, so it has no server environment to read. Until 2.29.0 the editor bundle carried a global `process` shim from `vite-plugin-node-polyfills`. With the shim present, `createEnvProviderState()` read an undefined flag, `undefined !== 'false'` resolved to `true`, and the preview took the blocked branch whatever the instance was configured to do.

#32569 commented the plugin out for unrelated reasons, the shim went away, and the false claim went with it. That is a side effect, not a deliberate fix, and nothing stops a future polyfill change from bringing it back.

This PR adds the missing guard. It starts the backend with env access allowed and asserts the preview never reports access as denied. No production code changes.

## How to test

```
pnpm build:docker
pnpm --filter=n8n-playwright test:container:sqlite tests/e2e/workflows/editor/expressions/env-access.spec.ts
```

The test is container-only, because it needs the backend started with specific environment variables; it skips in local mode.

To confirm it is not vacuous, change `ENV_ACCESS_DENIED_MESSAGE` to `not accessible via UI` and re-run. It fails with `Received string: "[not accessible via UI, please run node]"`. I ran that check in container mode, and confirmed by `docker inspect` that the stack's n8n container really receives `N8N_BLOCK_ENV_ACCESS_IN_NODE=false`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2997

Reported in https://github.com/n8n-io/n8n/issues/29603, across 2.18.5 to 2.27.4, all of them before 2.29.0.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

