### PR TITLE
feat: Enable the v3 migration report and fix findings table layout (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
@@ -19,7 +19,7 @@ export type BreakingChangeVersion = z.infer<typeof breakingChangeVersionSchema>;
  * When a new major version is released, update this value and add the
  * corresponding breaking-change rules on the backend.
  */
-export const MIGRATION_REPORT_TARGET_VERSION: BreakingChangeVersion | null = null;
+export const MIGRATION_REPORT_TARGET_VERSION: BreakingChangeVersion | null = 'v3';
 
 // Common schemas
 const recommendationSchema = z.object({

--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -113,7 +113,7 @@ const resetFilters = () => {
 };
 
 const shouldBeIconButton = computed(() => {
-	return !hasFilters.value;
+	return props.justIcon && !hasFilters.value;
 });
 
 watch(filtersLength, (value) => {

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
@@ -67,7 +67,7 @@ const tableHeaders = computed<Array<TableHeader<AffectedWorkflow>>>(() => {
 		{
 			title: i18n.baseText('settings.migrationReport.detail.table.name'),
 			key: 'name',
-			width: 200,
+			width: 240,
 		},
 		{
 			title: i18n.baseText('settings.migrationReport.detail.table.status'),
@@ -76,26 +76,27 @@ const tableHeaders = computed<Array<TableHeader<AffectedWorkflow>>>(() => {
 				row.active
 					? i18n.baseText('settings.migrationReport.detail.table.active')
 					: i18n.baseText('settings.migrationReport.detail.table.deactivated'),
-			width: 40,
+			width: 120,
 		},
 		{
 			title: i18n.baseText('settings.migrationReport.detail.table.nodesAffected'),
 			key: 'issues',
+			width: 240,
 		},
 		{
 			title: i18n.baseText('settings.migrationReport.detail.table.numberOfExecutions'),
 			key: 'numberOfExecutions',
-			width: 40,
+			width: 160,
 		},
 		{
 			title: i18n.baseText('settings.migrationReport.detail.table.lastExecuted'),
 			key: 'lastExecutedAt',
-			width: 40,
+			width: 120,
 		},
 		{
 			title: i18n.baseText('settings.migrationReport.detail.table.lastUpdated'),
 			key: 'lastUpdatedAt',
-			width: 40,
+			width: 120,
 		},
 	];
 

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.test.ts
@@ -130,10 +130,9 @@ describe('MigrationRules', () => {
 			});
 
 			// API called with correct context
-			expect(breakingChangesApi.getReport).toHaveBeenCalledWith(
-				rootStore.restApiContext,
-				undefined,
-			);
+			expect(breakingChangesApi.getReport).toHaveBeenCalledWith(rootStore.restApiContext, {
+				version: 'v3',
+			});
 
 			// Loading skeletons are gone
 			expect(document.querySelectorAll('.el-skeleton').length).toBe(0);
@@ -227,7 +226,7 @@ describe('MigrationRules', () => {
 				expect(screen.getByText('No workflow issues detected')).toBeInTheDocument();
 				expect(
 					screen.getByText(
-						"Your workflows are fully compatible with version 2.0.0. You're good to go!",
+						"Your workflows are fully compatible with version 3.0.0. You're good to go!",
 					),
 				).toBeInTheDocument();
 			});
@@ -315,7 +314,7 @@ describe('MigrationRules', () => {
 				expect(screen.getByText('No instance issues detected')).toBeInTheDocument();
 				expect(
 					screen.getByText(
-						"Your instance is fully compatible with version 2.0.0. You're good to go!",
+						"Your instance is fully compatible with version 3.0.0. You're good to go!",
 					),
 				).toBeInTheDocument();
 			});
@@ -403,10 +402,9 @@ describe('MigrationRules', () => {
 
 			// API called and data reloaded
 			await waitFor(() => {
-				expect(breakingChangesApi.refreshReport).toHaveBeenCalledWith(
-					rootStore.restApiContext,
-					undefined,
-				);
+				expect(breakingChangesApi.refreshReport).toHaveBeenCalledWith(rootStore.restApiContext, {
+					version: 'v3',
+				});
 				expect(screen.getByText('Updated Rule')).toBeInTheDocument();
 				expect(screen.getByText('10 Workflows')).toBeInTheDocument();
 			});


### PR DESCRIPTION
## Summary

Enable the migration report for the n8n v3 migration.

Set the shared migration report target version to `v3`. This enables the settings page and the backend breaking-changes module.

Keep the workflow details page readable on laptop screens. Give table columns enough space for their headings and allow the table to scroll at narrower widths.

Render the Filters control as a text button when `justIcon` is disabled. Preserve the existing icon-only behavior in resource lists.

## How to test

1. Start n8n.
2. Open **Settings**.
3. Confirm that **Migration report** appears in the settings menu.
4. Open **Migration report**.
5. Open a workflow issue to view its workflow details.
6. Confirm that the Filters button contains its text.
7. Resize the window to a laptop width.
8. Confirm that the table headings do not overlap.
9. Confirm that the table scrolls horizontally when the available width is too small.
10. Open a standard resource list, such as Workflows.
11. Confirm that its Filters control remains icon-only when no filter is active.

No additional environment variables or feature flags are required.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI