### PR TITLE
ci: Add post-checkout hook to inform about pnpm 12

### DIFF
--- a/.githooks/check-pnpm.sh
+++ b/.githooks/check-pnpm.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# .githooks/check-pnpm — symlink or call from post-merge, post-rewrite, post-checkout
+
+WANTED=$(sed -n 's/.*"packageManager": *"pnpm@\([0-9]*\).*/\1/p' package.json)
+CURRENT=$(pnpm --version 2>/dev/null | cut -d. -f1)
+[ -z "$WANTED" ] || [ "$WANTED" = "$CURRENT" ] && exit 0
+echo ""
+echo "⚠ This repo now pins pnpm $WANTED (you have ${CURRENT:-none})."
+echo "  pnpm should auto-download it on the next command."
+echo "  If that fails (pnpm 10 can't install v12), reinstall:"
+echo "    curl -fsSL https://get.pnpm.io/install.sh | sh -"
+echo ""
+exit 0

--- a/.githooks/check-pnpm.sh
+++ b/.githooks/check-pnpm.sh
@@ -2,7 +2,7 @@
 # .githooks/check-pnpm — symlink or call from post-merge, post-rewrite, post-checkout
 
 WANTED=$(sed -n 's/.*"packageManager": *"pnpm@\([0-9]*\).*/\1/p' package.json)
-CURRENT=$(pnpm --version 2>/dev/null | cut -d. -f1)
+CURRENT=$(cd ~ && pnpm --version 2>/dev/null | cut -d. -f1)
 [ -z "$WANTED" ] || [ "$WANTED" = "$CURRENT" ] && exit 0
 echo ""
 echo "⚠ This repo now pins pnpm $WANTED (you have ${CURRENT:-none})."

--- a/.githooks/check-pnpm.sh
+++ b/.githooks/check-pnpm.sh
@@ -6,8 +6,8 @@ CURRENT=$(cd ~ && pnpm --version 2>/dev/null | cut -d. -f1)
 [ -z "$WANTED" ] || [ "$WANTED" = "$CURRENT" ] && exit 0
 echo ""
 echo "⚠ This repo now pins pnpm $WANTED (you have ${CURRENT:-none})."
-echo "  pnpm should auto-download it on the next command."
-echo "  If that fails (pnpm 10 can't install v12), reinstall:"
+echo "  pnpm should auto-download it on the next install command."
+echo "  If that fails (some pnpm 10 versions can't install v12), reinstall:"
 echo "    curl -fsSL https://get.pnpm.io/install.sh | sh -"
 echo ""
 exit 0

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-# npmrc is only read by <v10 pnpm installations. We can safely have this here as
-# many of the <v10 versions can't switch to pnpm 12 anyways so we want to
-# have a custom error here.
-package-manager-strict-version=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
-# https://github.com/pnpm/pnpm/issues/7024
+# npmrc is only read by <v10 pnpm installations. We can safely have this here as
+# many of the <v10 versions can't switch to pnpm 12 anyways so we want to
+# have a custom error here.
+package-manager-strict-version=true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,19 @@
+post-merge:
+  commands:
+    check-pnpm:
+      run: sh .githooks/check-pnpm.sh
+
+post-rewrite:
+  commands:
+    check-pnpm:
+      run: sh .githooks/check-pnpm.sh
+
+post-checkout:
+  commands:
+    check-pnpm:
+      # $3 is 1 for a branch checkout, 0 for a file checkout — skip the latter
+      run: '[ "{3}" = "0" ] || sh .githooks/check-pnpm.sh'
+
 pre-commit:
   commands:
     biome_check:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,7 @@
+output:
+  - execution_out
+  - failure
+
 pre-commit:
   commands:
     biome_check:


### PR DESCRIPTION
## Summary

When user is on other that pnpm 12: 

<img width="787" height="244" alt="image" src="https://github.com/user-attachments/assets/5eed03c9-3681-4b92-8e81-e22abf567d3f" />

When user is on pnpm 12

<img width="758" height="127" alt="image" src="https://github.com/user-attachments/assets/f5123002-a460-4526-8ea3-597f268da2f8" />

## How to test

Git switch to this PR branch, git switch back, rinse and repeat

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

