### PR TITLE
fix(editor): Hide the AI Assistant settings page when it has nothing to show

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
@@ -3,7 +3,9 @@ import { setActivePinia } from 'pinia';
 import { ref } from 'vue';
 import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router';
 import { GLOBAL_MEMBER_SCOPES, GLOBAL_OWNER_SCOPES, type Scope } from '@n8n/permissions';
+import type { FrontendModuleSettings } from '@n8n/api-types';
 import { useRBACStore } from '@n8n/stores/rbac.store';
+import { useSettingsStore } from '@n8n/stores/settings.store';
 import { mockedStore } from '@/__tests__/utils';
 import { VIEWS } from '@/app/constants';
 import { usePostHog } from '@/app/stores/posthog.store';
@@ -53,6 +55,22 @@ function setGlobalScopes(scopes: Scope[]) {
 	useRBACStore().globalScopes = [...scopes];
 }
 
+const instanceAiModuleSettings: NonNullable<FrontendModuleSettings['instance-ai']> = {
+	enabled: true,
+	localGatewayDisabled: false,
+	browserUseEnabled: true,
+	proxyEnabled: false,
+	cloudManaged: false,
+	sandboxEnabled: true,
+	workflowBuilderAvailable: true,
+	sandboxUnavailableReason: null,
+	runDebugEnabled: false,
+};
+
+function setAssistantEnabled(enabled: boolean) {
+	useSettingsStore().moduleSettings = { 'instance-ai': { ...instanceAiModuleSettings, enabled } };
+}
+
 let posthogStore: ReturnType<typeof mockedStore<typeof usePostHog>>;
 
 function setOpenWorkflowInAssistantTreatment(isTreatment: boolean) {
@@ -65,6 +83,7 @@ beforeEach(() => {
 	posthogStore = mockedStore(usePostHog);
 	setOpenWorkflowInAssistantTreatment(false);
 	setGlobalScopes(GLOBAL_OWNER_SCOPES);
+	setAssistantEnabled(true);
 });
 
 describe('InstanceAiModule legacy route redirects', () => {
@@ -153,6 +172,23 @@ describe('InstanceAiModule settings page access', () => {
 			await router.push('/settings/assistant');
 
 			expect(router.currentRoute.value.name).toBe(INSTANCE_AI_SETTINGS_VIEW);
+		});
+
+		describe('while the assistant is off, which hides the row', () => {
+			beforeEach(() => {
+				setAssistantEnabled(false);
+			});
+
+			it('is not offered the settings page', () => {
+				expect(isSettingsPageAvailable()).toBe(false);
+			});
+
+			it('is sent to the homepage', async () => {
+				const router = createTestRouter();
+				await router.push('/settings/assistant');
+
+				expect(router.currentRoute.value.name).toBe(VIEWS.HOMEPAGE);
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
@@ -1,11 +1,22 @@
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
 import { ref } from 'vue';
 import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router';
+import { GLOBAL_MEMBER_SCOPES, GLOBAL_OWNER_SCOPES, type Scope } from '@n8n/permissions';
+import { useRBACStore } from '@n8n/stores/rbac.store';
+import { mockedStore } from '@/__tests__/utils';
+import { VIEWS } from '@/app/constants';
+import { usePostHog } from '@/app/stores/posthog.store';
 import { InstanceAiModule } from '../module.descriptor';
 import { INSTANCE_AI_VIEW, INSTANCE_AI_THREAD_VIEW, INSTANCE_AI_SETTINGS_VIEW } from '../constants';
 
 vi.mock('../composables/useInstanceAiAvailability', () => ({
 	useInstanceAiAvailable: () => ref(true),
 	useInstanceAiReady: () => ref(true),
+}));
+
+vi.mock('@n8n/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: vi.fn() }),
 }));
 
 const stub = { render: () => null };
@@ -27,6 +38,7 @@ function createTestRouter() {
 	return createRouter({
 		history: createMemoryHistory(),
 		routes: [
+			{ path: '/home', name: VIEWS.HOMEPAGE, component: stub },
 			...moduleRoutes.filter((route) => route.path.startsWith('/')),
 			{
 				path: '/settings',
@@ -36,6 +48,24 @@ function createTestRouter() {
 		],
 	});
 }
+
+function setGlobalScopes(scopes: Scope[]) {
+	useRBACStore().globalScopes = [...scopes];
+}
+
+let posthogStore: ReturnType<typeof mockedStore<typeof usePostHog>>;
+
+function setOpenWorkflowInAssistantTreatment(isTreatment: boolean) {
+	posthogStore.isVariantEnabled.mockReturnValue(isTreatment);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	setActivePinia(createTestingPinia({ stubActions: false }));
+	posthogStore = mockedStore(usePostHog);
+	setOpenWorkflowInAssistantTreatment(false);
+	setGlobalScopes(GLOBAL_OWNER_SCOPES);
+});
 
 describe('InstanceAiModule legacy route redirects', () => {
 	it('redirects /instance-ai to the /assistant view', async () => {
@@ -64,5 +94,65 @@ describe('InstanceAiModule legacy route redirects', () => {
 
 		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_SETTINGS_VIEW);
 		expect(router.currentRoute.value.path).toBe('/settings/assistant');
+	});
+});
+
+describe('InstanceAiModule settings page access', () => {
+	const isSettingsPageAvailable = () => InstanceAiModule.settingsPages?.[0]?.available;
+
+	describe('a viewer who can manage Instance AI', () => {
+		it('is offered the settings page', () => {
+			expect(isSettingsPageAvailable()).toBe(true);
+		});
+
+		it('reaches the settings page', async () => {
+			const router = createTestRouter();
+			await router.push('/settings/assistant');
+
+			expect(router.currentRoute.value.name).toBe(INSTANCE_AI_SETTINGS_VIEW);
+		});
+	});
+
+	describe('a member, for whom the page renders no sections', () => {
+		beforeEach(() => {
+			setGlobalScopes(GLOBAL_MEMBER_SCOPES);
+		});
+
+		it('is not offered the settings page', () => {
+			expect(isSettingsPageAvailable()).toBe(false);
+		});
+
+		it('is sent to the homepage instead of a page with only a header', async () => {
+			const router = createTestRouter();
+			await router.push('/settings/assistant');
+
+			expect(router.currentRoute.value.name).toBe(VIEWS.HOMEPAGE);
+		});
+
+		it('is sent to the homepage from the legacy settings path too', async () => {
+			const router = createTestRouter();
+			await router.push('/settings/instance-ai');
+
+			expect(router.currentRoute.value.name).toBe(VIEWS.HOMEPAGE);
+		});
+	});
+
+	// Experiment cleanup: remove with openWorkflowInAssistant.
+	describe('a member in the openWorkflowInAssistant treatment', () => {
+		beforeEach(() => {
+			setGlobalScopes(GLOBAL_MEMBER_SCOPES);
+			setOpenWorkflowInAssistantTreatment(true);
+		});
+
+		it('is offered the settings page, which holds their default editor row', () => {
+			expect(isSettingsPageAvailable()).toBe(true);
+		});
+
+		it('reaches the settings page', async () => {
+			const router = createTestRouter();
+			await router.push('/settings/assistant');
+
+			expect(router.currentRoute.value.name).toBe(INSTANCE_AI_SETTINGS_VIEW);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
@@ -20,6 +20,7 @@ import {
 	useInstanceAiAvailable,
 	useInstanceAiReady,
 } from './composables/useInstanceAiAvailability';
+import { useSettingsStore } from '@n8n/stores/settings.store';
 import { canManageInstanceAi } from './instanceAiPermissions';
 
 /**
@@ -32,7 +33,15 @@ import { canManageInstanceAi } from './instanceAiPermissions';
  * Experiment cleanup: drop the treatment term with openWorkflowInAssistant.
  */
 function hasInstanceAiSettingsContent(): boolean {
-	return canManageInstanceAi() || useOpenWorkflowInAssistantStore().isTreatment;
+	if (canManageInstanceAi()) return true;
+
+	// The view drops the default editor row while the assistant is off — it shows
+	// the empty state instead — so the row is the member's only reason to visit.
+	// A member never loads the admin settings, so `enabled` on the module
+	// settings is the flag the view falls back to for them.
+	const isAssistantEnabled = useSettingsStore().moduleSettings['instance-ai']?.enabled === true;
+
+	return isAssistantEnabled && useOpenWorkflowInAssistantStore().isTreatment;
 }
 
 const InstanceAiView = async () => await import('./InstanceAiView.vue');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
@@ -14,11 +14,26 @@ import {
 } from './composables/useInstanceAiHandoff';
 // Experiment cleanup: remove with openWorkflowInAssistant.
 import { launchWorkflowThread } from '@/experiments/openWorkflowInAssistant/launchWorkflowThread';
+// Experiment cleanup: remove with openWorkflowInAssistant.
+import { useOpenWorkflowInAssistantStore } from '@/experiments/openWorkflowInAssistant/stores/openWorkflowInAssistant.store';
 import {
 	useInstanceAiAvailable,
 	useInstanceAiReady,
 } from './composables/useInstanceAiAvailability';
-import { hasPermission } from '@/app/utils/rbac/permissions';
+import { canManageInstanceAi } from './instanceAiPermissions';
+
+/**
+ * The settings page renders its sections only for a viewer who can manage
+ * Instance AI. Everybody else gets a page with nothing but its header. The one
+ * exception is the default editor row, which the openWorkflowInAssistant
+ * experiment adds for members in its treatment group. The sidebar entry and the
+ * route use the same gate, so n8n does not offer or serve an empty page.
+ *
+ * Experiment cleanup: drop the treatment term with openWorkflowInAssistant.
+ */
+function hasInstanceAiSettingsContent(): boolean {
+	return canManageInstanceAi() || useOpenWorkflowInAssistantStore().isTreatment;
+}
 
 const InstanceAiView = async () => await import('./InstanceAiView.vue');
 const InstanceAiEmptyView = async () => await import('./InstanceAiEmptyView.vue');
@@ -121,10 +136,14 @@ export const InstanceAiModule: FrontendModuleDescription = {
 			path: 'assistant',
 			name: INSTANCE_AI_SETTINGS_VIEW,
 			component: SettingsInstanceAiView,
+			beforeEnter: () => (hasInstanceAiSettingsContent() ? true : { name: VIEWS.HOMEPAGE }),
 			meta: {
 				layout: 'settings',
 				middleware: ['authenticated', 'rbac', 'custom'],
 				middlewareOptions: {
+					// `beforeEnter` is the gate that matters. Keep `instanceAi:message`
+					// here, because a member in the openWorkflowInAssistant treatment
+					// must also pass this check to reach their default editor row.
 					rbac: {
 						scope: ['instanceAi:message', 'instanceAi:manage'],
 					},
@@ -183,9 +202,7 @@ export const InstanceAiModule: FrontendModuleDescription = {
 			route: { to: { name: INSTANCE_AI_SETTINGS_VIEW } },
 			preview: true,
 			get available() {
-				return hasPermission(['rbac'], {
-					rbac: { scope: ['instanceAi:message', 'instanceAi:manage'] },
-				});
+				return hasInstanceAiSettingsContent();
 			},
 		},
 	],


### PR DESCRIPTION
## Summary

A member who opened **Settings → AI Assistant** got a page with nothing but its header.

The entry point and the content disagreed about who may see the page:

| Layer | Gate |
|---|---|
| Settings sidebar entry (`available`) | `instanceAi:message` **or** `instanceAi:manage` |
| Route `rbac` middleware | `instanceAi:message` **or** `instanceAi:manage` |
| Every section of `SettingsInstanceAiView.vue` | `instanceAi:manage` |

`hasScope` defaults to `mode: 'oneOf'`, and `GLOBAL_MEMBER_SCOPES` holds `instanceAi:message` but not `instanceAi:manage` (the same is true of the `AiAssistant use` custom-role group). So every member was offered the page, passed the route guard, and then hit a view where each block collapsed to `<!--v-if-->`.

The behaviour was also inverted: a member on an instance with the assistant **off** saw the empty-state teaser, while a member on an instance with it **on** saw nothing at all.

This PR gates the sidebar entry and the route on the same predicate the content uses: whoever can manage Instance AI, plus a member in the `openWorkflowInAssistant` treatment, who still gets the default editor row. Everyone else is no longer offered the page, and a direct URL sends them to the homepage.

### Notes for reviewers

- The route keeps `instanceAi:message` in its `rbac` scope list on purpose. `beforeEnter` is the real gate now, but a member in the `openWorkflowInAssistant` treatment must still pass the `rbac` middleware to reach their default editor row (the experiment's notification deep-links to this page). There is a comment on the line saying so.
- A member in the `openWorkflowInAssistant` treatment keeps the entry only while the assistant is on. The view drops their default editor row when it is off, because it shows the empty state instead.
- Nothing member-configurable is lost. `updatePreferences` still exposes a per-user model and `localGatewayDisabled`, but no UI edits the per-user model any more, and `localGatewayDisabled` is only flipped by the computer-use setup flows.
- If product decides a member should see a read-only view of the instance configuration (open question on the ticket since 11 Aug), that view can land later and this gate widens with it.

## How to test

1. Sign in as the instance owner → **Settings → AI Assistant** is listed and renders its sections, as before.
2. Sign in as a member (or a custom role holding only `AiAssistant use`) → the **AI Assistant** entry is gone from the settings sidebar.
3. As that member, open `/settings/assistant` (or the legacy `/settings/instance-ai`) directly → you land on the homepage instead of an empty page.

Unit tests cover all three, plus the `openWorkflowInAssistant` treatment member who must keep access:

```
pnpm --filter n8n-editor-ui vitest run src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-450

Same root cause as the already-closed INS-477, from the other direction: that ticket removed the member-facing sections, which left members with a page that renders nothing.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


