### PR TITLE
fix(editor): Merge native agent tools into n8n nodes

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts
@@ -320,7 +320,7 @@ describe('AgentToolsConnectionModalWrapper', () => {
 		expect(modalAttrs.open).toBe(true);
 	});
 
-	it('assigns each available item the category tab it belongs to', async () => {
+	it('puts native and other node tools in the n8n nodes category', async () => {
 		const recommended: INodeTypeDescription = {
 			...WIKIPEDIA,
 			displayName: 'Gmail',
@@ -342,7 +342,8 @@ describe('AgentToolsConnectionModalWrapper', () => {
 		const categoryById = new Map(getItems().map((item) => [item.id, item.category]));
 
 		expect(categoryById.get(`nodeType:${SLACK.name}`)).toBe('app-action');
-		expect(categoryById.get('nodeType:n8n-nodes-base.gmail')).toBe('n8n');
+		expect(categoryById.get('nodeType:n8n-nodes-base.gmail')).toBe('app-action');
+		expect(modalAttrs.categories).toEqual(['all', 'mcp', 'app-action', 'workflows']);
 	});
 
 	it('assigns workflows to the workflows category', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolsConnectionModalWrapper.vue
@@ -73,7 +73,7 @@ import type { WorkflowToolIncompatibilityReason } from '@n8n/api-types';
 import { toToolIconSource } from '../utils/toolIconSource';
 import { workflowToolTriggerLabel } from '../utils/workflowToolTriggers';
 
-const BASE_CATEGORIES: ToolCategoryKey[] = ['all', 'mcp', 'n8n', 'app-action', 'workflows'];
+const BASE_CATEGORIES: ToolCategoryKey[] = ['all', 'mcp', 'app-action', 'workflows'];
 /** Prefix for the synthetic ids of gateway-backed rows in the n8n Connect section. */
 const N8N_CONNECT_ID_PREFIX = 'n8n-connect:';
 const incompatibleWorkflowToolBodyNodeTypes = new Set<string>(
@@ -681,7 +681,7 @@ function availableNodeItem(nodeType: INodeTypeDescription): NodeConnectionItem {
 /**
  * Same node, presented in the n8n Connect section: credentials are managed, so
  * it carries the "Free credits" pill and adds without a Connect step. The node
- * still appears under its native tab for users who want their own credential.
+ * still appears under n8n nodes for users who want their own credential.
  */
 function n8nConnectNodeItem(nodeType: INodeTypeDescription): NodeConnectionItem {
 	return {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentToolCatalog.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentToolCatalog.test.ts
@@ -151,15 +151,15 @@ describe('useAgentToolCatalog', () => {
 		expect(availableToolTypes.value.map((nt) => nt.name)).not.toContain(OPENAI.name);
 	});
 
-	it('orders MCP, then n8n tools, then the rest by popularity', () => {
+	it('orders MCP tools first, then all n8n nodes by popularity', () => {
 		const { availableToolTypes } = useAgentToolCatalog();
 		const names = availableToolTypes.value.map((nt) => nt.name);
 
-		expect(names.indexOf(MCP.name)).toBeLessThan(names.indexOf(CODE_TOOL.name));
-		expect(names.indexOf(CODE_TOOL.name)).toBeLessThan(names.indexOf(SLACK.name));
+		expect(names.indexOf(MCP.name)).toBeLessThan(names.indexOf(SLACK.name));
+		expect(names.indexOf(SLACK.name)).toBeLessThan(names.indexOf(CODE_TOOL.name));
 	});
 
-	it('categorizes community packages by provenance, ignoring a self-declared n8n subcategory', () => {
+	it('categorizes all non-MCP tools as n8n nodes', () => {
 		const community = makeNodeType({
 			name: 'n8n-nodes-firecrawl.firecrawlTool',
 			displayName: 'Firecrawl',
@@ -172,7 +172,7 @@ describe('useAgentToolCatalog', () => {
 		expect(toolCategoryForNodeType(community)).toBe('app-action');
 		expect(toolCategoryForNodeType(SLACK)).toBe('app-action');
 		expect(toolCategoryForNodeType(MCP)).toBe('mcp');
-		expect(toolCategoryForNodeType(CODE_TOOL)).toBe('n8n');
+		expect(toolCategoryForNodeType(CODE_TOOL)).toBe('app-action');
 	});
 
 	it('keeps uninstalled verified community tools that getNodeType cannot resolve', () => {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentToolCatalog.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentToolCatalog.ts
@@ -11,7 +11,6 @@ import {
 } from '@n8n/api-types';
 import nodePopularity from 'virtual:node-popularity-data';
 
-import { AI_SECTION_RECOMMENDED_TOOLS } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { ToolCategoryKey } from '@/features/shared/toolsConnection/types';
@@ -33,14 +32,6 @@ function isHiddenAvailableToolType(nodeType: INodeTypeDescription): boolean {
 	return hiddenAvailableToolNodeTypes.has(nodeType.name);
 }
 
-function hasToolsSubcategory(nodeType: INodeTypeDescription, subcategory: string): boolean {
-	return nodeType.codex?.subcategories?.Tools?.includes(subcategory) ?? false;
-}
-
-export function isAvailableN8nToolType(nodeType: INodeTypeDescription): boolean {
-	return hasToolsSubcategory(nodeType, AI_SECTION_RECOMMENDED_TOOLS);
-}
-
 export function isWorkflowCompatibleWithAgentTools(workflow: IWorkflowDb): boolean {
 	return getWorkflowToolIncompatibilityReason(workflow) === null;
 }
@@ -48,16 +39,13 @@ export function isWorkflowCompatibleWithAgentTools(workflow: IWorkflowDb): boole
 /**
  * Tab a node type belongs to in the tools connection modal.
  *
- * Community packages list alongside first-party ones in the app-action tab, but
- * are still matched first, by provenance rather than install state: that stops a
- * third-party package claiming the n8n tab through a self-declared "Recommended
- * Tools" codex subcategory. Nothing is taken from the MCP tab, which only
- * matches first-party names.
+ * MCP tools keep their own tab. All other tools use the n8n nodes tab.
+ * Community packages are still matched first by provenance so they cannot
+ * claim another category through their metadata.
  */
 export function toolCategoryForNodeType(nodeType: INodeTypeDescription): ToolCategoryKey {
 	if (isCommunityPackageName(nodeType.name)) return 'app-action';
 	if (isMcpRelatedNodeType(nodeType.name)) return 'mcp';
-	if (isAvailableN8nToolType(nodeType)) return 'n8n';
 	return 'app-action';
 }
 
@@ -66,7 +54,7 @@ export function toolCategoryForNodeType(nodeType: INodeTypeDescription): ToolCat
  * truth. Every category `toolCategoryForNodeType` can return must appear here:
  * `indexOf` returns -1 for a missing one, which would sort it ahead of the rest.
  */
-const NODE_CATEGORY_ORDER: ToolCategoryKey[] = ['mcp', 'n8n', 'app-action'];
+const NODE_CATEGORY_ORDER: ToolCategoryKey[] = ['mcp', 'app-action'];
 
 function nodeTypeOrderRank(nodeType: INodeTypeDescription): number {
 	return NODE_CATEGORY_ORDER.indexOf(toolCategoryForNodeType(nodeType));


### PR DESCRIPTION
## Summary

- Remove the `n8n native` tab from the new Agents tool picker.
- Show Code and HTTP Request under `n8n nodes`.
- Keep the MCP, Gateway credits, and Workflows categories unchanged.
- Add regression coverage for the category mapping and the visible tabs.

<img width="792" height="720" alt="image" src="https://github.com/user-attachments/assets/d234f55c-f395-424e-a158-d91dc3b47cdd" />


## How to test

1. Open the new Agents UI.
2. Open an agent.
3. Add a tool.
4. Confirm that the tabs do not include `n8n native`.
5. Open `n8n nodes`.
6. Confirm that Code and HTTP Request appear in this tab.

Run these automated checks from `packages/frontend/editor-ui`:

- `pnpm test src/features/agents/composables/useAgentToolCatalog.test.ts src/features/agents/__tests__/AgentToolsConnectionModalWrapper.test.ts`
- `pnpm lint`
- `pnpm typecheck`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-838

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## 🤖 PR Summary generated by AI

This PR merges native tools into `n8n nodes` in the new Agents tool picker. It removes the redundant tab and updates the regression tests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

