### PR TITLE
fix(editor): Stop rendering task and sub-agent labels with no text

### DIFF
--- a/packages/@n8n/instance-ai/src/__tests__/tool-test-utils.test.ts
+++ b/packages/@n8n/instance-ai/src/__tests__/tool-test-utils.test.ts
@@ -1,0 +1,32 @@
+import type { BuiltTool } from '@n8n/agents';
+import { z } from 'zod';
+
+import { parseToolInput } from './tool-test-utils';
+
+function builtToolWith(inputSchema: BuiltTool['inputSchema']): BuiltTool {
+	return { name: 'demo', description: 'demo', inputSchema } as BuiltTool;
+}
+
+describe('parseToolInput', () => {
+	it('validates input against a Zod input schema', () => {
+		const tool = builtToolWith(z.object({ title: z.string().min(1) }));
+
+		expect(parseToolInput(tool, { title: 'Build a workflow' }).success).toBe(true);
+		expect(parseToolInput(tool, { title: '' }).success).toBe(false);
+	});
+
+	it('reports a usable error for a tool carrying a raw JSON Schema', () => {
+		// MCP tools carry a JSON Schema, which has no `safeParse`.
+		const tool = builtToolWith({ type: 'object', properties: { title: { type: 'string' } } });
+
+		expect(() => parseToolInput(tool, { title: 'x' })).toThrow(
+			'Tool "demo" has no Zod input schema',
+		);
+	});
+
+	it('reports a usable error for a tool with no input schema', () => {
+		expect(() => parseToolInput(builtToolWith(undefined), {})).toThrow(
+			'Tool "demo" has no Zod input schema',
+		);
+	});
+});

