### PR TITLE
fix(core): Treat Instance AI model stream stalls as dropped provider connections

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/stream-transport-error.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/stream-transport-error.test.ts
@@ -1,3 +1,5 @@
+import { ModelStreamStallError } from '@n8n/agents';
+
 import { QuotaExhaustedStreamError } from '../instance-ai.service';
 import { isStreamTransportError } from '../stream-transport-error';
 
@@ -10,6 +12,10 @@ function socketError(code: string, message = 'socket failure'): Error {
 }
 
 describe('isStreamTransportError', () => {
+	it('matches a stalled model stream', () => {
+		expect(isStreamTransportError(new ModelStreamStallError(90_000))).toBe(true);
+	});
+
 	it('matches undici mid-stream termination with no cause attached', () => {
 		expect(isStreamTransportError(new TypeError('terminated'))).toBe(true);
 	});

--- a/packages/cli/src/modules/instance-ai/stream-transport-error.ts
+++ b/packages/cli/src/modules/instance-ai/stream-transport-error.ts
@@ -1,13 +1,18 @@
+import { ModelStreamStallError } from '@n8n/agents';
 import { isDnsFailure, isTransportFailure } from '@n8n/backend-network';
 import { isQuotaExhaustedError } from '@n8n/instance-ai';
 
 /**
  * True when a run died because the connection to the model provider broke.
  *
+ * A `ModelStreamStallError` is a dead connection detected by silence instead of a socket error.
  * Quota is checked first: hitting the credit wall at the model call also dies
  * as a transport failure, which `QuotaExhaustedStreamError` keeps as its
  * `cause`. DNS is excluded so a misconfigured `baseURL` stays visible.
  */
 export function isStreamTransportError(error: unknown): boolean {
-	return !isQuotaExhaustedError(error) && !isDnsFailure(error) && isTransportFailure(error);
+	return (
+		!isQuotaExhaustedError(error) &&
+		(error instanceof ModelStreamStallError || (!isDnsFailure(error) && isTransportFailure(error)))
+	);
 }


### PR DESCRIPTION
## Summary

Instance AI now treats a stalled model stream the same way as a dropped provider connection.

The chunk-idle watchdog from #35943 throws `ModelStreamStallError` when the model stream sends no data for 90 seconds. Instance AI already downgrades provider connection drops (undici `TypeError: terminated`, `ECONNRESET`, …) to a warn log and shows the user a "connection dropped" message (#35587). The stall error did not match that classification because it carries no `code`. The result: every stall produced a Sentry error event (INSTANCE-BACKEND-27MA: 258 events / 246 users in the last 30 days), and the user saw the generic "Something went wrong" message.

This PR adds `ModelStreamStallError` to `isStreamTransportError`. Both consumers of that predicate change behaviour:

- `InstanceAiErrorReporterService` logs the stall at warn level with `threadId`/`runId` and sends no Sentry event.
- `getUserFacingErrorMessage` returns "The connection to the AI provider dropped before I could finish that response. Please try again."

The watchdog deadlines, the retry policy, and keepalive handling do not change. That work is tracked in AGENT-695 / #37558.

## How to test

1. Run the unit test from `packages/cli`:
   `pnpm test src/modules/instance-ai/__tests__/stream-transport-error.test.ts`
2. Manual check: point `N8N_INSTANCE_AI_MODEL_URL` at a local OpenAI-compatible endpoint that accepts the request, sends one chunk, and then holds the connection open without data. Send a message in the AI Assistant chat. After 90 seconds the chat shows the "connection to the AI provider dropped" message. The server log contains a warn entry `Instance AI stream transport failure in instance-ai-stream`, and no Sentry event is sent.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-627
- Related: https://linear.app/n8n/issue/AGENT-695 (deadline tuning and keepalive-aware stall detection, #37558)
- Fixes INSTANCE-BACKEND-27MA

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

