### PR TITLE
fix(editor): Fix issue preventing users from being able to disconnect own credentials in some cases

### DIFF
--- a/packages/@n8n/permissions/src/roles/__tests__/end-user-credential-scope.test.ts
+++ b/packages/@n8n/permissions/src/roles/__tests__/end-user-credential-scope.test.ts
@@ -32,6 +32,15 @@ describe('credential:createEndUser default grants', () => {
 		expect(PROJECT_CUSTOM_ROLE_OPERATIONS.credential).toContain('createEndUser');
 	});
 
+	it('is distinct from credential:connect, which every project role holds', () => {
+		// Connecting an own account is not managing the credential: every project role,
+		// viewers included, may connect; only admins and owners may create or retype.
+		expect(PROJECT_VIEWER_SCOPES).toContain('credential:connect');
+		expect(PROJECT_EDITOR_SCOPES).toContain('credential:connect');
+		expect(REGULAR_PROJECT_ADMIN_SCOPES).toContain('credential:connect');
+		expect(PERSONAL_PROJECT_OWNER_SCOPES).toContain('credential:connect');
+	});
+
 	it('survives the credential owner sharing mask but not the user mask', () => {
 		expect(CREDENTIALS_SHARING_OWNER_SCOPES).toContain('credential:createEndUser');
 		expect(CREDENTIALS_SHARING_USER_SCOPES).not.toContain('credential:createEndUser');

--- a/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
@@ -177,6 +177,11 @@ export const PROJECT_VIEWER_SCOPES: Scope[] = [
 	'agent:execute',
 	'credential:list',
 	'credential:read',
+	// Connecting an own account to an end-user credential, not editing the shared
+	// credential. A viewer who runs a workflow through a form or chat trigger must be
+	// able to connect/disconnect their own account, and the connection is only retained while its
+	// user holds this scope (see credential-connection-status.service.ts).
+	'credential:connect',
 	'project:list',
 	'project:read',
 	'project:export',

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -71,27 +71,40 @@ describe('DynamicCredentialsController', () => {
 		credentialsFinderService.findCredentialForUser.mockResolvedValue(mock<CredentialsEntity>());
 	});
 
+	// Neither endpoint asks for a scope on the shared credential. Both key on the
+	// caller's own identity server side — the connect binds the callback to it (see
+	// 'binds the state to the intended n8n user'), and the delete derives its storage
+	// key from it — so a session user resolves the credential by id, the same path a
+	// static-token caller takes.
 	describe('in-app access control', () => {
-		it('returns 404 when an authenticated user cannot access the credential', async () => {
-			credentialsFinderService.findCredentialForUser.mockResolvedValue(null);
-			const user = mock<AuthenticatedRequest['user']>({ id: 'user-123' });
-			const req = mock<AuthenticatedRequest>({
-				user,
+		const foreignCredentialRequest = () =>
+			mock<AuthenticatedRequest>({
+				user: mock<AuthenticatedRequest['user']>({ id: 'user-123' }),
 				params: { id: 'foreign-credential' },
 				query: { resolverId: 'resolver-123' },
 				headers: { authorization: 'Bearer token123' },
 			});
-			const res = mock<Response>();
 
-			await expect(controller.authorizeCredential(req, res)).rejects.toThrow(
+		it('resolves the credential by id when connecting, not by the caller scopes', async () => {
+			enterpriseCredentialsService.getOne.mockResolvedValue(null);
+			const req = foreignCredentialRequest();
+
+			await expect(controller.authorizeCredential(req, mock<Response>())).rejects.toThrow(
 				'Credential not found',
 			);
-			expect(credentialsFinderService.findCredentialForUser).toHaveBeenCalledWith(
-				'foreign-credential',
-				user,
-				['credential:update'],
+			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('foreign-credential');
+			expect(credentialsFinderService.findCredentialForUser).not.toHaveBeenCalled();
+		});
+
+		it('resolves the credential by id when disconnecting, not by the caller scopes', async () => {
+			enterpriseCredentialsService.getOne.mockResolvedValue(null);
+			const req = foreignCredentialRequest();
+
+			await expect(controller.revokeCredential(req, mock<Response>())).rejects.toThrow(
+				'Credential not found',
 			);
-			expect(enterpriseCredentialsService.getOne).not.toHaveBeenCalled();
+			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('foreign-credential');
+			expect(credentialsFinderService.findCredentialForUser).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -71,40 +71,50 @@ describe('DynamicCredentialsController', () => {
 		credentialsFinderService.findCredentialForUser.mockResolvedValue(mock<CredentialsEntity>());
 	});
 
-	// Neither endpoint asks for a scope on the shared credential. Both key on the
-	// caller's own identity server side — the connect binds the callback to it (see
-	// 'binds the state to the intended n8n user'), and the delete derives its storage
-	// key from it — so a session user resolves the credential by id, the same path a
-	// static-token caller takes.
 	describe('in-app access control', () => {
-		const foreignCredentialRequest = () =>
-			mock<AuthenticatedRequest>({
-				user: mock<AuthenticatedRequest['user']>({ id: 'user-123' }),
-				params: { id: 'foreign-credential' },
-				query: { resolverId: 'resolver-123' },
-				headers: { authorization: 'Bearer token123' },
-			});
+		const foreignCredentialRequest = () => {
+			const user = mock<AuthenticatedRequest['user']>({ id: 'user-123' });
+			return {
+				user,
+				req: mock<AuthenticatedRequest>({
+					user,
+					params: { id: 'foreign-credential' },
+					query: { resolverId: 'resolver-123' },
+					headers: { authorization: 'Bearer token123' },
+				}),
+			};
+		};
 
-		it('resolves the credential by id when connecting, not by the caller scopes', async () => {
-			enterpriseCredentialsService.getOne.mockResolvedValue(null);
-			const req = foreignCredentialRequest();
+		// Both sides of the same self-service action ask the same question: may the
+		// caller connect their own account to this end-user credential.
+		it('requires credential:connect to connect', async () => {
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(null);
+			const { user, req } = foreignCredentialRequest();
 
 			await expect(controller.authorizeCredential(req, mock<Response>())).rejects.toThrow(
 				'Credential not found',
 			);
-			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('foreign-credential');
-			expect(credentialsFinderService.findCredentialForUser).not.toHaveBeenCalled();
+			expect(credentialsFinderService.findCredentialForUser).toHaveBeenCalledWith(
+				'foreign-credential',
+				user,
+				['credential:connect'],
+			);
+			expect(enterpriseCredentialsService.getOne).not.toHaveBeenCalled();
 		});
 
-		it('resolves the credential by id when disconnecting, not by the caller scopes', async () => {
-			enterpriseCredentialsService.getOne.mockResolvedValue(null);
-			const req = foreignCredentialRequest();
+		it('requires credential:connect to disconnect', async () => {
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(null);
+			const { user, req } = foreignCredentialRequest();
 
 			await expect(controller.revokeCredential(req, mock<Response>())).rejects.toThrow(
 				'Credential not found',
 			);
-			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('foreign-credential');
-			expect(credentialsFinderService.findCredentialForUser).not.toHaveBeenCalled();
+			expect(credentialsFinderService.findCredentialForUser).toHaveBeenCalledWith(
+				'foreign-credential',
+				user,
+				['credential:connect'],
+			);
+			expect(enterpriseCredentialsService.getOne).not.toHaveBeenCalled();
 		});
 	});
 
@@ -957,6 +967,69 @@ describe('DynamicCredentialsController', () => {
 			// 2. Returns 204 status
 			expect(res.status).toHaveBeenCalledWith(204);
 			expect(res.send).toHaveBeenCalled();
+		});
+
+		it('audits the disconnect for a session user', async () => {
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const user = mock<AuthenticatedRequest['user']>({ id: 'user-123' });
+			const req = mock<AuthenticatedRequest>({
+				user,
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+			res.status.mockReturnThis();
+
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue({
+				metadata: { name: 'oauth2-introspection-identifier', description: '' },
+				getSecret: vi.fn(),
+				setSecret: vi.fn(),
+				validateOptions: vi.fn(),
+				deleteSecret: vi.fn().mockResolvedValue(undefined),
+			});
+			cipher.decryptV2.mockResolvedValue('{}');
+
+			await controller.revokeCredential(req, res);
+
+			expect(eventService.emit).toHaveBeenCalledWith('credentials-user-disconnected', {
+				user,
+				credentialId: '1',
+				credentialType: 'googleOAuth2Api',
+			});
+		});
+
+		it('does not audit a disconnect the resolver cannot perform', async () => {
+			// A resolver without `deleteSecret` deletes nothing, so recording a
+			// disconnect would claim something that did not happen.
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const req = mock<AuthenticatedRequest>({
+				user: mock<AuthenticatedRequest['user']>({ id: 'user-123' }),
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+			res.status.mockReturnThis();
+
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue({
+				metadata: { name: 'oauth2-introspection-identifier', description: '' },
+				getSecret: vi.fn(),
+				setSecret: vi.fn(),
+				validateOptions: vi.fn(),
+			});
+
+			await controller.revokeCredential(req, res);
+
+			expect(eventService.emit).not.toHaveBeenCalledWith(
+				'credentials-user-disconnected',
+				expect.anything(),
+			);
+			expect(res.status).toHaveBeenCalledWith(204);
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -171,6 +171,17 @@ export class DynamicCredentialsController {
 		this.dynamicCredentialCorsService.preflightHandler(req, res, ['post', 'options']);
 	}
 
+	/**
+	 * POST /credentials/:id/authorize
+	 *
+	 * Mints a provider authorization URL for the caller's own connection.
+	 *
+	 * Not gated by a scope on the credential, for the same reason as `/revoke`: the
+	 * connection binds to the caller's own identity (the CSRF state carries their
+	 * context, and the callback stores the token under their key), so no caller can
+	 * connect an account on someone else's behalf. A project viewer who connected
+	 * through a form or chat panel needs this to reconnect after disconnecting.
+	 */
 	@Post('/:id/authorize', {
 		allowUnauthenticated: true,
 		middlewares: getDynamicCredentialMiddlewares(),
@@ -182,8 +193,7 @@ export class DynamicCredentialsController {
 	async authorizeCredential(req: Request, res: Response): Promise<string> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['post', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
-		const user = isAuthenticatedRequest(req) ? req.user : undefined;
-		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:update');
+		const credential = await this.findCredentialToUse(req.params.id);
 
 		const resolverId = req.query.resolverId as string | undefined;
 		const { resolver, resolverEntity } = await this.getResolverInstance(resolverId);

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -113,12 +113,15 @@ export class DynamicCredentialsController {
 	 *
 	 * Deletes the caller's own stored connection for the given credential.
 	 *
-	 * Not gated by a scope on the credential: the resolver derives the storage key
-	 * from the caller's own identity, so the worst any caller can do is clear their
-	 * own entry. `credential:update` asks whether the caller may edit the shared
-	 * credential, which is the wrong question here — a project viewer who connected
-	 * their own account through a form or chat panel must still be able to
-	 * disconnect it. Same reasoning as `/my-connection` below.
+	 * Gated on `credential:connect`, the scope that means "may you connect your own
+	 * account to this end-user credential" — the same scope the connect flow demands
+	 * (`oauth.service.ts`) and the same one a stored connection is retained by
+	 * (`credential-connection-status.service.ts`). `credential:update` asks whether
+	 * the caller may edit the shared credential, which is the wrong question for
+	 * removing an own connection.
+	 *
+	 * A caller who has since lost access holds no scope here and must use
+	 * `/my-connection` below, which carries no scope check by design.
 	 */
 	@Delete('/:id/revoke', {
 		allowUnauthenticated: true,
@@ -131,7 +134,8 @@ export class DynamicCredentialsController {
 	async revokeCredential(req: Request, res: Response): Promise<void> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['delete', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
-		const credential = await this.findCredentialToUse(req.params.id);
+		const user = isAuthenticatedRequest(req) ? req.user : undefined;
+		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:connect');
 
 		const resolverId = req.query.resolverId as string | undefined;
 		const { resolver, resolverEntity } = await this.getResolverInstance(resolverId);
@@ -146,16 +150,16 @@ export class DynamicCredentialsController {
 				resolverId: resolverEntity.id,
 				resolverName: resolverEntity.type,
 			});
-		}
 
-		// Static-token callers have no n8n user, and the event requires one, so they
-		// are skipped.
-		if (isAuthenticatedRequest(req)) {
-			this.eventService.emit('credentials-user-disconnected', {
-				user: req.user,
-				credentialId: credential.id,
-				credentialType: credential.type,
-			});
+			// Only audit a delete that actually ran. Static-token callers have no n8n
+			// user, and the event requires one, so they are skipped.
+			if (user) {
+				this.eventService.emit('credentials-user-disconnected', {
+					user,
+					credentialId: credential.id,
+					credentialType: credential.type,
+				});
+			}
 		}
 
 		res.status(204).send(); // 204 No Content indicates successful deletion
@@ -176,11 +180,13 @@ export class DynamicCredentialsController {
 	 *
 	 * Mints a provider authorization URL for the caller's own connection.
 	 *
-	 * Not gated by a scope on the credential, for the same reason as `/revoke`: the
-	 * connection binds to the caller's own identity (the CSRF state carries their
-	 * context, and the callback stores the token under their key), so no caller can
-	 * connect an account on someone else's behalf. A project viewer who connected
-	 * through a form or chat panel needs this to reconnect after disconnecting.
+	 * Gated on `credential:connect`, matching `/revoke` above and the in-app connect
+	 * flow in `oauth.service.ts`: connecting an own account to an end-user credential
+	 * does not require edit rights on the shared credential.
+	 *
+	 * Note this path passes the caller's identity to the resolver to validate, so it
+	 * depends on the resolver-identity compatibility check the execution path applies
+	 * (`carriesN8nIdentity` in `dynamic-credential.service.ts`).
 	 */
 	@Post('/:id/authorize', {
 		allowUnauthenticated: true,
@@ -193,7 +199,8 @@ export class DynamicCredentialsController {
 	async authorizeCredential(req: Request, res: Response): Promise<string> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['post', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
-		const credential = await this.findCredentialToUse(req.params.id);
+		const user = isAuthenticatedRequest(req) ? req.user : undefined;
+		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:connect');
 
 		const resolverId = req.query.resolverId as string | undefined;
 		const { resolver, resolverEntity } = await this.getResolverInstance(resolverId);

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -108,6 +108,18 @@ export class DynamicCredentialsController {
 		this.dynamicCredentialCorsService.preflightHandler(req, res, ['delete', 'options']);
 	}
 
+	/**
+	 * DELETE /credentials/:id/revoke
+	 *
+	 * Deletes the caller's own stored connection for the given credential.
+	 *
+	 * Not gated by a scope on the credential: the resolver derives the storage key
+	 * from the caller's own identity, so the worst any caller can do is clear their
+	 * own entry. `credential:update` asks whether the caller may edit the shared
+	 * credential, which is the wrong question here — a project viewer who connected
+	 * their own account through a form or chat panel must still be able to
+	 * disconnect it. Same reasoning as `/my-connection` below.
+	 */
 	@Delete('/:id/revoke', {
 		allowUnauthenticated: true,
 		middlewares: getDynamicCredentialMiddlewares(),
@@ -119,8 +131,7 @@ export class DynamicCredentialsController {
 	async revokeCredential(req: Request, res: Response): Promise<void> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['delete', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
-		const user = isAuthenticatedRequest(req) ? req.user : undefined;
-		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:update');
+		const credential = await this.findCredentialToUse(req.params.id);
 
 		const resolverId = req.query.resolverId as string | undefined;
 		const { resolver, resolverEntity } = await this.getResolverInstance(resolverId);
@@ -134,6 +145,16 @@ export class DynamicCredentialsController {
 				configuration: resolverConfig,
 				resolverId: resolverEntity.id,
 				resolverName: resolverEntity.type,
+			});
+		}
+
+		// Static-token callers have no n8n user, and the event requires one, so they
+		// are skipped.
+		if (isAuthenticatedRequest(req)) {
+			this.eventService.emit('credentials-user-disconnected', {
+				user: req.user,
+				credentialId: credential.id,
+				credentialType: credential.type,
 			});
 		}
 

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -635,7 +635,7 @@ describe('DynamicNodeParametersService', () => {
 		});
 
 		it('should throw for an end-user credential the user may read but not connect', async () => {
-			// A project viewer holds `credential:read` without `credential:connect`.
+			// A caller who holds `credential:read` without `credential:connect`.
 			credentialsFinderService.findCredentialIdsWithScopeForUser
 				.mockResolvedValueOnce(new Set(['cred-1']))
 				.mockResolvedValueOnce(new Set());

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -136,9 +136,9 @@ export class DynamicNodeParametersService {
 	 * user's own connection, so it requires `credential:connect` — the same scope the
 	 * connect flow itself demands — on top of the `credential:read` checked above.
 	 *
-	 * Read access alone is not enough: a project viewer holds `credential:read` but may
-	 * not connect an account, and should be told so rather than shown a list built from
-	 * a connection they are not allowed to hold.
+	 * Read access alone is not enough: a caller who may read the credential but not
+	 * connect an account should be told so rather than shown a list built from a
+	 * connection they are not allowed to hold.
 	 */
 	private async assertMayUseEndUserCredentials(user: User, credentialIds: string[]) {
 		const credentials = await this.credentialsRepository.getManyByIds(credentialIds);

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -549,7 +549,7 @@ describe('GET /credentials/:id', () => {
 				id: teamProject.id,
 			},
 			sharedWithProjects: [],
-			scopes: ['credential:read'],
+			scopes: ['credential:connect', 'credential:read'],
 		});
 		expect(response.body.data.data).toBeUndefined();
 	});

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -370,7 +370,7 @@ describe('GET /credentials', () => {
 
 		expect(teamCredAsViewer.id).toBe(teamCredentialAsViewer.id);
 		expect(teamCredAsViewer.data).not.toBeDefined();
-		expect(teamCredAsViewer.scopes).toEqual(['credential:read'].sort());
+		expect(teamCredAsViewer.scopes).toEqual(['credential:connect', 'credential:read'].sort());
 
 		expect(teamCredAsEditor.id).toBe(teamCredentialAsEditor.id);
 		expect(teamCredAsEditor.data).toBeDefined();

--- a/packages/cli/test/integration/dynamic-credentials.ee/design-time-parameter-loading.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/design-time-parameter-loading.api.test.ts
@@ -133,7 +133,7 @@ beforeEach(async () => {
 	// End-user credentials live in team projects only.
 	teamProject = await createTeamProject(undefined, member);
 	await linkUserToProject(otherMember, teamProject, 'project:editor');
-	// A viewer can read the credential but not connect an account to it.
+	// A viewer can read the credential and connect their own account to it.
 	await linkUserToProject(viewer, teamProject, 'project:viewer');
 
 	const resolverRepository = Container.get(DynamicCredentialResolverRepository);
@@ -283,16 +283,17 @@ describe('design-time parameter loading with end-user credentials', () => {
 		expect(driveScope.isDone()).toBe(false);
 	});
 
-	test('refuses a user who may read the credential but not connect it', async () => {
-		// Resolution would key on this user's own connection, which they are not allowed
-		// to hold — so say that, rather than listing anything.
+	test('treats a project viewer as connectable, so it asks them to connect', async () => {
+		// A viewer holds `credential:connect`, so resolution keys on their own
+		// connection like any other user's. Not having connected yet is the answer,
+		// not a permission error — and either way the vendor is not called.
 		const credential = await createEndUserCredential();
 		const driveScope = mockDriveListing();
 
 		const response = await listResources(viewer, credential);
 
-		expect(response.statusCode).toBe(403);
-		expect(response.body.message).toContain('permission to connect');
+		expect(response.statusCode).toBe(500);
+		expect(response.body.message).toContain('is not connected for you');
 		expect(driveScope.isDone()).toBe(false);
 	});
 

--- a/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.auth.api.test.ts
@@ -1,19 +1,37 @@
 import { LicenseState } from '@n8n/backend-common';
-import { mockInstance, getPersonalProject, testDb } from '@n8n/backend-test-utils';
-import type { CredentialsEntity, User } from '@n8n/db';
+import {
+	createTeamProject,
+	linkUserToProject,
+	mockInstance,
+	getPersonalProject,
+	testDb,
+} from '@n8n/backend-test-utils';
+import type { CredentialsEntity, Project, User } from '@n8n/db';
 import { GLOBAL_OWNER_ROLE } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { Cipher } from 'n8n-core';
 import nock from 'nock';
 import { mock } from 'vitest-mock-extended';
 
 import { CredentialsHelper } from '@/credentials-helper';
+import { EventService } from '@/events/event.service';
+import {
+	SYSTEM_RESOLVER_ID,
+	SYSTEM_RESOLVER_NAME,
+	SYSTEM_RESOLVER_TYPE,
+} from '@/modules/dynamic-credentials.ee/constants';
+import { DynamicCredentialEntryStorage } from '@/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-entry-storage';
+import { DynamicCredentialUserEntryStorage } from '@/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-user-entry-storage';
 import type { DynamicCredentialResolver } from '@/modules/dynamic-credentials.ee/database/entities/credential-resolver';
+import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository';
+import { DynamicCredentialEntryRepository } from '@/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-entry.repository';
+import { DynamicCredentialUserEntryRepository } from '@/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-user-entry.repository';
 import { DynamicCredentialsConfig } from '@/modules/dynamic-credentials.ee/dynamic-credentials.config';
 import { DynamicCredentialResolverService } from '@/modules/dynamic-credentials.ee/services/credential-resolver.service';
 import { Telemetry } from '@/telemetry';
 
 import { saveCredential } from '../shared/db/credentials';
-import { createUser } from '../shared/db/users';
+import { createMember, createUser } from '../shared/db/users';
 import * as utils from '../shared/utils';
 
 mockInstance(Telemetry);
@@ -211,6 +229,28 @@ describe('Dynamic Credentials API', () => {
 					.set('X-Authorization', 'Bearer ')
 					.expect(401);
 			});
+
+			it('should not emit the disconnect event, which needs an n8n user', async () => {
+				const emitSpy = vi
+					.spyOn(Container.get(EventService), 'emit')
+					.mockImplementation(() => true);
+
+				try {
+					await testServer.authlessAgent
+						.delete(`/credentials/${savedCredential.id}/revoke`)
+						.query({ resolverId: resolver.id })
+						.set('X-Authorization', 'Bearer static-test-token')
+						.set('Authorization', 'Bearer test-token')
+						.expect(204);
+
+					expect(emitSpy).not.toHaveBeenCalledWith(
+						'credentials-user-disconnected',
+						expect.anything(),
+					);
+				} finally {
+					emitSpy.mockRestore();
+				}
+			});
 		});
 	});
 
@@ -283,15 +323,176 @@ describe('Dynamic Credentials API', () => {
 				expect(response.body?.data).toBeUndefined();
 			});
 
-			it('should not revoke a credential the member cannot access', async () => {
-				const response = await testServer
+			it("confines the delete to the caller's own entry", async () => {
+				// The resolver keys the entry on the caller's own identity, so the delete
+				// cannot reach another subject's entry. Revoke therefore needs no scope on
+				// the shared credential.
+				const entryStorage = Container.get(DynamicCredentialEntryStorage);
+				const entryRepository = Container.get(DynamicCredentialEntryRepository);
+
+				// 'user-123' is the subject the mocked introspection endpoint returns for
+				// the caller's bearer token.
+				await entryStorage.setCredentialData(
+					savedCredential.id,
+					'user-123',
+					resolver.id,
+					'caller-payload',
+					{},
+				);
+				await entryStorage.setCredentialData(
+					savedCredential.id,
+					'another-subject',
+					resolver.id,
+					'other-payload',
+					{},
+				);
+
+				await testServer
 					.authAgentFor(unrelatedMember)
 					.delete(`/credentials/${savedCredential.id}/revoke`)
 					.query({ resolverId: resolver.id })
-					.set('Authorization', 'Bearer test-token');
+					.set('Authorization', 'Bearer test-token')
+					.expect(204);
 
-				expect([403, 404]).toContain(response.status);
+				await expect(
+					entryRepository.findOne({
+						where: { credentialId: savedCredential.id, subjectId: 'user-123' },
+					}),
+				).resolves.toBeNull();
+				await expect(
+					entryRepository.findOne({
+						where: { credentialId: savedCredential.id, subjectId: 'another-subject' },
+					}),
+				).resolves.not.toBeNull();
 			});
+		});
+	});
+
+	// The connect panel shared by the Form, Chat and MCP triggers uses the system n8n
+	// resolver, which keys each entry on the caller's n8n user id.
+	describe('DELETE /credentials/:id/revoke with the system resolver', () => {
+		let teamProject: Project;
+		let viewer: User;
+		let secondViewer: User;
+		let userEntryStorage: DynamicCredentialUserEntryStorage;
+		let userEntryRepository: DynamicCredentialUserEntryRepository;
+
+		const seedUserEntry = async (credentialId: string, userId: string) =>
+			await userEntryStorage.setCredentialData(
+				credentialId,
+				userId,
+				SYSTEM_RESOLVER_ID,
+				'encrypted-payload',
+				{},
+			);
+
+		const saveResolvableCredential = async () =>
+			await saveCredential(
+				{
+					name: 'Panel Dynamic Credential',
+					type: 'oAuth2Api',
+					isResolvable: true,
+					data: {
+						clientId: 'test-client-id',
+						clientSecret: 'test-client-secret',
+						authUrl: 'https://test.domain/oauth2/auth',
+						accessTokenUrl: 'https://test.domain/oauth2/token',
+						grantType: 'authorizationCode',
+					},
+				},
+				{ project: teamProject, role: 'credential:owner' },
+			);
+
+		/** Matches how the panel calls the endpoint: session cookie, no bearer token. */
+		const disconnectAs = (user: User, credentialId: string) =>
+			testServer
+				.authAgentFor(user)
+				.delete(`/credentials/${credentialId}/revoke`)
+				.query({ resolverId: SYSTEM_RESOLVER_ID, authSource: 'cookie' });
+
+		beforeAll(async () => {
+			teamProject = await createTeamProject(undefined, owner);
+			viewer = await createMember();
+			secondViewer = await createMember();
+			await linkUserToProject(viewer, teamProject, 'project:viewer');
+			await linkUserToProject(secondViewer, teamProject, 'project:viewer');
+
+			userEntryStorage = Container.get(DynamicCredentialUserEntryStorage);
+			userEntryRepository = Container.get(DynamicCredentialUserEntryRepository);
+
+			// The outer setup truncates the resolver table, which drops the row the
+			// module seeds at init.
+			const resolverRepository = Container.get(DynamicCredentialResolverRepository);
+			await resolverRepository.save(
+				resolverRepository.create({
+					id: SYSTEM_RESOLVER_ID,
+					name: SYSTEM_RESOLVER_NAME,
+					type: SYSTEM_RESOLVER_TYPE,
+					config: await Container.get(Cipher).encryptV2({}),
+				}),
+			);
+		});
+
+		it('lets a project viewer disconnect their own connection', async () => {
+			const credential = await saveResolvableCredential();
+			await seedUserEntry(credential.id, viewer.id);
+
+			await disconnectAs(viewer, credential.id).expect(204);
+
+			const remaining = await userEntryRepository.find({
+				where: { credentialId: credential.id, userId: viewer.id },
+			});
+			expect(remaining).toHaveLength(0);
+		});
+
+		it("does not affect other users' connections on the same credential", async () => {
+			const credential = await saveResolvableCredential();
+			await seedUserEntry(credential.id, viewer.id);
+			await seedUserEntry(credential.id, secondViewer.id);
+
+			await disconnectAs(viewer, credential.id).expect(204);
+
+			const secondViewerEntries = await userEntryRepository.find({
+				where: { credentialId: credential.id, userId: secondViewer.id },
+			});
+			expect(secondViewerEntries).toHaveLength(1);
+		});
+
+		it('lets a user without project access clear their own connection', async () => {
+			// User had access in the past, connected, then lost project access.
+			// They must still be able to clear their own stored tokens.
+			const outsider = await createMember();
+			const credential = await saveResolvableCredential();
+			await seedUserEntry(credential.id, outsider.id);
+
+			await disconnectAs(outsider, credential.id).expect(204);
+
+			const remaining = await userEntryRepository.find({
+				where: { credentialId: credential.id, userId: outsider.id },
+			});
+			expect(remaining).toHaveLength(0);
+		});
+
+		it('emits credentials-user-disconnected audit event on success', async () => {
+			const credential = await saveResolvableCredential();
+			await seedUserEntry(credential.id, viewer.id);
+
+			const emitSpy = vi.spyOn(Container.get(EventService), 'emit').mockImplementation(() => true);
+
+			try {
+				await disconnectAs(viewer, credential.id).expect(204);
+
+				expect(emitSpy).toHaveBeenCalledWith(
+					'credentials-user-disconnected',
+					expect.objectContaining({
+						credentialId: credential.id,
+						credentialType: credential.type,
+						user: expect.objectContaining({ id: viewer.id }),
+					}),
+				);
+			} finally {
+				emitSpy.mockRestore();
+			}
 		});
 	});
 });

--- a/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.auth.api.test.ts
@@ -20,11 +20,9 @@ import {
 	SYSTEM_RESOLVER_NAME,
 	SYSTEM_RESOLVER_TYPE,
 } from '@/modules/dynamic-credentials.ee/constants';
-import { DynamicCredentialEntryStorage } from '@/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-entry-storage';
 import { DynamicCredentialUserEntryStorage } from '@/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-user-entry-storage';
 import type { DynamicCredentialResolver } from '@/modules/dynamic-credentials.ee/database/entities/credential-resolver';
 import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository';
-import { DynamicCredentialEntryRepository } from '@/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-entry.repository';
 import { DynamicCredentialUserEntryRepository } from '@/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-user-entry.repository';
 import { DynamicCredentialsConfig } from '@/modules/dynamic-credentials.ee/dynamic-credentials.config';
 import { DynamicCredentialResolverService } from '@/modules/dynamic-credentials.ee/services/credential-resolver.service';
@@ -312,62 +310,28 @@ describe('Dynamic Credentials API', () => {
 		});
 
 		describe("when an unrelated authenticated member targets another user's credential", () => {
-			it('mints an authorization URL bound to the caller', async () => {
-				// No scope on the shared credential is required: the flow binds to the
-				// caller's own identity, so the connection can only ever populate their
-				// own entry. The URL itself carries no secret — client id, redirect uri,
-				// scopes and a single-use state token.
+			it('should not return an authorization URL for a credential the member cannot access', async () => {
 				const response = await testServer
 					.authAgentFor(unrelatedMember)
 					.post(`/credentials/${savedCredential.id}/authorize`)
 					.query({ resolverId: resolver.id })
-					.set('Authorization', 'Bearer test-token')
-					.expect(200);
+					.set('Authorization', 'Bearer test-token');
 
-				expect(response.body.data).toContain('https://test.domain/oauth2/auth');
+				expect([403, 404]).toContain(response.status);
+				expect(response.body?.data).toBeUndefined();
 			});
 
-			it("confines the delete to the caller's own entry", async () => {
-				// The resolver keys the entry on the caller's own identity, so the delete
-				// cannot reach another subject's entry. Revoke therefore needs no scope on
-				// the shared credential.
-				const entryStorage = Container.get(DynamicCredentialEntryStorage);
-				const entryRepository = Container.get(DynamicCredentialEntryRepository);
-
-				// 'user-123' is the subject the mocked introspection endpoint returns for
-				// the caller's bearer token.
-				await entryStorage.setCredentialData(
-					savedCredential.id,
-					'user-123',
-					resolver.id,
-					'caller-payload',
-					{},
-				);
-				await entryStorage.setCredentialData(
-					savedCredential.id,
-					'another-subject',
-					resolver.id,
-					'other-payload',
-					{},
-				);
-
-				await testServer
+			it('should not revoke a credential the member cannot even read', async () => {
+				// `credential:connect` is the floor: a member with no relationship to the
+				// credential holds no scope on it. They clear their own stored tokens
+				// through `/my-connection`, which carries no scope check by design.
+				const response = await testServer
 					.authAgentFor(unrelatedMember)
 					.delete(`/credentials/${savedCredential.id}/revoke`)
 					.query({ resolverId: resolver.id })
-					.set('Authorization', 'Bearer test-token')
-					.expect(204);
+					.set('Authorization', 'Bearer test-token');
 
-				await expect(
-					entryRepository.findOne({
-						where: { credentialId: savedCredential.id, subjectId: 'user-123' },
-					}),
-				).resolves.toBeNull();
-				await expect(
-					entryRepository.findOne({
-						where: { credentialId: savedCredential.id, subjectId: 'another-subject' },
-					}),
-				).resolves.not.toBeNull();
+				expect([403, 404]).toContain(response.status);
 			});
 		});
 	});
@@ -444,24 +408,6 @@ describe('Dynamic Credentials API', () => {
 			);
 		});
 
-		it('lets a project viewer reconnect after disconnecting', async () => {
-			const credential = await saveResolvableCredential();
-			await seedUserEntry(credential.id, viewer.id);
-
-			await disconnectAs(viewer, credential.id).expect(204);
-
-			const response = await reconnectAs(viewer, credential.id).expect(200);
-			expect(response.body.data).toContain('https://test.domain/oauth2/auth');
-		});
-
-		it('lets a user without project access reconnect their own connection', async () => {
-			const outsider = await createMember();
-			const credential = await saveResolvableCredential();
-
-			const response = await reconnectAs(outsider, credential.id).expect(200);
-			expect(response.body.data).toContain('https://test.domain/oauth2/auth');
-		});
-
 		it('lets a project viewer disconnect their own connection', async () => {
 			const credential = await saveResolvableCredential();
 			await seedUserEntry(credential.id, viewer.id);
@@ -487,11 +433,28 @@ describe('Dynamic Credentials API', () => {
 			expect(secondViewerEntries).toHaveLength(1);
 		});
 
-		it('lets a user without project access clear their own connection', async () => {
-			// User had access in the past, connected, then lost project access.
-			// They must still be able to clear their own stored tokens.
+		it('lets any authenticated user disconnect from a global end-user credential', async () => {
+			// Deliberate, and the one case with no membership check: a globally shared
+			// end-user credential grants connect access to every user, because each
+			// connects their own account (see role.service.ts and the global branch in
+			// credentials-finder.service.ts). The delete stays keyed to the caller.
 			const outsider = await createMember();
-			const credential = await saveResolvableCredential();
+			const credential = await saveCredential(
+				{
+					name: 'Global End-User Credential',
+					type: 'oAuth2Api',
+					isResolvable: true,
+					isGlobal: true,
+					data: {
+						clientId: 'test-client-id',
+						clientSecret: 'test-client-secret',
+						authUrl: 'https://test.domain/oauth2/auth',
+						accessTokenUrl: 'https://test.domain/oauth2/token',
+						grantType: 'authorizationCode',
+					},
+				},
+				{ project: teamProject, role: 'credential:owner' },
+			);
 			await seedUserEntry(credential.id, outsider.id);
 
 			await disconnectAs(outsider, credential.id).expect(204);
@@ -500,6 +463,35 @@ describe('Dynamic Credentials API', () => {
 				where: { credentialId: credential.id, userId: outsider.id },
 			});
 			expect(remaining).toHaveLength(0);
+		});
+
+		it('refuses a user who has lost project access, who uses /my-connection instead', async () => {
+			// `credential:connect` is the floor for this endpoint, and a user who lost
+			// project access holds nothing. `/my-connection` is the un-gated path that
+			// still lets them clear their own tokens — covered in my-connection.api.test.ts.
+			const outsider = await createMember();
+			const credential = await saveResolvableCredential();
+			await seedUserEntry(credential.id, outsider.id);
+
+			const response = await disconnectAs(outsider, credential.id);
+			expect([403, 404]).toContain(response.status);
+
+			const remaining = await userEntryRepository.find({
+				where: { credentialId: credential.id, userId: outsider.id },
+			});
+			expect(remaining).toHaveLength(1);
+		});
+
+		it('lets a project viewer reconnect after disconnecting', async () => {
+			// The panel's in-session reconnect: the first connect consumed its one-time
+			// link, so Connect mints a new one instead of reloading the page.
+			const credential = await saveResolvableCredential();
+			await seedUserEntry(credential.id, viewer.id);
+
+			await disconnectAs(viewer, credential.id).expect(204);
+
+			const response = await reconnectAs(viewer, credential.id).expect(200);
+			expect(response.body.data).toContain('https://test.domain/oauth2/auth');
 		});
 
 		it('emits credentials-user-disconnected audit event on success', async () => {

--- a/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.auth.api.test.ts
@@ -312,15 +312,19 @@ describe('Dynamic Credentials API', () => {
 		});
 
 		describe("when an unrelated authenticated member targets another user's credential", () => {
-			it('should not return an authorization URL for a credential the member cannot access', async () => {
+			it('mints an authorization URL bound to the caller', async () => {
+				// No scope on the shared credential is required: the flow binds to the
+				// caller's own identity, so the connection can only ever populate their
+				// own entry. The URL itself carries no secret — client id, redirect uri,
+				// scopes and a single-use state token.
 				const response = await testServer
 					.authAgentFor(unrelatedMember)
 					.post(`/credentials/${savedCredential.id}/authorize`)
 					.query({ resolverId: resolver.id })
-					.set('Authorization', 'Bearer test-token');
+					.set('Authorization', 'Bearer test-token')
+					.expect(200);
 
-				expect([403, 404]).toContain(response.status);
-				expect(response.body?.data).toBeUndefined();
+				expect(response.body.data).toContain('https://test.domain/oauth2/auth');
 			});
 
 			it("confines the delete to the caller's own entry", async () => {
@@ -410,6 +414,13 @@ describe('Dynamic Credentials API', () => {
 				.delete(`/credentials/${credentialId}/revoke`)
 				.query({ resolverId: SYSTEM_RESOLVER_ID, authSource: 'cookie' });
 
+		/** The panel's reconnect: the first connect consumed its one-time link, so it mints a new one. */
+		const reconnectAs = (user: User, credentialId: string) =>
+			testServer
+				.authAgentFor(user)
+				.post(`/credentials/${credentialId}/authorize`)
+				.query({ resolverId: SYSTEM_RESOLVER_ID, authSource: 'cookie' });
+
 		beforeAll(async () => {
 			teamProject = await createTeamProject(undefined, owner);
 			viewer = await createMember();
@@ -431,6 +442,24 @@ describe('Dynamic Credentials API', () => {
 					config: await Container.get(Cipher).encryptV2({}),
 				}),
 			);
+		});
+
+		it('lets a project viewer reconnect after disconnecting', async () => {
+			const credential = await saveResolvableCredential();
+			await seedUserEntry(credential.id, viewer.id);
+
+			await disconnectAs(viewer, credential.id).expect(204);
+
+			const response = await reconnectAs(viewer, credential.id).expect(200);
+			expect(response.body.data).toContain('https://test.domain/oauth2/auth');
+		});
+
+		it('lets a user without project access reconnect their own connection', async () => {
+			const outsider = await createMember();
+			const credential = await saveResolvableCredential();
+
+			const response = await reconnectAs(outsider, credential.id).expect(200);
+			expect(response.body.data).toContain('https://test.domain/oauth2/auth');
 		});
 
 		it('lets a project viewer disconnect their own connection', async () => {


### PR DESCRIPTION
## Summary
There was an edge case where it was possible for a user to be able to connect new end-user credentials, but not disconnect them. This was also an issue for reconnecting credentials.

If a user was given access to a workflow that used some EU credentials, but they were not given explicit `credential:update` permissions to those credentials, they were able to connect them but rejected for disconnecting or reconnecting. The fix was simple: remove that credential check from that location.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
1. As admin user A create a workflow that uses private credentials, and has either a chat or form trigger protected behind 'n8n User Auth' (required to use EU credentials). Share that workflow (and NOT the credentials) with member B.
2. As B, open the public URL of the form or chat and connect credentials.
3. Now open the credential modal again and click 'disconnect'. Before this branch, nothing would happen. With this branch, it will disconnect the credential as expected.
4. After disconnecting click the 'connect' button again - despite appearing the same as the 'connect' button on a fresh page load, this actually has a different 'reconnect' flow. Before this PR it would momentarily open a popup before closing it and leaving an error in the console - after this PR, it opens the oauth popup as expected.

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-1350/users-without-credentialupdate-cant-disconnect-their-own-connected
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

