### PR TITLE
fix(core): Retry Instance AI model turns when the provider stream closes without output

### DIFF
--- a/packages/@n8n/agents/src/runtime/loop/__tests__/stream-sink.test.ts
+++ b/packages/@n8n/agents/src/runtime/loop/__tests__/stream-sink.test.ts
@@ -1,0 +1,88 @@
+import { convertArrayToReadableStream, MockLanguageModelV3 } from 'ai/test';
+
+import type { StreamWriterGuard } from '../../streaming/stream-writer-guard';
+import type { RunServices } from '../run-output-sink';
+import { StreamSink } from '../stream-sink';
+
+type MockStreamResult = Awaited<ReturnType<MockLanguageModelV3['doStream']>>;
+type MockStreamPart = MockStreamResult['stream'] extends ReadableStream<infer P> ? P : never;
+
+const USAGE: Extract<MockStreamPart, { type: 'finish' }>['usage'] = {
+	inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+	outputTokens: { total: 5, text: 5, reasoning: 0 },
+};
+
+function makeEmptyTurn(): MockStreamResult {
+	return {
+		stream: convertArrayToReadableStream([{ type: 'stream-start', warnings: [] }]),
+	};
+}
+
+function makeTextTurn(text: string): MockStreamResult {
+	const parts: MockStreamPart[] = [
+		{ type: 'stream-start', warnings: [] },
+		{ type: 'text-start', id: 'txt-1' },
+		{ type: 'text-delta', id: 'txt-1', delta: text },
+		{ type: 'text-end', id: 'txt-1' },
+		{ type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: USAGE },
+	];
+	return { stream: convertArrayToReadableStream(parts) };
+}
+
+describe('StreamSink', () => {
+	it('retries an empty model stream without forwarding its error', async () => {
+		const model = new MockLanguageModelV3({
+			provider: 'mock',
+			modelId: 'scripted',
+			doStream: [makeEmptyTurn(), makeTextTurn('recovered response')],
+		});
+		const write = vi.fn<StreamWriterGuard['write']>().mockResolvedValue(undefined);
+		const guard = { write } as unknown as StreamWriterGuard;
+		const sink = new StreamSink(guard, { modelId: 'mock/scripted' } as RunServices, {
+			modelStreamIdleTimeoutMs: 0,
+			smoothStream: false,
+		});
+
+		const result = await sink.callModel({
+			model,
+			system: [],
+			messages: [{ role: 'user', content: 'hello' }],
+			abortSignal: new AbortController().signal,
+			hasTools: false,
+			aiTools: {},
+			aiSdkOptions: {},
+		});
+
+		expect(result.newMessages).toEqual([
+			{ role: 'assistant', content: [{ type: 'text', text: 'recovered response' }] },
+		]);
+		expect(write.mock.calls.some(([chunk]) => chunk.type === 'error')).toBe(false);
+		expect(model.doStreamCalls).toHaveLength(2);
+	});
+
+	it('preserves the no-output error after one retry', async () => {
+		const model = new MockLanguageModelV3({
+			provider: 'mock',
+			modelId: 'scripted',
+			doStream: [makeEmptyTurn(), makeEmptyTurn()],
+		});
+		const sink = new StreamSink(
+			{ write: async () => {} } as unknown as StreamWriterGuard,
+			{ modelId: 'mock/scripted' } as RunServices,
+			{ modelStreamIdleTimeoutMs: 0, smoothStream: false },
+		);
+
+		await expect(
+			sink.callModel({
+				model,
+				system: [],
+				messages: [{ role: 'user', content: 'hello' }],
+				abortSignal: new AbortController().signal,
+				hasTools: false,
+				aiTools: {},
+				aiSdkOptions: {},
+			}),
+		).rejects.toHaveProperty('name', 'AI_NoOutputGeneratedError');
+		expect(model.doStreamCalls).toHaveLength(2);
+	});
+});

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -151,16 +151,17 @@ export class StreamSink implements RunOutputSink<void> {
 			try {
 				return await this.streamModelTurn(ctx, turnAbort, { idleMs, firstOutputMs }, attemptState);
 			} catch (error) {
-				// A stall before any content is invisible to the user (and to the
-				// host's persistence) — re-issue the request instead of failing the
-				// run for what is usually a dead connection at request time. Once
-				// content has streamed, a retry would duplicate segments and orphan
+				// A stalled or empty stream before any content is invisible to the user
+				// (and to the host's persistence) — re-issue the request instead of
+				// failing the run for what is usually a dead connection at request time.
+				// Once content has streamed, a retry would duplicate segments and orphan
 				// already-persisted tool-call facts, so the error surfaces instead.
 				// The abandoned attempt's prompt processing goes unbilled — accepted:
 				// it only has usage at all when the stream died between message_start
 				// and the first content chunk.
 				const retryable =
-					error instanceof ModelStreamStallError &&
+					(error instanceof ModelStreamStallError ||
+						loadAi().NoOutputGeneratedError.isInstance(error)) &&
 					attempt < MAX_MODEL_STREAM_STALL_RETRIES &&
 					!attemptState.streamedContent &&
 					!ctx.abortSignal.aborted;
@@ -176,7 +177,7 @@ export class StreamSink implements RunOutputSink<void> {
 		attemptState: { streamedContent: boolean },
 	): Promise<ModelTurnResult> {
 		const { idleMs, firstOutputMs } = deadlines;
-		const { streamText } = loadAi();
+		const { NoOutputGeneratedError, streamText } = loadAi();
 		const result = streamText({
 			model: ctx.model,
 			instructions: ctx.system,
@@ -218,6 +219,9 @@ export class StreamSink implements RunOutputSink<void> {
 		// cancels the underlying fetch and the async iterator throws; the error
 		// propagates to the StreamSession which closes the consumer stream.
 		for await (const chunk of chunkStream) {
+			// The rejected result promises surface this error after the stream
+			// closes. Forwarding it here would mark a successful retry as failed.
+			if (chunk.type === 'error' && NoOutputGeneratedError.isInstance(chunk.error)) continue;
 			// Anything beyond transport bookkeeping counts as content: once seen,
 			// a stalled attempt is no longer silently retryable (see callModel).
 			if (!STALL_RETRY_SAFE_CHUNK_TYPES.has(chunk.type)) attemptState.streamedContent = true;


### PR DESCRIPTION
## Summary

When the model provider closes the response stream before it sends any content or finish chunk, the AI SDK fails the turn with `AI_NoOutputGeneratedError` ("No output generated. The model stream ended without a finish chunk."). The agents runtime failed the whole run on that first attempt. Instance AI then showed "Something went wrong before I could finish that response. Please try again." and filed an error-level Sentry event (`INSTANCE-BACKEND-27G7`, ~50 events across ~53 users since 2026-08-05).

The Sentry events arrive in bursts of 2–8 independent cloud instances within seconds of each other, across many n8n versions. That pattern points to transient upstream drops, not to a logic bug in n8n. The runtime already retries a model call once when the stream stalls before any content. This PR treats the empty-stream close the same way.

Changes in `packages/@n8n/agents`:

- `StreamSink.callModel` retries the model call once when the SDK rejects the turn with `NoOutputGeneratedError`. The retry uses the same guards as the stall retry: nothing was streamed, the run was not aborted, at most `MAX_MODEL_STREAM_STALL_RETRIES` (1) retries.
- `StreamSink.streamModelTurn` does not forward the SDK's no-output `error` chunk downstream. The SDK rejects the result promises with the same error object, so nothing is lost. Forwarding the chunk would mark a successful retry as `errored` in the Instance AI executor, which flags a run on any error chunk.
- When the retry also fails, the unchanged `NoOutputGeneratedError` propagates as before. The user-facing message and the Sentry severity do not change.

## How to test

1. Run the new unit tests:
   ```bash
   cd packages/@n8n/agents && pnpm test src/runtime/loop/__tests__/stream-sink.test.ts
   ```
   The first test scripts a model whose first stream closes right after `stream-start` and whose second stream returns text. `callModel` returns the text and writes no `error` chunk. The second test scripts two empty streams. `callModel` rejects with `AI_NoOutputGeneratedError` after exactly two model calls.
2. Manual check (optional): point an agent or Instance AI at a model endpoint stub that returns an SSE response and closes it right after the headers on the first request, then serves a normal response. Before this PR the run fails at once. After this PR the runtime sends a second request and the run completes.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-604
- Sentry: `INSTANCE-BACKEND-27G7`

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

