### PR TITLE
fix(core): Reuse an existing consent grant after the visitor authenticates mid-flow

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
@@ -420,7 +420,7 @@ describe('runtime gate: verifyOAuthAccessToken enforces workflow:execute', () =>
 	});
 });
 
-describe('IAM-1353 repro: consent reuse on a second visit', () => {
+describe('consent reuse on a second visit', () => {
 	const pkce = async () => {
 		const { createHash, randomBytes } = await import('node:crypto');
 		const codeVerifier = randomBytes(32).toString('base64url');
@@ -483,9 +483,9 @@ describe('IAM-1353 repro: consent reuse on a second visit', () => {
 	});
 
 	test('a visitor who already consented is auto-approved after authenticating mid-flow', async () => {
-		// This is the real IAM-1353 shape: the visitor already has a UserConsent row from a
-		// prior visit (e.g. the local grant cookie was cleared/expired), but their n8n-auth
-		// cookie is gone too — so the very first /oauth/authorize hit has no cookie to check
+		// The visitor already has a UserConsent row from a prior visit (e.g. the local grant
+		// cookie was cleared/expired), but their n8n-auth cookie is gone too — so the very
+		// first /oauth/authorize hit has no cookie to check
 		// and tryAutoApproveConsent is skipped. They then log in as part of reaching the
 		// (auth-gated) consent page. GET /consent/details now retries the reuse check once
 		// the user is authenticated, instead of unconditionally returning the manual picker.

--- a/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
@@ -11,16 +11,29 @@ import { Container } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
 import { CHAT_TRIGGER_NODE_TYPE, CHAT_TRIGGER_PATH_SUFFIX, WEBHOOK_NODE_TYPE } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
+import request from 'supertest';
 
 import { createMember, createOwner } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
 
+import { AuthService } from '@/auth/auth.service';
+import { AUTH_COOKIE_NAME } from '@/constants';
 import { OAuthTokenService } from '@/modules/oauth-server/oauth-token.service';
 import { CacheService } from '@/services/cache/cache.service';
 import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
 import { UrlService } from '@/services/url.service';
 
+/** Root-level (no `/rest` prefix) agent authenticated as `user` — `authAgentFor` always
+ * prefixes `/rest`, which 404s against root-level routes like `/oauth/authorize`. */
+const rootAgentFor = (user: User) => {
+	const agent = request.agent(testServer.app);
+	const token = Container.get(AuthService).issueJWT(user, user.mfaEnabled);
+	agent.jar.setCookie(`${AUTH_COOKIE_NAME}=${token}`);
+	return agent;
+};
+
 import { OAuthClientRepository } from '../database/repositories/oauth-client.repository';
+import { UserConsentRepository } from '../database/repositories/oauth-user-consent.repository';
 
 const testServer = setupTestServer({ modules: ['oauth-server', 'mcp'], endpointGroups: ['mcp'] });
 
@@ -105,6 +118,7 @@ afterEach(async () => {
 		'RefreshToken',
 		'AuthorizationCode',
 		'OAuthClient',
+		'UserConsent',
 		'WebhookEntity',
 		'SharedWorkflow',
 		'WorkflowEntity',
@@ -403,5 +417,123 @@ describe('runtime gate: verifyOAuthAccessToken enforces workflow:execute', () =>
 		);
 
 		expect(result.user?.id).toBe(member.id);
+	});
+});
+
+describe('IAM-1353 repro: consent reuse on a second visit', () => {
+	const pkce = async () => {
+		const { createHash, randomBytes } = await import('node:crypto');
+		const codeVerifier = randomBytes(32).toString('base64url');
+		const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+		return { codeVerifier, codeChallenge };
+	};
+
+	const authorizeQuery = (resourceUrl: string, codeChallenge: string, state: string) => ({
+		client_id: resourceUrl,
+		redirect_uri: resourceUrl,
+		response_type: 'code',
+		code_challenge: codeChallenge,
+		code_challenge_method: 'S256',
+		resource: resourceUrl,
+		state,
+	});
+
+	test('a second visit reuses consent when the visitor is already logged in', async () => {
+		// Control case: confirms tryAutoApproveConsent/tryReuseConsent themselves work when
+		// the n8n-auth cookie is already present on the very first /oauth/authorize hit.
+		const path = chatPath();
+		await createPublishedChatWorkflow(path, chatTriggerNode());
+		const resourceUrl = resourceUrlFor(path);
+
+		const authAgent = rootAgentFor(owner);
+
+		const { codeChallenge: cc1 } = await pkce();
+		const first = await authAgent
+			.get('/oauth/authorize')
+			.query(authorizeQuery(resourceUrl, cc1, 'state-1'));
+		expect(first.statusCode).toBe(302);
+		expect(first.headers.location).toBe('/oauth/consent');
+
+		const rawSetCookie: string | string[] = first.headers['set-cookie'] ?? [];
+		const setCookies = Array.isArray(rawSetCookie) ? rawSetCookie : [rawSetCookie];
+		const sessionCookie = setCookies
+			.map((cookie) => cookie.split(';')[0])
+			.find((cookie) => cookie.startsWith('n8n-oauth-session='));
+		expect(sessionCookie).toBeDefined();
+
+		// `/consent/approve` lives under the `/rest` prefix, unlike the root-level
+		// `/oauth/*` routes — a separate, `/rest`-prefixed agent for the same user,
+		// carrying the session cookie the authorize step just set.
+		const consentAgent = testServer.authAgentFor(owner);
+		consentAgent.jar.setCookie(sessionCookie ?? '');
+
+		const approve = await consentAgent
+			.post('/consent/approve')
+			.send({ approved: true, scopes: [] });
+		expect(approve.statusCode).toBe(200);
+
+		const { codeChallenge: cc2 } = await pkce();
+		const second = await authAgent
+			.get('/oauth/authorize')
+			.query(authorizeQuery(resourceUrl, cc2, 'state-2'));
+
+		expect(second.statusCode).toBe(302);
+		expect(second.headers.location).not.toBe('/oauth/consent');
+		expect(second.headers.location).toContain(resourceUrl);
+	});
+
+	test('a visitor who already consented is still shown the manual approve screen when they authenticate mid-flow', async () => {
+		// This is the real IAM-1353 shape: the visitor already has a UserConsent row from a
+		// prior visit (e.g. the local grant cookie was cleared/expired), but their n8n-auth
+		// cookie is gone too — so the very first /oauth/authorize hit has no cookie to check
+		// and tryAutoApproveConsent is skipped. They then log in as part of reaching the
+		// (auth-gated) consent page. Once logged in, nothing ever re-attempts auto-approval:
+		// GET /consent/details unconditionally returns the manual approve/deny picker.
+		const path = chatPath();
+		await createPublishedChatWorkflow(path, chatTriggerNode());
+		const resourceUrl = resourceUrlFor(path);
+
+		// Seed a prior consent for this exact (clientId, user) pair, as a previous visit
+		// would have left behind.
+		await Container.get(OAuthClientRepository).upsert(
+			{
+				id: resourceUrl,
+				name: 'chat trigger',
+				redirectUris: [resourceUrl],
+				grantTypes: ['authorization_code', 'refresh_token'],
+				tokenEndpointAuthMethod: 'none',
+			},
+			['id'],
+		);
+		await Container.get(UserConsentRepository).upsert(
+			{ userId: owner.id, clientId: resourceUrl, grantedAt: Date.now(), scope: [] },
+			['userId', 'clientId'],
+		);
+
+		// Not authenticated yet on this first hit — the browser has no n8n-auth cookie.
+		const { codeChallenge } = await pkce();
+		const first = await testServer.restlessAgent
+			.get('/oauth/authorize')
+			.query(authorizeQuery(resourceUrl, codeChallenge, 'state-1'));
+		expect(first.statusCode).toBe(302);
+		expect(first.headers.location).toBe('/oauth/consent');
+
+		const rawSetCookie: string | string[] = first.headers['set-cookie'] ?? [];
+		const setCookies = Array.isArray(rawSetCookie) ? rawSetCookie : [rawSetCookie];
+		const sessionCookie = setCookies
+			.map((cookie) => cookie.split(';')[0])
+			.find((cookie) => cookie.startsWith('n8n-oauth-session='));
+		expect(sessionCookie).toBeDefined();
+
+		// The visitor now logs in (this is the "just logged in" step from the ticket),
+		// carrying the same in-flight OAuth session cookie into the authenticated request.
+		const consentAgent = testServer.authAgentFor(owner);
+		consentAgent.jar.setCookie(sessionCookie ?? '');
+
+		const details = await consentAgent.get('/consent/details');
+
+		// Desired: already consented, so this should signal auto-approval instead of
+		// requiring another manual click.
+		expect(details.body.data?.autoApproved ?? false).toBe(true);
 	});
 });

--- a/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/chat-trigger-resource.resolver.api.test.ts
@@ -482,13 +482,13 @@ describe('IAM-1353 repro: consent reuse on a second visit', () => {
 		expect(second.headers.location).toContain(resourceUrl);
 	});
 
-	test('a visitor who already consented is still shown the manual approve screen when they authenticate mid-flow', async () => {
+	test('a visitor who already consented is auto-approved after authenticating mid-flow', async () => {
 		// This is the real IAM-1353 shape: the visitor already has a UserConsent row from a
 		// prior visit (e.g. the local grant cookie was cleared/expired), but their n8n-auth
 		// cookie is gone too — so the very first /oauth/authorize hit has no cookie to check
 		// and tryAutoApproveConsent is skipped. They then log in as part of reaching the
-		// (auth-gated) consent page. Once logged in, nothing ever re-attempts auto-approval:
-		// GET /consent/details unconditionally returns the manual approve/deny picker.
+		// (auth-gated) consent page. GET /consent/details now retries the reuse check once
+		// the user is authenticated, instead of unconditionally returning the manual picker.
 		const path = chatPath();
 		await createPublishedChatWorkflow(path, chatTriggerNode());
 		const resourceUrl = resourceUrlFor(path);

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
@@ -89,6 +89,7 @@ describe('OAuthConsentService', () => {
 
 			expect(result).toEqual({
 				ok: true,
+				autoApproved: false,
 				clientName: 'Test Client',
 				clientId: 'client-123',
 				redirectUri: 'https://example.com/callback',
@@ -176,6 +177,7 @@ describe('OAuthConsentService', () => {
 
 			expect(result).toEqual({
 				ok: true,
+				autoApproved: false,
 				clientName: 'Test Client',
 				clientId: 'client-123',
 				redirectUri: 'https://example.com/callback',
@@ -284,6 +286,7 @@ describe('OAuthConsentService', () => {
 
 			expect(result).toEqual({
 				ok: true,
+				autoApproved: false,
 				clientName: 'Test Client',
 				clientId: 'client-123',
 				resourceName: 'My Workflow',
@@ -325,6 +328,7 @@ describe('OAuthConsentService', () => {
 
 			expect(result).toEqual({
 				ok: true,
+				autoApproved: false,
 				clientName: 'Test Client',
 				clientId: 'client-123',
 				resourceName: undefined,

--- a/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
@@ -44,6 +44,18 @@ export class OAuthConsentController {
 				return;
 			}
 
+			if (consentDetails.autoApproved) {
+				// The session's decision is already made — consume it, same as a manual approval.
+				this.oauthSessionService.clearSession(res);
+				res.json({
+					data: {
+						autoApproved: true,
+						redirectUrl: consentDetails.redirectUrl,
+					},
+				});
+				return;
+			}
+
 			res.json({
 				data: {
 					clientName: consentDetails.clientName,

--- a/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
@@ -51,6 +51,7 @@ export class OAuthConsentController {
 					data: {
 						autoApproved: true,
 						redirectUrl: consentDetails.redirectUrl,
+						uiHints: consentDetails.uiHints,
 					},
 				});
 				return;

--- a/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
@@ -17,7 +17,13 @@ import {
 import { UrlService } from '@/services/url.service';
 
 type ConsentDetailsResult =
-	| { ok: true; autoApproved: true; redirectUrl: string }
+	| {
+			ok: true;
+			autoApproved: true;
+			redirectUrl: string;
+			/** Presentational hints for the header icon while the redirect happens. */
+			uiHints?: ConsentUiHints;
+	  }
 	| {
 			ok: true;
 			autoApproved: false;
@@ -90,7 +96,12 @@ export class OAuthConsentService {
 				// resolver's DB-backed lookup twice.
 				const reuse = await this.tryReuseConsent(user, sessionPayload, resource);
 				if (reuse) {
-					return { ok: true, autoApproved: true, redirectUrl: reuse.redirectUrl };
+					return {
+						ok: true,
+						autoApproved: true,
+						redirectUrl: reuse.redirectUrl,
+						uiHints: resource.uiHints,
+					};
 				}
 
 				if (!(await resource.authorize(user)))

--- a/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
@@ -75,11 +75,6 @@ export class OAuthConsentService {
 				return null;
 			}
 
-			const reuse = await this.tryReuseConsent(user, sessionPayload);
-			if (reuse) {
-				return { ok: true, autoApproved: true, redirectUrl: reuse.redirectUrl };
-			}
-
 			if (sessionPayload.resource) {
 				const resource = await this.protectedResourceRegistry.getByResourceUrl(
 					sessionPayload.resource,
@@ -87,6 +82,15 @@ export class OAuthConsentService {
 
 				if (!resource) {
 					return { ok: false, reason: 'resource_unavailable' };
+				}
+
+				// Resolved once above and threaded through, so a first-time consent (the
+				// common case here — a prior consent already short-circuits via
+				// tryAutoApproveConsent at /oauth/authorize) doesn't pay for the resource
+				// resolver's DB-backed lookup twice.
+				const reuse = await this.tryReuseConsent(user, sessionPayload, resource);
+				if (reuse) {
+					return { ok: true, autoApproved: true, redirectUrl: reuse.redirectUrl };
 				}
 
 				if (!(await resource.authorize(user)))
@@ -321,13 +325,20 @@ export class OAuthConsentService {
 		return scopes;
 	}
 
+	/**
+	 * @param resolvedResource The caller's own resolution of `sessionPayload.resource`,
+	 * when it already has one — skips resolving it again here.
+	 */
 	async tryReuseConsent(
 		user: User,
 		sessionPayload: OAuthSessionPayload,
+		resolvedResource?: ProtectedResource,
 	): Promise<{ redirectUrl: string } | null> {
 		if (!sessionPayload.resource) return null;
 
-		const resource = await this.protectedResourceRegistry.getByResourceUrl(sessionPayload.resource);
+		const resource =
+			resolvedResource ??
+			(await this.protectedResourceRegistry.getByResourceUrl(sessionPayload.resource));
 		if (!resource?.isFirstParty) return null;
 
 		const consent = await this.userConsentRepository.findOne({

--- a/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
@@ -17,8 +17,10 @@ import {
 import { UrlService } from '@/services/url.service';
 
 type ConsentDetailsResult =
+	| { ok: true; autoApproved: true; redirectUrl: string }
 	| {
 			ok: true;
+			autoApproved: false;
 			clientName: string;
 			clientId: string;
 			resourceName?: string;
@@ -73,6 +75,11 @@ export class OAuthConsentService {
 				return null;
 			}
 
+			const reuse = await this.tryReuseConsent(user, sessionPayload);
+			if (reuse) {
+				return { ok: true, autoApproved: true, redirectUrl: reuse.redirectUrl };
+			}
+
 			if (sessionPayload.resource) {
 				const resource = await this.protectedResourceRegistry.getByResourceUrl(
 					sessionPayload.resource,
@@ -92,6 +99,7 @@ export class OAuthConsentService {
 
 				return {
 					ok: true,
+					autoApproved: false,
 					clientName: client.name,
 					clientId: client.id,
 					resourceName: resource.displayName,
@@ -117,6 +125,7 @@ export class OAuthConsentService {
 
 			return {
 				ok: true,
+				autoApproved: false,
 				clientName: client.name,
 				clientId: client.id,
 				redirectUri: sessionPayload.redirectUri,

--- a/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
@@ -32,6 +32,8 @@ export type ConsentDetails =
 			 */
 			autoApproved: true;
 			redirectUrl: string;
+			/** Presentation hints from the resource, used for the header icon while redirecting. */
+			uiHints?: ConsentUiHints;
 	  }
 	| ({ autoApproved?: false } & ConsentDetailsPicker);
 

--- a/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
@@ -4,6 +4,13 @@ import type { IRestApiContext } from '../types';
 import { makeRestApiRequest } from '../utils';
 
 export interface ConsentDetails {
+	/**
+	 * Set when a prior consent already covers this request — e.g. the visitor only
+	 * authenticated as part of reaching this page. `redirectUrl` is then the only other
+	 * field present: there is nothing left to show a picker for.
+	 */
+	autoApproved?: boolean;
+	redirectUrl?: string;
 	clientName: string;
 	clientId: string;
 	redirectUri?: string;

--- a/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
@@ -3,14 +3,7 @@ import type { ConsentUiHints } from '@n8n/api-types';
 import type { IRestApiContext } from '../types';
 import { makeRestApiRequest } from '../utils';
 
-export interface ConsentDetails {
-	/**
-	 * Set when a prior consent already covers this request — e.g. the visitor only
-	 * authenticated as part of reaching this page. `redirectUrl` is then the only other
-	 * field present: there is nothing left to show a picker for.
-	 */
-	autoApproved?: boolean;
-	redirectUrl?: string;
+export interface ConsentDetailsPicker {
 	clientName: string;
 	clientId: string;
 	redirectUri?: string;
@@ -29,6 +22,18 @@ export interface ConsentDetails {
 	/** True only for first-party clients (e.g. form triggers) that skip the trust gate. */
 	isFirstParty?: boolean;
 }
+
+export type ConsentDetails =
+	| {
+			/**
+			 * A prior consent already covers this request — e.g. the visitor only
+			 * authenticated as part of reaching this page. There is nothing left to
+			 * show a picker for.
+			 */
+			autoApproved: true;
+			redirectUrl: string;
+	  }
+	| ({ autoApproved?: false } & ConsentDetailsPicker);
 
 export interface ConsentApprovalResponse {
 	status: string;

--- a/packages/frontend/editor-ui/src/app/stores/consent.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/consent.store.test.ts
@@ -1,0 +1,96 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useConsentStore } from './consent.store';
+import { ResponseError } from '@n8n/rest-api-client/utils';
+
+const { getConsentDetails, approveConsent } = vi.hoisted(() => ({
+	getConsentDetails: vi.fn(),
+	approveConsent: vi.fn(),
+}));
+
+vi.mock('@n8n/rest-api-client/api/consent', () => ({
+	getConsentDetails,
+	approveConsent,
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: vi.fn(() => ({
+		restApiContext: { baseUrl: 'http://localhost:5678', pushRef: 'test' },
+	})),
+}));
+
+describe('useConsentStore', () => {
+	let consentStore: ReturnType<typeof useConsentStore>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setActivePinia(createPinia());
+		consentStore = useConsentStore();
+	});
+
+	it('stores the resolved details and clears loading', async () => {
+		const details = { clientName: 'Test Client', clientId: 'client-1', scopes: [] };
+		getConsentDetails.mockResolvedValue(details);
+
+		const result = await consentStore.fetchConsentDetails();
+
+		expect(result).toEqual(details);
+		expect(consentStore.consentDetails).toEqual(details);
+		expect(consentStore.isLoading).toBe(false);
+	});
+
+	it('sets a resource_unavailable error code on a 422', async () => {
+		getConsentDetails.mockRejectedValue(new ResponseError('gone', { httpStatusCode: 422 }));
+
+		await expect(consentStore.fetchConsentDetails()).rejects.toThrow('gone');
+
+		expect(consentStore.errorCode).toBe('resource_unavailable');
+		expect(consentStore.error).toBe('gone');
+		expect(consentStore.isLoading).toBe(false);
+	});
+
+	// A component that abandons one fetch (e.g. it re-fetches, or a fresh mount starts
+	// its own call) must not have its result overwritten by the earlier, now-stale one
+	// resolving later — regardless of which settles first.
+	it('ignores a stale call that resolves after a newer one', async () => {
+		let resolveStale!: (value: unknown) => void;
+		getConsentDetails.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveStale = resolve;
+			}),
+		);
+		const staleCall = consentStore.fetchConsentDetails();
+
+		const freshDetails = { clientName: 'Fresh Client', clientId: 'client-2', scopes: [] };
+		getConsentDetails.mockResolvedValueOnce(freshDetails);
+		await consentStore.fetchConsentDetails();
+
+		expect(consentStore.consentDetails).toEqual(freshDetails);
+
+		resolveStale({ clientName: 'Stale Client', clientId: 'client-1', scopes: [] });
+		await staleCall;
+
+		expect(consentStore.consentDetails).toEqual(freshDetails);
+	});
+
+	it('ignores a stale call failing after a newer one succeeded', async () => {
+		let rejectStale!: (reason: unknown) => void;
+		getConsentDetails.mockReturnValueOnce(
+			new Promise((_resolve, reject) => {
+				rejectStale = reject;
+			}),
+		);
+		const staleCall = consentStore.fetchConsentDetails().catch(() => {});
+
+		const freshDetails = { clientName: 'Fresh Client', clientId: 'client-2', scopes: [] };
+		getConsentDetails.mockResolvedValueOnce(freshDetails);
+		await consentStore.fetchConsentDetails();
+
+		rejectStale(new Error('stale failure'));
+		await staleCall;
+
+		expect(consentStore.consentDetails).toEqual(freshDetails);
+		expect(consentStore.error).toBeNull();
+		expect(consentStore.isLoading).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/consent.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/consent.store.ts
@@ -15,24 +15,36 @@ export const useConsentStore = defineStore(STORES.CONSENT, () => {
 
 	const rootStore = useRootStore();
 
+	// Guards against a stale call's response overwriting a newer call's, if two are
+	// ever in flight at once — each call only writes shared state while it's still
+	// the most recently issued one.
+	let latestRequestId = 0;
+
 	const fetchConsentDetails = async () => {
+		const requestId = ++latestRequestId;
 		isLoading.value = true;
 		error.value = null;
 		errorCode.value = null;
 
 		try {
-			consentDetails.value = await consentApi.getConsentDetails(rootStore.restApiContext);
+			const response = await consentApi.getConsentDetails(rootStore.restApiContext);
+			if (requestId !== latestRequestId) return consentDetails.value;
+			consentDetails.value = response;
 			return consentDetails.value;
 		} catch (err) {
-			if (err instanceof ResponseError && err.httpStatusCode === 422) {
-				errorCode.value = 'resource_unavailable';
-			} else if (err instanceof ResponseError && err.httpStatusCode === 403) {
-				errorCode.value = 'forbidden';
+			if (requestId === latestRequestId) {
+				if (err instanceof ResponseError && err.httpStatusCode === 422) {
+					errorCode.value = 'resource_unavailable';
+				} else if (err instanceof ResponseError && err.httpStatusCode === 403) {
+					errorCode.value = 'forbidden';
+				}
+				error.value = err instanceof Error ? err.message : 'Failed to load consent details';
 			}
-			error.value = err instanceof Error ? err.message : 'Failed to load consent details';
 			throw err;
 		} finally {
-			isLoading.value = false;
+			if (requestId === latestRequestId) {
+				isLoading.value = false;
+			}
 		}
 	};
 

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
@@ -5,6 +5,7 @@ import OAuthConsentView from '@/app/views/OAuthConsentView.vue';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import { within } from '@testing-library/vue';
+import { nextTick } from 'vue';
 
 vi.mock('@n8n/rest-api-client/api/consent');
 
@@ -117,6 +118,64 @@ describe('OAuthConsentView', () => {
 		// A rejected request must not present the broad instance permission grant.
 		expect(queryByText('Test MCP Client wants access to your n8n instance')).toBeNull();
 		expect(queryByText('Get a list of your workflows')).toBeNull();
+	});
+
+	it('should redirect immediately without showing the picker or a success message when the server auto-approves', async () => {
+		// The visitor never clicked anything here — a "success" message would be
+		// confusing for something they didn't consciously trigger, so this must render
+		// the same blank state as the initial fetch, not the manual-approve success screen.
+		const redirectUrl = 'https://legitimate-client.com/callback?code=reused';
+		consentStore.fetchConsentDetails.mockResolvedValue({
+			autoApproved: true,
+			redirectUrl,
+		} as never);
+
+		const { queryByTestId, getByTestId } = renderComponent();
+		await waitAllPromises();
+
+		expect(consentStore.approveConsent).not.toHaveBeenCalled();
+		expect(queryByTestId('consent-allow-button')).toBeNull();
+		expect(queryByTestId('consent-deny-button')).toBeNull();
+		expect(queryByTestId('consent-success-screen')).toBeNull();
+		expect(getByTestId('consent-loading')).toBeVisible();
+		expect(window.location.href).toBe(redirectUrl);
+	});
+
+	it('should not flash the generic instance-wide picker while the details fetch is pending', async () => {
+		// Before the fetch resolves, `consentDetails` is still null (its initial state,
+		// and its value on a fetch error too), so the template must not fall through to
+		// the generic/default-resource copy — that's not known to be correct yet.
+		consentStore.consentDetails = null;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let resolveFetch!: (value: any) => void;
+		consentStore.fetchConsentDetails.mockImplementation(
+			async () =>
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				await new Promise<any>((resolve) => {
+					resolveFetch = resolve;
+				}),
+		);
+
+		const { queryByTestId, getByTestId, queryByText } = renderComponent();
+		await nextTick();
+
+		expect(queryByTestId('consent-content')).toBeNull();
+		expect(queryByText('Test MCP Client wants access to your n8n instance')).toBeNull();
+		expect(getByTestId('consent-loading')).toBeVisible();
+
+		// The real store assigns `consentDetails` as part of resolving the fetch;
+		// mirror that so the template's store-bound `clientDetails` picks it up too.
+		const resolvedDetails = {
+			clientName: 'Test MCP Client',
+			clientId: 'test-client-id',
+			scopes: [],
+		};
+		consentStore.consentDetails = resolvedDetails;
+		resolveFetch(resolvedDetails);
+		await waitAllPromises();
+
+		expect(queryByTestId('consent-loading')).toBeNull();
+		expect(getByTestId('consent-content')).toBeVisible();
 	});
 
 	it('should redirect to home page when deny is clicked', async () => {

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -63,6 +63,7 @@ const clientDetails = computed<ConsentDetailsPicker | null>(() => {
 	return details && !details.autoApproved ? details : null;
 });
 const resourceName = computed(() => clientDetails.value?.resourceName);
+const uiHints = computed(() => consentStore.consentDetails?.uiHints);
 // Known clients get their brand mark on the left tile; unknown ones fall back to the MCP glyph.
 const clientBrandIcon = computed(() => getClientBrand(clientDetails.value?.clientName ?? '').icon);
 // Localized noun for first-party copy, driven by the resource's consentType hint.
@@ -178,18 +179,13 @@ onMounted(async () => {
 		<div :class="$style['consent-dialog']">
 			<header :class="$style.header">
 				<div :class="$style.logo">
-					<N8nIcon
-						v-if="clientDetails?.uiHints?.icon"
-						:icon="clientDetails.uiHints.icon"
-						size="large"
-						color="text-dark"
-					/>
+					<N8nIcon v-if="uiHints?.icon" :icon="uiHints.icon" size="large" color="text-dark" />
 					<component
 						:is="clientBrandIcon"
 						v-else-if="clientBrandIcon"
 						:class="$style['brand-icon']"
 					/>
-					<N8nIcon v-else icon="mcp" size="large" color="text-dark" />
+					<N8nIcon v-else-if="detailsResolved || error" icon="mcp" size="large" color="text-dark" />
 				</div>
 				<!-- Pending-connection connector: a dashed SVG line marching toward the n8n tile
 				     with a slow muted spinner badge. Decorative. -->

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -3,7 +3,7 @@ import { useConsentStore } from '@/app/stores/consent.store';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useI18n } from '@n8n/i18n';
 import type { BaseTextKey } from '@n8n/i18n';
-import { onMounted, computed, ref, watch } from 'vue';
+import { onMounted, onUnmounted, computed, ref, watch } from 'vue';
 import type { ConsentDetailsPicker } from '@n8n/rest-api-client/api/consent';
 import {
 	N8nButton,
@@ -35,8 +35,14 @@ const waitingForRedirect = ref(false);
 // the visitor never clicked anything here, so a "success" message would be confusing —
 // this renders the same blank state as the initial fetch, not a message that then flashes.
 const autoApprovedRedirect = ref(false);
+const detailsResolved = ref(false);
 const redirectUriTrusted = ref(false);
 const selectedScopes = ref<string[]>([]);
+
+let isActive = true;
+onUnmounted(() => {
+	isActive = false;
+});
 
 const error = computed(() => consentStore.error);
 const loading = computed(() => consentStore.isLoading);
@@ -149,6 +155,8 @@ onMounted(async () => {
 	documentTitle.set(i18n.baseText('oauth.consentView.title'));
 	try {
 		const details = await consentStore.fetchConsentDetails();
+		if (!isActive) return;
+		detailsResolved.value = true;
 		if (details?.autoApproved && details.redirectUrl) {
 			autoApprovedRedirect.value = true;
 			window.location.href = details.redirectUrl;
@@ -159,6 +167,7 @@ onMounted(async () => {
 			available_scopes_count: availableScopes.value.length,
 		});
 	} catch (err) {
+		if (!isActive) return;
 		toast.showError(err, i18n.baseText('oauth.consentView.error.fetchDetails'));
 	}
 });
@@ -232,7 +241,7 @@ onMounted(async () => {
 				the visitor didn't ask for — the header's own connector spinner already
 				signals activity while this redirects. -->
 			<div
-				v-else-if="autoApprovedRedirect || !clientDetails"
+				v-else-if="autoApprovedRedirect || !detailsResolved"
 				:class="$style.content"
 				data-test-id="consent-loading"
 			/>
@@ -309,7 +318,7 @@ onMounted(async () => {
 				</div>
 			</div>
 			<footer
-				v-if="!waitingForRedirect && !autoApprovedRedirect && (error || clientDetails)"
+				v-if="!waitingForRedirect && !autoApprovedRedirect && (error || detailsResolved)"
 				:class="$style.footer"
 			>
 				<!-- Third-party clients: the redirect destination, with the trust acknowledgment

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -31,6 +31,10 @@ const telemetry = useTelemetry();
 
 // Success state:
 const waitingForRedirect = ref(false);
+// Set instead of `waitingForRedirect` when the server silently reused a prior consent:
+// the visitor never clicked anything here, so a "success" message would be confusing —
+// this renders the same blank state as the initial fetch, not a message that then flashes.
+const autoApprovedRedirect = ref(false);
 const redirectUriTrusted = ref(false);
 const selectedScopes = ref<string[]>([]);
 
@@ -139,7 +143,12 @@ const handleClose = () => {
 onMounted(async () => {
 	documentTitle.set(i18n.baseText('oauth.consentView.title'));
 	try {
-		await consentStore.fetchConsentDetails();
+		const details = await consentStore.fetchConsentDetails();
+		if (details?.autoApproved && details.redirectUrl) {
+			autoApprovedRedirect.value = true;
+			window.location.href = details.redirectUrl;
+			return;
+		}
 		telemetry.track('User viewed MCP consent screen', {
 			client_name: clientDetails.value?.clientName,
 			available_scopes_count: availableScopes.value.length,
@@ -213,6 +222,15 @@ onMounted(async () => {
 					:content="errorMessage ?? ''"
 				></N8nNotice>
 			</div>
+			<!-- Nothing resolved yet, or the server just silently reused a prior consent:
+				never guess at generic instance-wide copy, and never announce a "success"
+				the visitor didn't ask for — the header's own connector spinner already
+				signals activity while this redirects. -->
+			<div
+				v-else-if="autoApprovedRedirect || !clientDetails"
+				:class="$style.content"
+				data-test-id="consent-loading"
+			/>
 			<!-- Default content -->
 			<div v-else :class="$style.content" data-test-id="consent-content">
 				<N8nHeading v-if="clientDetails?.isFirstParty" tag="h2" size="large" :bold="true">
@@ -285,7 +303,7 @@ onMounted(async () => {
 					</ul>
 				</div>
 			</div>
-			<footer v-if="!waitingForRedirect" :class="$style.footer">
+			<footer v-if="!waitingForRedirect && !autoApprovedRedirect" :class="$style.footer">
 				<!-- Third-party clients: the redirect destination, with the trust acknowledgment
 				     below it in the action row so it reads as a step rather than banner small
 				     print. Both are gated on the same `trustRequired` as the Allow button, so the

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -4,7 +4,7 @@ import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useI18n } from '@n8n/i18n';
 import type { BaseTextKey } from '@n8n/i18n';
 import { onMounted, computed, ref, watch } from 'vue';
-import type { ConsentDetails } from '@n8n/rest-api-client/api/consent';
+import type { ConsentDetailsPicker } from '@n8n/rest-api-client/api/consent';
 import {
 	N8nButton,
 	N8nCallout,
@@ -40,7 +40,6 @@ const selectedScopes = ref<string[]>([]);
 
 const error = computed(() => consentStore.error);
 const loading = computed(() => consentStore.isLoading);
-const resourceName = computed(() => consentStore.consentDetails?.resourceName);
 
 const errorMessage = computed(() => {
 	if (consentStore.errorCode === 'resource_unavailable') {
@@ -51,7 +50,13 @@ const errorMessage = computed(() => {
 	return consentStore.error;
 });
 
-const clientDetails = computed<ConsentDetails | null>(() => consentStore.consentDetails);
+// Narrows away the auto-approved redirect signal, which carries none of these fields
+// and is handled separately in `onMounted` before this is ever read.
+const clientDetails = computed<ConsentDetailsPicker | null>(() => {
+	const details = consentStore.consentDetails;
+	return details && !details.autoApproved ? details : null;
+});
+const resourceName = computed(() => clientDetails.value?.resourceName);
 // Known clients get their brand mark on the left tile; unknown ones fall back to the MCP glyph.
 const clientBrandIcon = computed(() => getClientBrand(clientDetails.value?.clientName ?? '').icon);
 // Localized noun for first-party copy, driven by the resource's consentType hint.
@@ -303,7 +308,10 @@ onMounted(async () => {
 					</ul>
 				</div>
 			</div>
-			<footer v-if="!waitingForRedirect && !autoApprovedRedirect" :class="$style.footer">
+			<footer
+				v-if="!waitingForRedirect && !autoApprovedRedirect && (error || clientDetails)"
+				:class="$style.footer"
+			>
 				<!-- Third-party clients: the redirect destination, with the trust acknowledgment
 				     below it in the action row so it reads as a step rather than banner small
 				     print. Both are gated on the same `trustRequired` as the Allow button, so the


### PR DESCRIPTION
## Summary

Chat Trigger (and Form Trigger) with n8n User Auth repeatedly showed the OAuth consent screen for the same user, even with a prior consent already on file.

`tryAutoApproveConsent` only ran once, at the very first `/oauth/authorize` hit - before the visitor was known to be authenticated. A visitor who wasn't logged in yet at that exact moment, and only authenticated as part of
reaching the (auth-gated) `/oauth/consent` page, never got a second chance to have their prior consent reused. `OAuthConsentController.getConsentDetails` unconditionally rendered the manual approve/deny picker, even when a matching `UserConsent` row already existed.

Fix: `OAuthConsentService.getConsentDetails` retries the reuse check once the user is authenticated, and returns an `autoApproved`/`redirectUrl` signal when it succeeds. The frontend follows that redirect immediately instead of
rendering the picker, and shows a neutral blank state (no generic or
"success" copy) while it does.

## How to test

1. Create a Chat Trigger (or Form Trigger) workflow with **Authentication →
   n8n User Auth**, activate it, and open its production URL in a fresh
   session.
2. Log in and approve the consent screen once.
3. Clear cookies (or open a fresh private window) and revisit the same URL.
4. Log in again - before this fix, you'd see the manual approve screen again;
   after this fix, it redirects straight through with a brief blank state,
   no picker and no "Access granted" flash.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1353

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

