### PR TITLE
fix(editor): Keep the AI Assistant context chip within the composer width

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiInput.vue
@@ -581,7 +581,12 @@ const resizable = computed(() => {
 					:class="$style.contextChip"
 					:data-test-id="props.contextChip.testId ?? 'instance-ai-handoff-context-chip'"
 				>
-					<N8nTag :text="props.contextChip.label" :clickable="false" size="lg">
+					<N8nTag
+						:class="$style.contextChipTag"
+						:text="props.contextChip.label"
+						:clickable="false"
+						size="lg"
+					>
 						<template #tag>
 							<span :class="$style.contextChipContent">
 								<N8nIcon
@@ -589,7 +594,9 @@ const resizable = computed(() => {
 									size="small"
 									data-test-id="instance-ai-handoff-context-chip-icon"
 								/>
-								<span :class="$style.contextChipText">{{ props.contextChip.label }}</span>
+								<span :class="$style.contextChipText" :title="props.contextChip.label">{{
+									props.contextChip.label
+								}}</span>
 								<button
 									type="button"
 									:class="$style.contextChipClose"
@@ -681,15 +688,25 @@ const resizable = computed(() => {
 	max-width: 100%;
 }
 
+.contextChipTag {
+	min-width: 0;
+	max-width: 100%;
+}
+
 .contextChipContent {
 	display: inline-flex;
 	align-items: center;
+	min-width: 0;
 	gap: var(--spacing--4xs);
 	line-height: var(--line-height--xs);
 }
 
 .contextChipText {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	white-space: nowrap;
+	line-height: var(--line-height--sm);
 }
 
 .contextChipClose {


### PR DESCRIPTION
## Summary

When you click **Fix with Assistant** in an agent preview, the AI Assistant composer shows a context chip with the label `{agentName} — {sessionTitle}`. When the label was long, the chip ran past the right edge of the composer.

Cause: the design-system `N8nTag` sets `min-width: max-content`, and no element inside the chip could shrink.

Fix (CSS only, in `InstanceAiInput.vue`):
- Override the tag `min-width` inside the chip so it can shrink to the composer width.
- Let the content row shrink (`min-width: 0`).
- Truncate the label with an ellipsis and give it a line height that does not clip descenders (same pattern as `NodeChip.vue`).
- Expose the full label through a `title` attribute.

The design system is not changed. Test ids, props, events, and i18n keys are unchanged.

Layout verified with a standalone Playwright repro of the DOM chain: before, the chip extended 339px past the composer edge; after, it ends flush with the composer edge, the label is truncated, and the dismiss button stays fully visible. A short label still renders shrink-to-fit.

## How to test

1. Open an agent and start a preview session in which a tool call fails.
2. Click **Fix with Assistant** in the preview.
3. The AI Assistant opens with a context chip in the composer. Use an agent with a long name and a long session title.
4. Check: the chip stays inside the composer, the label ends with an ellipsis, and the × button is visible and works.
5. Hover the label: the full text shows as a tooltip.
6. Check with a short label: the chip still shrinks to fit its content.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-825

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