--- a/packages/@n8n/instance-ai/src/__tests__/tool-test-utils.ts
+++ b/packages/@n8n/instance-ai/src/__tests__/tool-test-utils.ts
@@ -1,17 +1,28 @@
-import type { BuiltTool, InterruptibleToolContext, ToolContext } from '@n8n/agents';
-import type { SafeParseReturnType, ZodType } from 'zod';
+import {
+	isZodSchema,
+	type BuiltTool,
+	type InterruptibleToolContext,
+	type ToolContext,
+} from '@n8n/agents';
+import type { SafeParseReturnType } from 'zod';
 
 /**
  * Validate raw tool input against the tool's declared input schema, the way the
  * runtime does before it calls the handler. Use it to assert on input contracts
  * that `executeTool` bypasses.
+ *
+ * `BuiltTool.inputSchema` is a Zod schema or a raw JSON Schema (MCP tools), so
+ * the Zod path is asserted rather than assumed.
  */
 export function parseToolInput(
 	tool: BuiltTool,
 	input: unknown,
 ): SafeParseReturnType<unknown, unknown> {
-	if (!tool.inputSchema) throw new Error(`Tool "${tool.name}" has no input schema`);
-	return (tool.inputSchema as ZodType).safeParse(input);
+	const { inputSchema } = tool;
+	if (!isZodSchema(inputSchema)) {
+		throw new Error(`Tool "${tool.name}" has no Zod input schema to validate against`);
+	}
+	return inputSchema.safeParse(input);
 }
 
 export async function executeTool<TOutput = Record<string, unknown>>(

--- a/packages/@n8n/instance-ai/src/__tests__/tool-test-utils.ts
+++ b/packages/@n8n/instance-ai/src/__tests__/tool-test-utils.ts
@@ -1,4 +1,18 @@
 import type { BuiltTool, InterruptibleToolContext, ToolContext } from '@n8n/agents';
+import type { SafeParseReturnType, ZodType } from 'zod';
+
+/**
+ * Validate raw tool input against the tool's declared input schema, the way the
+ * runtime does before it calls the handler. Use it to assert on input contracts
+ * that `executeTool` bypasses.
+ */
+export function parseToolInput(
+	tool: BuiltTool,
+	input: unknown,
+): SafeParseReturnType<unknown, unknown> {
+	if (!tool.inputSchema) throw new Error(`Tool "${tool.name}" has no input schema`);
+	return (tool.inputSchema as ZodType).safeParse(input);
+}
 
 export async function executeTool<TOutput = Record<string, unknown>>(
 	tool: BuiltTool,

--- a/packages/@n8n/instance-ai/src/tools/__tests__/task-control.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/task-control.tool.test.ts
@@ -1,6 +1,6 @@
 import type { Mock } from 'vitest';
 
-import { executeTool } from '../../__tests__/tool-test-utils';
+import { executeTool, parseToolInput } from '../../__tests__/tool-test-utils';
 import type { OrchestrationContext } from '../../types';
 import { createTaskControlTool } from '../task-control.tool';
 
@@ -209,6 +209,42 @@ describe('task-control tool', () => {
 			expect(result).toEqual({
 				result: 'Error: correction delivery not available.',
 			});
+		});
+	});
+});
+
+describe('task-control tool — checklist item contract', () => {
+	function checklistInput(description: string) {
+		return {
+			action: 'update-checklist',
+			tasks: [{ id: 'task-1', description, status: 'todo' }],
+		};
+	}
+
+	it('accepts a checklist item with a description', () => {
+		const tool = createTaskControlTool(createMockContext());
+
+		const parsed = parseToolInput(tool, checklistInput('Create the Users data table'));
+
+		expect(parsed.success).toBe(true);
+	});
+
+	it('rejects a checklist item whose description is blank', () => {
+		const tool = createTaskControlTool(createMockContext());
+
+		const parsed = parseToolInput(tool, checklistInput('  '));
+
+		expect(parsed.success).toBe(false);
+	});
+
+	it('trims surrounding whitespace off the description', () => {
+		const tool = createTaskControlTool(createMockContext());
+
+		const parsed = parseToolInput(tool, checklistInput('\nCreate the Users data table\n'));
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.success && parsed.data).toMatchObject({
+			tasks: [{ description: 'Create the Users data table' }],
 		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/plan.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/plan.tool.test.ts
@@ -1,4 +1,4 @@
-import { executeTool } from '../../../__tests__/tool-test-utils';
+import { executeTool, parseToolInput } from '../../../__tests__/tool-test-utils';
 import { PlanValidationError } from '../../../planned-tasks/planned-task-service';
 import type { OrchestrationContext, PlannedTaskService, TaskStorage } from '../../../types';
 import { createPlanTool } from '../plan.tool';
@@ -475,5 +475,40 @@ describe('createPlanTool — createPlan validation failures', () => {
 				suspend: vi.fn(),
 			}),
 		).rejects.toBe(storageError);
+	});
+});
+
+describe('createPlanTool — task title contract', () => {
+	it('accepts a task with a title', () => {
+		const tool = createPlanTool(createMockContext());
+
+		const parsed = parseToolInput(tool, planInput());
+
+		expect(parsed.success).toBe(true);
+	});
+
+	it('rejects a task whose title is blank', () => {
+		const tool = createPlanTool(createMockContext());
+
+		const parsed = parseToolInput(tool, {
+			...planInput(),
+			tasks: [{ ...validTasks()[0], title: '   ' }],
+		});
+
+		expect(parsed.success).toBe(false);
+	});
+
+	it('trims surrounding whitespace off the title', () => {
+		const tool = createPlanTool(createMockContext());
+
+		const parsed = parseToolInput(tool, {
+			...planInput(),
+			tasks: [{ ...validTasks()[0], title: '\nBuild Slack notifier\n' }],
+		});
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.success && parsed.data).toMatchObject({
+			tasks: [{ title: 'Build Slack notifier' }],
+		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/plan.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/plan.tool.ts
@@ -8,7 +8,11 @@ import { PLANNED_TASK_KINDS, type OrchestrationContext, type PlannedTask } from 
 
 const plannedTaskSchema = z.object({
 	id: z.string().describe('Stable task identifier used by dependency edges'),
-	title: z.string().describe('Short user-facing task title'),
+	title: z
+		.string()
+		.trim()
+		.min(1, 'Task title must not be empty — it is the label the user sees')
+		.describe('Short user-facing task title'),
 	kind: z.enum(PLANNED_TASK_KINDS),
 	spec: z.string().describe('Detailed executor briefing for this task'),
 	deps: z

--- a/packages/@n8n/instance-ai/src/tools/task-control.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/task-control.tool.ts
@@ -2,7 +2,7 @@
  * Consolidated task-control tool — update-checklist + cancel-task + correct-task.
  */
 import { Tool } from '@n8n/agents';
-import { taskListSchema } from '@n8n/api-types';
+import { taskItemSchema } from '@n8n/api-types';
 import { z } from 'zod';
 
 import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
@@ -10,13 +10,27 @@ import type { OrchestrationContext } from '../types';
 
 // ── Action schemas ──────────────────────────────────────────────────────────
 
+/**
+ * Stricter than the transport `taskItemSchema`: the description is the only
+ * label the checklist row shows, so a blank one renders an empty row. Rejecting
+ * it here returns a correctable error to the model, while the transport schema
+ * stays lenient for checklists persisted before this guard.
+ */
+const checklistItemSchema = taskItemSchema.extend({
+	description: z
+		.string()
+		.trim()
+		.min(1, 'Task description must not be empty — it is the label the user sees')
+		.describe('What this task accomplishes'),
+});
+
 const updateChecklistAction = z.object({
 	action: z
 		.literal('update-checklist')
 		.describe(
 			'Write or update a lightweight visible checklist for multi-step work that does not need scheduler-driven execution. For coordinated background tasks, use create-tasks instead.',
 		),
-	tasks: taskListSchema.shape.tasks,
+	tasks: z.array(checklistItemSchema).describe('Ordered list of tasks'),
 });
 
 const cancelTaskAction = z.object({

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7178,6 +7178,7 @@
 	"instanceAi.planReview.denied": "Plan denied",
 	"instanceAi.planReview.changesRequested": "Changes requested",
 	"instanceAi.planReview.updating": "Updating plan...",
+	"instanceAi.tasks.untitled": "Untitled task",
 	"instanceAi.message.retry": "Retry",
 	"instanceAi.input.amendPlaceholder": "Amend the {role} agent...",
 	"instanceAi.fixWithAi.button": "Fix with AI",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiStatusBar.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiStatusBar.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import type { InstanceAiAgentNode, InstanceAiMessage } from '@n8n/api-types';
+import { createThreadComponentRenderer } from './createThreadComponentRenderer';
+import InstanceAiStatusBar from '../components/InstanceAiStatusBar.vue';
+import type { ThreadRuntime } from '../instanceAi.store';
+
+let thread: ThreadRuntime;
+const renderComponent = createThreadComponentRenderer(InstanceAiStatusBar, {}, () => thread);
+
+function makeAgentNode(overrides: Partial<InstanceAiAgentNode> = {}): InstanceAiAgentNode {
+	return {
+		agentId: 'agent-1',
+		role: 'orchestrator',
+		status: 'completed',
+		textContent: '',
+		reasoning: '',
+		toolCalls: [],
+		children: [],
+		timeline: [],
+		...overrides,
+	};
+}
+
+/** A finished orchestrator turn with a builder still running in the background. */
+function messageWithActiveBuilder(builder: Partial<InstanceAiAgentNode>): InstanceAiMessage {
+	return {
+		id: 'msg-1',
+		role: 'assistant',
+		content: '',
+		reasoning: '',
+		isStreaming: false,
+		createdAt: '2026-09-08T00:00:00.000Z',
+		agentTree: makeAgentNode({
+			children: [
+				makeAgentNode({
+					agentId: 'builder-1',
+					kind: 'builder',
+					role: 'workflow-builder',
+					status: 'active',
+					...builder,
+				}),
+			],
+		}),
+	};
+}
+
+describe('InstanceAiStatusBar', () => {
+	beforeEach(() => {
+		createTestingPinia();
+	});
+
+	function renderWith(builder: Partial<InstanceAiAgentNode>) {
+		thread = {
+			id: 'thread-1',
+			messages: [messageWithActiveBuilder(builder)],
+			isStreaming: false,
+			isAwaitingConfirmation: false,
+		} as unknown as ThreadRuntime;
+		return renderComponent();
+	}
+
+	it('labels the bar with the active builder title', () => {
+		const { getByTestId } = renderWith({ title: 'Building workflow' });
+
+		expect(getByTestId('instance-ai-status-bar')).toHaveTextContent('Building workflow');
+	});
+
+	it('falls back to the role label when the title is blank', () => {
+		const { getByTestId } = renderWith({ title: '' });
+
+		expect(getByTestId('instance-ai-status-bar')).toHaveTextContent('Building workflow');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/PlanReviewPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/PlanReviewPanel.test.ts
@@ -171,3 +171,23 @@ describe('PlanReviewPanel', () => {
 		expect(queryByText('Plan approved')).not.toBeInTheDocument();
 	});
 });
+
+describe('PlanReviewPanel — blank titles', () => {
+	it('labels a task whose title is blank', () => {
+		const { getByText } = renderComponent({
+			props: {
+				plannedTasks: [
+					{
+						id: 'table',
+						title: '  ',
+						kind: 'manage-data-tables',
+						spec: 'Create a table.',
+						deps: [],
+					},
+				],
+			},
+		});
+
+		expect(getByText('Untitled task')).toBeInTheDocument();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/TaskChecklist.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/TaskChecklist.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { createComponentRenderer } from '@/__tests__/render';
+import TaskChecklist from '../components/TaskChecklist.vue';
+
+const renderComponent = createComponentRenderer(TaskChecklist);
+
+describe('TaskChecklist', () => {
+	it('renders the description of each task', () => {
+		const { getByText } = renderComponent({
+			props: {
+				tasks: { tasks: [{ id: 't1', description: 'Create the Users table', status: 'todo' }] },
+			},
+		});
+
+		expect(getByText('Create the Users table')).toBeInTheDocument();
+	});
+
+	it('labels a task whose description is blank', () => {
+		const { getByText } = renderComponent({
+			props: { tasks: { tasks: [{ id: 't1', description: '  ', status: 'todo' }] } },
+		});
+
+		expect(getByText('Untitled task')).toBeInTheDocument();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
@@ -110,6 +110,31 @@ describe('extractArtifacts', () => {
 		expect(extractArtifacts(node)[0].name).toBe('Untitled');
 	});
 
+	test('falls back to Untitled when a built workflow reports a blank name', () => {
+		const node = makeAgentNode({
+			toolCalls: [
+				makeToolCall({
+					toolName: 'build-workflow',
+					args: { name: '' },
+					result: { workflowId: 'wf-1', workflowName: '' },
+				}),
+			],
+		});
+		expect(extractArtifacts(node)[0].name).toBe('Untitled');
+	});
+
+	test('falls back to Untitled when a data table reports a blank name', () => {
+		const node = makeAgentNode({
+			toolCalls: [
+				makeToolCall({
+					toolName: 'data-tables',
+					result: { tableId: 'dt-1', name: '  ' },
+				}),
+			],
+		});
+		expect(extractArtifacts(node)[0].name).toBe('Untitled');
+	});
+
 	test('ignores targetResource with non-artifact type', () => {
 		const node = makeAgentNode({
 			targetResource: { id: 'cred-1', type: 'credential', name: 'API Key' },

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
@@ -102,6 +102,14 @@ describe('extractArtifacts', () => {
 		expect(extractArtifacts(node)[0].name).toBe('Untitled');
 	});
 
+	test('falls back to Untitled when the name and subtitle are blank', () => {
+		const node = makeAgentNode({
+			subtitle: '   ',
+			targetResource: { id: 'wf-1', type: 'workflow', name: '' },
+		});
+		expect(extractArtifacts(node)[0].name).toBe('Untitled');
+	});
+
 	test('ignores targetResource with non-artifact type', () => {
 		const node = makeAgentNode({
 			targetResource: { id: 'cred-1', type: 'credential', name: 'API Key' },

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/builderAgents.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/builderAgents.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import type { InstanceAiAgentNode, InstanceAiMessage } from '@n8n/api-types';
-import { messageHasVisibleContent } from '../builderAgents';
+import { getAgentSectionTitle, messageHasVisibleContent } from '../builderAgents';
 
 function makeAgentNode(overrides: Partial<InstanceAiAgentNode> = {}): InstanceAiAgentNode {
 	return {
@@ -73,5 +73,31 @@ describe('messageHasVisibleContent', () => {
 		);
 
 		expect(messageHasVisibleContent(message)).toBe(true);
+	});
+});
+
+describe('getAgentSectionTitle', () => {
+	test('uses the title when the backend set one', () => {
+		const node = makeAgentNode({ title: 'Building agent', role: 'agent-builder' });
+
+		expect(getAgentSectionTitle(node)).toBe('Building agent');
+	});
+
+	test('skips a blank title and falls back to the builder role label', () => {
+		const node = makeAgentNode({ title: '', role: 'workflow-builder', kind: 'builder' });
+
+		expect(getAgentSectionTitle(node)).toBe('Building workflow');
+	});
+
+	test('skips a blank subtitle so the caller can show its own fallback', () => {
+		const node = makeAgentNode({ title: '', subtitle: '   ', role: '' });
+
+		expect(getAgentSectionTitle(node)).toBeUndefined();
+	});
+
+	test('falls back to the subtitle of a non-builder sub-agent', () => {
+		const node = makeAgentNode({ role: 'eval-setup', subtitle: 'Set up evaluations' });
+
+		expect(getAgentSectionTitle(node)).toBe('Set up evaluations');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
@@ -92,6 +92,33 @@ describe('useResourceRegistry', () => {
 			expect(linkableResourceNameIndex.get('my workflow')?.id).toBe('wf-1');
 		});
 
+		test('keeps the known name when a follow-up call reports a blank name', async () => {
+			const { messages, producedArtifacts, linkableResourceNameIndex } = setup();
+
+			messages.value = [
+				makeMessage({
+					agentTree: makeAgentNode({
+						toolCalls: [
+							makeToolCall({
+								toolName: 'build-workflow',
+								result: { workflowId: 'wf-1', workflowName: 'Lead routing' },
+							}),
+							makeToolCall({
+								toolCallId: 'tc-2',
+								toolName: 'build-workflow',
+								result: { workflowId: 'wf-1', workflowName: '' },
+							}),
+						],
+					}),
+				}),
+			];
+			await nextTick();
+
+			expect(producedArtifacts.get('wf-1')?.name).toBe('Lead routing');
+			expect(linkableResourceNameIndex.get('lead routing')?.id).toBe('wf-1');
+			expect(linkableResourceNameIndex.has('')).toBe(false);
+		});
+
 		test('falls back to args.name when result has no workflowName', async () => {
 			const { messages, producedArtifacts, linkableResourceNameIndex } = setup();
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
@@ -333,11 +333,12 @@ export function extractArtifacts(node: InstanceAiAgentNode): ArtifactInfo[] {
 		) {
 			seenIds.add(result.workflowId);
 			const name =
-				(typeof result.workflowName === 'string' ? result.workflowName : undefined) ??
-				(typeof (tc.args as Record<string, unknown>)?.name === 'string'
-					? ((tc.args as Record<string, unknown>).name as string)
-					: undefined) ??
-				'Untitled';
+				firstNonBlank(
+					typeof result.workflowName === 'string' ? result.workflowName : undefined,
+					typeof (tc.args as Record<string, unknown>)?.name === 'string'
+						? ((tc.args as Record<string, unknown>).name as string)
+						: undefined,
+				) ?? 'Untitled';
 			artifacts.push({
 				type: 'workflow',
 				resourceId: result.workflowId,
@@ -371,7 +372,7 @@ export function extractArtifacts(node: InstanceAiAgentNode): ArtifactInfo[] {
 			artifacts.push({
 				type: 'data-table',
 				resourceId: tableId,
-				name: tableName ?? 'Untitled',
+				name: firstNonBlank(tableName) ?? 'Untitled',
 				projectId: tableProjectId,
 				completedAt: tc.completedAt,
 			});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
@@ -3,7 +3,7 @@ import type {
 	InstanceAiTimelineEntry,
 	InstanceAiToolCallState,
 } from '@n8n/api-types';
-import { isActiveBuilderAgent, isBuilderAgent } from './builderAgents';
+import { firstNonBlank, isActiveBuilderAgent, isBuilderAgent } from './builderAgents';
 
 /** Tool calls that are internal bookkeeping and should not be shown to the user. */
 export const HIDDEN_TOOLS = new Set(['updateWorkingMemory']);
@@ -312,7 +312,7 @@ export function extractArtifacts(node: InstanceAiAgentNode): ArtifactInfo[] {
 			const artifact: ArtifactInfo = {
 				type,
 				resourceId: node.targetResource.id,
-				name: node.targetResource.name ?? node.subtitle ?? 'Untitled',
+				name: firstNonBlank(node.targetResource.name, node.subtitle) ?? 'Untitled',
 				completedAt: undefined,
 			};
 			if (node.targetResource.projectId) artifact.projectId = node.targetResource.projectId;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/builderAgents.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/builderAgents.ts
@@ -26,6 +26,26 @@ export function getBuilderRoleLabel(
 	return BUILDER_ROLE_LABELS[node.role];
 }
 
+/** First candidate that has content, trimmed. A blank one never wins over the next. */
+export function firstNonBlank(...candidates: Array<string | undefined>): string | undefined {
+	return candidates.map((candidate) => candidate?.trim()).find((candidate) => candidate);
+}
+
+/**
+ * Header label for a sub-agent section. Blank candidates are skipped: an empty
+ * title or subtitle — which older threads persisted — would otherwise leave a
+ * header with nothing in it but a chevron.
+ */
+export function getAgentSectionTitle(node: InstanceAiAgentNode): string | undefined {
+	return firstNonBlank(
+		node.title,
+		getBuilderRoleLabel(node),
+		node.targetResource?.name,
+		node.subtitle,
+		node.role,
+	);
+}
+
 /** True when the node is a builder sub-agent that is currently running. */
 export function isActiveBuilderAgent(node: InstanceAiAgentNode): boolean {
 	return isBuilderAgent(node) && node.status === 'active';

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentSection.vue
@@ -9,7 +9,7 @@ import type { InstanceAiAgentNode } from '@n8n/api-types';
 import { CollapsibleRoot, CollapsibleTrigger } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
 import SubagentStepTimeline from './SubagentStepTimeline.vue';
-import { getBuilderRoleLabel } from '../builderAgents';
+import { getAgentSectionTitle } from '../builderAgents';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 
 const props = defineProps<{
@@ -23,15 +23,7 @@ const isExpanded = ref(settingsStore.isCloudDeployment);
 
 const isError = computed(() => props.agentNode.status === 'error');
 
-const sectionTitle = computed(
-	() =>
-		props.agentNode.title ??
-		getBuilderRoleLabel(props.agentNode) ??
-		props.agentNode.targetResource?.name ??
-		props.agentNode.subtitle ??
-		props.agentNode.role ??
-		'Working...',
-);
+const sectionTitle = computed(() => getAgentSectionTitle(props.agentNode) ?? 'Working...');
 
 /**
  * Most recent timeline entry that SubagentStepTimeline can render (text,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiStatusBar.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiStatusBar.vue
@@ -11,7 +11,7 @@ import { useThread } from '../instanceAi.store';
 import { useToolLabel } from '../toolLabels';
 import {
 	collectActiveBuilderAgents,
-	getBuilderRoleLabel,
+	getAgentSectionTitle,
 	isActiveBuilderAgent,
 } from '../builderAgents';
 
@@ -40,7 +40,8 @@ function deriveActivity(messages: InstanceAiMessage[]): { label: string; detail?
 	// Check active children first (sub-agents)
 	const activeChild = tree.children.find((c: InstanceAiAgentNode) => c.status === 'active');
 	if (activeChild) {
-		const roleLabel = activeChild.title ?? getBuilderRoleLabel(activeChild) ?? activeChild.role;
+		const roleLabel =
+			getAgentSectionTitle(activeChild) ?? i18n.baseText('instanceAi.statusBar.thinking');
 		const activeTool = activeChild.toolCalls.find((tc: InstanceAiToolCallState) => tc.isLoading);
 		if (activeTool) {
 			const toolLabel = getToolLabel(activeTool.toolName, activeTool.args);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
@@ -89,12 +89,20 @@ function isTaskExpandedByDefault(task: PlannedTaskArg): boolean {
 	return !isVerificationTask(task);
 }
 
+/**
+ * Plans saved before titles were required can hold a blank one, which would
+ * render a task row with a number and no label.
+ */
+function getTitle(task: PlannedTaskArg): string {
+	return task.title.trim() || i18n.baseText('instanceAi.tasks.untitled');
+}
+
 function getDescription(task: PlannedTaskArg): string {
 	let text = task.spec;
 	if (task.deps.length) {
 		const depNames = task.deps.map((depId) => {
 			const dep = props.plannedTasks.find((t) => t.id === depId);
-			return dep?.title ?? depId;
+			return dep ? getTitle(dep) : depId;
 		});
 		text += `\nDepends on: ${depNames.join(', ')}`;
 	}
@@ -193,7 +201,7 @@ function handleDeny() {
 						<button type="button" :class="$style.taskRow">
 							<span :class="$style.taskNumber">{{ idx + 1 }}</span>
 							<span :class="$style.taskTitleGroup">
-								<N8nText bold size="large" :class="$style.taskTitle">{{ task.title }}</N8nText>
+								<N8nText bold size="large" :class="$style.taskTitle">{{ getTitle(task) }}</N8nText>
 								<N8nIcon
 									icon="chevron-right"
 									size="medium"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/TaskChecklist.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/TaskChecklist.vue
@@ -1,12 +1,15 @@
 <script lang="ts" setup>
 import type { TaskList } from '@n8n/api-types';
 import { N8nCard, N8nIcon, N8nText, type IconName, type TextColor } from '@n8n/design-system';
+import { useI18n } from '@n8n/i18n';
 import { computed } from 'vue';
 import ButtonLike from './ButtonLike.vue';
 
 const props = defineProps<{
 	tasks?: TaskList;
 }>();
+
+const i18n = useI18n();
 
 type StatusConfig = {
 	icon: IconName;
@@ -43,6 +46,9 @@ const taskList = computed(() =>
 		return {
 			...task,
 			...config,
+			// Threads saved before descriptions were required can hold a blank one,
+			// which would render a row with an icon and no label.
+			description: task.description.trim() || i18n.baseText('instanceAi.tasks.untitled'),
 		};
 	}),
 );

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
@@ -39,8 +39,15 @@ interface Collections {
 	linkableByName: Map<string, ResourceEntry>;
 }
 
+/**
+ * A blank string is treated as absent. Every caller uses the result as the head
+ * of a fallback chain, so a blank name from a patch call would otherwise beat
+ * the known name and re-key the indexes under an empty string.
+ */
 function optionalString(val: unknown): string | undefined {
-	return typeof val === 'string' ? val : undefined;
+	if (typeof val !== 'string') return undefined;
+	const trimmed = val.trim();
+	return trimmed === '' ? undefined : trimmed;
 }
 
 type RecordProducedOptions = {


### PR DESCRIPTION
## Summary

Instance AI could show a task row, or a sub-agent header, with no label at all. The header then rendered as an empty pill with only a chevron. INS-343 reports the visible result.

The label is empty for two separate reasons. This PR closes both.

**1. Nothing rejected a blank title.** `create-tasks` accepted `title: z.string()` and the `update-checklist` action accepted `description: z.string()`. Both now trim the value and need at least one character. An invalid value returns a tool error, so the model corrects itself.

The transport schemas (`taskItemSchema`, `taskListSchema`, `plannedTaskArgSchema`) stay lenient. They parse server-sent events and rehydrate old threads. A stricter transport schema would break plans that are already saved with a blank title.

**2. The frontend chains used `??`, which an empty string passes.** `AgentSection` selected the first non-null candidate, so a blank title won over the `Working...` fallback. The new `getAgentSectionTitle` helper skips blank candidates. `TaskChecklist` and `PlanReviewPanel` show `Untitled task` for a title that is already saved blank. `extractArtifacts` had the same fault and showed an artifact card with no name.

### On the original mechanism

The first empty label came from `truncateLabel`, which kept only the text before the first `.` or newline. A task that starts with a blank line, or with a leading `.`, produced an empty subtitle — the model never had to send an empty title. That helper fed the sub-agent `subtitle`.

This PR does not change it. `refactor(core): Remove legacy Instance AI eval agent (#36740)` removed its last caller, so `packages/@n8n/instance-ai/src/tools/orchestration/display-utils.ts` is now dead code on master. Fixing a function that nobody calls adds noise, so the change was dropped during the rebase. The file can be deleted in a separate cleanup.

## How to test

The backend guards stop new blank labels. The frontend guards handle threads that are already saved. Test both.

New plans:

1. Open Instance AI and ask for plan-worthy work, for example: `Create a Leads data table, then build a workflow that writes rows to it`.
2. Wait for the plan review card. Every task row shows a title.
3. Approve the plan. Each sub-agent section shows a header label, for example `Building workflow`.

Saved plans, to check the frontend fallback:

1. In the plan review card, run this in the browser console to blank a title, or edit `plannedTasks` in a component test: the row must show `Untitled task`, not an empty row.
2. The unit tests cover this path: `TaskChecklist.test.ts` and `PlanReviewPanel.test.ts`.

Automated tests:

```bash
cd packages/@n8n/instance-ai
pnpm test src/tools/orchestration/__tests__/display-utils.test.ts src/tools/orchestration/__tests__/plan.tool.test.ts src/tools/__tests__/task-control.tool.test.ts

cd packages/frontend/editor-ui
pnpm vitest run src/features/ai/instanceAi/__tests__/builderAgents.test.ts src/features/ai/instanceAi/__tests__/TaskChecklist.test.ts src/features/ai/instanceAi/__tests__/PlanReviewPanel.test.ts src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
```

No feature flag, license, or module is needed. Instance AI must be available in the instance.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-343

The reported thread is no longer in LangSmith, because traces expire. The cause was found in the code instead. The screenshot in the ticket identifies the component: `AgentSection`, with an empty header and the sub-agent steps below it.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

### Follow-up from code review

A review found the same fault in three more places. The second commit fixes them:

- `InstanceAiStatusBar` used the same `??` chain as the sub-agent header, so a blank builder title left the bar with no label.
- `extractArtifacts` was only half fixed. A built workflow or a data table that reports a blank name still produced an artifact card with no name.
- `optionalString` in `useResourceRegistry` accepted a blank string. This was not cosmetic: `recordProduced` then deleted the known name from the indexes and re-keyed the entry under an empty string, which stopped markdown auto-linking for that workflow. This contradicted the documented contract on `recordProduced`. A regression test covers it.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



