### PR TITLE
fix(core): Fix flakey e2e test by awaiting debounce (no-changelog)

### DIFF
--- a/packages/testing/playwright/composables/WorkflowComposer.ts
+++ b/packages/testing/playwright/composables/WorkflowComposer.ts
@@ -119,6 +119,7 @@ export class WorkflowComposer {
 		await this.n8n.page.keyboard.press('ControlOrMeta+a');
 		await this.n8n.page.keyboard.press('Backspace');
 		await this.n8n.page.keyboard.type(projectNameOrEmail, { delay: 50 });
+		await this.n8n.resourceMoveModal.waitForDebounce();
 
 		const projectOption = this.n8n.page
 			.getByTestId('project-sharing-info')

--- a/packages/testing/playwright/pages/components/ResourceMoveModal.ts
+++ b/packages/testing/playwright/pages/components/ResourceMoveModal.ts
@@ -62,4 +62,16 @@ export class ResourceMoveModal extends FloatingUiHelper {
 	async clickConfirmMoveButton(): Promise<void> {
 		await this.getMoveConfirmButton().click();
 	}
+
+	/**
+	 * Waits for the project select's remote search to settle after typing.
+	 * The search is debounced twice — element-plus's own remote-method
+	 * debounce and this component's own search debounce, 300ms each — so up
+	 * to ~600ms can pass between the last keystroke and the option list
+	 * actually reflecting it.
+	 */
+	async waitForDebounce(): Promise<void> {
+		// eslint-disable-next-line playwright/no-wait-for-timeout
+		await this.page.waitForTimeout(800);
+	}
 }


### PR DESCRIPTION
## Summary
Fixes an issue caused by a debounce not being accounted for in an e2e test; this lead to a race condition making the test flakey. Fixed by adding a helper to wait for it to complete.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
Run the test
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-1351/flaky-test-quarantined-should-move-the-workflow-to-expected-projects
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

