### PR TITLE
fix(editor): Center modal dialogs vertically in the viewport

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/dialog.scss
+++ b/packages/frontend/@n8n/design-system/src/css/dialog.scss
@@ -35,7 +35,7 @@
 
 @include mixins.b(dialog) {
 	position: relative;
-	margin: 0 auto 50px;
+	margin: 0 auto;
 	background: var.$dialog-background-color;
 	border-radius: var(--radius--sm);
 	box-shadow: var.$dialog-box-shadow;


### PR DESCRIPTION
## Summary

Element Plus dialogs (`Modal.vue` → `ElDialog`) sat 25px above the vertical middle of the viewport. A tall dialog, such as the agent "Edit schedule" modal, touched the top edge of the browser while empty space remained below it.

Cause: `.el-dialog` in `@n8n/design-system/src/css/dialog.scss` kept `margin: 0 auto 50px` from the old top-anchored Element UI layout. The overlay now centers the dialog with flexbox (`.el-overlay-dialog { justify-content: center }`), so the centered box included the 50px bottom margin.

Fix: drop the bottom margin (`margin: 0 auto`). The flex overlay centers the dialog itself.

Measured in headless Chromium at 1440x821 with the compiled stylesheet:

| Dialog height | Before (top / bottom gap) | After |
| --- | --- | --- |
| 300px | 236px / 286px | 261px / 261px |
| 700px | 36px / 86px | 61px / 61px |
| 767px (schedule modal) | 2px / 52px | 27px / 27px |

Dialogs that reset only `margin-bottom: 0` on the dialog element (`WorkflowDiffModal`, `WorkflowHistory` compare view, `AIBuilderDiffModal`, `ExpressionEditModal`, code editor in `ParameterInput`) keep the same geometry as before. Dialogs that are taller than the viewport still clip at the top; this is pre-existing and out of scope.

## How to test

1. Open an agent that has a scheduled task and click the task to open the "Edit schedule" modal.
2. Use a browser window that is about as tall as the modal (roughly 820px).
3. Check that the modal has the same gap above and below it. Before this change it starts at the top edge.
4. Open a small dialog, for example "Delete workflow". Check that it is centered.
5. Open the workflow history compare view and the expression editor. Check that both look the same as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-826

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Pure CSS change; verified with a headless layout probe, no unit test applies. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

