### PR TITLE
feat(core): Add a suggested migration for Execute Sub-workflow each mode (no-changelog)

### DIFF
--- a/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.migration.service.test.ts
+++ b/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.migration.service.test.ts
@@ -20,6 +20,7 @@ import {
 	AiTransformDeprecatedRule,
 	AI_TRANSFORM_NODE_TYPE,
 } from '../rules/v3/ai-transform-deprecated.rule';
+import { ExecuteWorkflowEachModeRule } from '../rules/v3/execute-workflow-each-mode.rule';
 import { createNode } from './test-helpers';
 
 describe('BreakingChangeMigrationService', () => {
@@ -233,5 +234,73 @@ describe('BreakingChangeMigrationService', () => {
 		const result = await service.migrateWorkflow(RULE_ID, 'wf-1', user);
 
 		expect(result.republishable).toBe(false);
+	});
+
+	describe('workflow-level migrations', () => {
+		const EACH_RULE_ID = 'execute-workflow-each-mode-v3';
+		const EXECUTE_WORKFLOW = 'n8n-nodes-base.executeWorkflow';
+
+		beforeEach(() => {
+			ruleRegistry.registerAll([new ExecuteWorkflowEachModeRule()]);
+		});
+
+		it('saves the nodes and connections the migration returns and validates the new graph', async () => {
+			const trigger = createNode('Trigger', 'n8n-nodes-base.scheduleTrigger');
+			const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+			// A plain object rather than mock<WorkflowEntity>: the migration deep-copies
+			// `connections`, and the deep mock proxy turns that copy into garbage.
+			const workflow = {
+				id: 'wf-1',
+				name: 'My WF',
+				nodes: [trigger, sub],
+				versionId: 'v1',
+				activeVersionId: 'v1',
+				connections: { Trigger: { main: [[{ node: 'Sub', type: 'main', index: 0 }]] } },
+			} as unknown as WorkflowEntity;
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(workflow);
+			workflowService.update.mockResolvedValue(mock<WorkflowEntity>({ versionId: 'new-version' }));
+			workflowValidationService.validateForActivation.mockReturnValue({ isValid: true });
+
+			const result = await service.migrateWorkflow(EACH_RULE_ID, 'wf-1', user);
+
+			expect(result).toEqual({
+				workflowId: 'wf-1',
+				newVersionId: 'new-version',
+				migratedNodeIds: [sub.id],
+				unmapped: [],
+				notes: [],
+				republishable: true,
+			});
+
+			const [, updateData] = workflowService.update.mock.calls[0];
+			expect(updateData.nodes.map((n) => n.name)).toEqual(['Trigger', 'Loop Over Items', 'Sub']);
+			expect(updateData.connections).toEqual({
+				Trigger: { main: [[{ node: 'Loop Over Items', type: 'main', index: 0 }]] },
+				'Loop Over Items': { main: [[], [{ node: 'Sub', type: 'main', index: 0 }]] },
+				Sub: { main: [[{ node: 'Loop Over Items', type: 'main', index: 0 }]] },
+			});
+			// The rewired graph, not the original one, is what gets validated for re-publish.
+			expect(workflowValidationService.validateForActivation).toHaveBeenCalledWith(
+				expect.objectContaining({ 'Loop Over Items': expect.anything() }),
+				updateData.connections,
+				nodeTypes,
+			);
+		});
+
+		it('surfaces a migration failure as a bad request without saving', async () => {
+			const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(buildWorkflow([sub]));
+			vi.spyOn(migrationRegistry, 'get').mockReturnValue({
+				ruleId: EACH_RULE_ID,
+				migrateWorkflow: () => {
+					throw new Error('cannot rewire');
+				},
+			});
+
+			await expect(service.migrateWorkflow(EACH_RULE_ID, 'wf-1', user)).rejects.toThrow(
+				'cannot rewire',
+			);
+			expect(workflowService.update).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.migration.service.test.ts
+++ b/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.migration.service.test.ts
@@ -162,6 +162,25 @@ describe('BreakingChangeMigrationService', () => {
 		expect(updateData.nodes.find((n) => n.id === otherNode.id)).toEqual(otherNode);
 	});
 
+	it('keeps the connections of a node-for-node migration intact', async () => {
+		const aiNode = createNode('Transform', AI_TRANSFORM_NODE_TYPE, { jsCode: 'return items;' });
+		const connections = { Transform: { main: [[{ node: 'End', type: 'main', index: 0 }]] } };
+		// A plain object so the connections reach the service as real data, not a deep mock.
+		const workflow = {
+			id: 'wf-1',
+			name: 'My WF',
+			nodes: [aiNode, createNode('End', 'n8n-nodes-base.noOp')],
+			connections: structuredClone(connections),
+		} as unknown as WorkflowEntity;
+		workflowFinderService.findWorkflowForUser.mockResolvedValue(workflow);
+		workflowService.update.mockResolvedValue(mock<WorkflowEntity>({ versionId: 'new-version' }));
+
+		await service.migrateWorkflow(RULE_ID, 'wf-1', user);
+
+		const [, updateData] = workflowService.update.mock.calls[0];
+		expect(updateData.connections).toEqual(connections);
+	});
+
 	it('marks a clean migration republishable when the published version was migrated and it validates', async () => {
 		const aiNode = createNode('Transform', AI_TRANSFORM_NODE_TYPE, { jsCode: 'return items;' });
 		// Published version == the version being migrated.
@@ -273,11 +292,22 @@ describe('BreakingChangeMigrationService', () => {
 			});
 
 			const [, updateData] = workflowService.update.mock.calls[0];
-			expect(updateData.nodes.map((n) => n.name)).toEqual(['Trigger', 'Loop Over Items', 'Sub']);
+			expect(updateData.nodes.map((n) => n.name)).toEqual([
+				'Trigger',
+				'Loop Over Items',
+				'Drop empty results',
+				'Sub',
+			]);
 			expect(updateData.connections).toEqual({
 				Trigger: { main: [[{ node: 'Loop Over Items', type: 'main', index: 0 }]] },
-				'Loop Over Items': { main: [[], [{ node: 'Sub', type: 'main', index: 0 }]] },
+				'Loop Over Items': {
+					main: [
+						[{ node: 'Drop empty results', type: 'main', index: 0 }],
+						[{ node: 'Sub', type: 'main', index: 0 }],
+					],
+				},
 				Sub: { main: [[{ node: 'Loop Over Items', type: 'main', index: 0 }]] },
+				'Drop empty results': { main: [[]] },
 			});
 			// The rewired graph, not the original one, is what gets validated for re-publish.
 			expect(workflowValidationService.validateForActivation).toHaveBeenCalledWith(

--- a/packages/cli/src/modules/breaking-changes/breaking-changes.migration-registry.service.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.migration-registry.service.ts
@@ -2,17 +2,17 @@ import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 
 import { nodeMigrations } from './migrations';
-import type { NodeMigration } from './migrations/node-migration';
+import type { Migration } from './migrations/node-migration';
 
 /**
- * Holds the node migrations, keyed by the breaking-change rule id that detects
- * the deprecated node. Detection (rules) and transformation (migrations) stay
+ * Holds the migrations, keyed by the breaking-change rule id that detects the
+ * deprecated node. Detection (rules) and transformation (migrations) stay
  * decoupled: a rule can exist with no migration, in which case the report falls
  * back to prose recommendations.
  */
 @Service()
 export class MigrationRegistry {
-	private readonly migrations = new Map<string, NodeMigration>();
+	private readonly migrations = new Map<string, Migration>();
 
 	constructor(private readonly logger: Logger) {
 		this.logger = logger.scoped('breaking-changes');
@@ -29,7 +29,7 @@ export class MigrationRegistry {
 		}
 	}
 
-	get(ruleId: string): NodeMigration | undefined {
+	get(ruleId: string): Migration | undefined {
 		return this.migrations.get(ruleId);
 	}
 

--- a/packages/cli/src/modules/breaking-changes/breaking-changes.migration.service.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.migration.service.ts
@@ -83,7 +83,7 @@ export class BreakingChangeMigrationService {
 
 		const applied = isWorkflowMigration(migration)
 			? this.applyWorkflowMigration(migration, workflow, affectedNodeIds)
-			: this.applyNodeMigration(migration, workflow.nodes, affectedNodeIds);
+			: this.applyNodeMigration(migration, workflow, affectedNodeIds);
 		const { nodes, connections, migratedNodeIds } = applied;
 		const unmapped = applied.unmapped ?? [];
 		const notes = applied.notes ?? [];
@@ -128,17 +128,17 @@ export class BreakingChangeMigrationService {
 		};
 	}
 
-	/** Swaps each affected node for its replacement in place; connections are untouched. */
+	/** Swaps each affected node for its replacement in place; connections are passed through untouched. */
 	private applyNodeMigration(
 		migration: NodeMigration,
-		nodes: INode[],
+		workflow: WorkflowEntity,
 		affectedNodeIds: Set<string>,
 	): WorkflowMigrationOutput {
 		const unmapped: string[] = [];
 		const notes: string[] = [];
 		const migratedNodeIds: string[] = [];
 
-		const migratedNodes = nodes.map((node) => {
+		const migratedNodes = workflow.nodes.map((node) => {
 			if (!affectedNodeIds.has(node.id)) return node;
 
 			// A node the migration refuses aborts the whole workflow before any save.
@@ -164,7 +164,13 @@ export class BreakingChangeMigrationService {
 			} satisfies INode;
 		});
 
-		return { nodes: migratedNodes, connections: {}, migratedNodeIds, unmapped, notes };
+		return {
+			nodes: migratedNodes,
+			connections: workflow.connections,
+			migratedNodeIds,
+			unmapped,
+			notes,
+		};
 	}
 
 	/** Hands the whole graph to the migration so it can add nodes and rewire edges. */

--- a/packages/cli/src/modules/breaking-changes/breaking-changes.migration.service.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.migration.service.ts
@@ -1,6 +1,6 @@
 import type { WorkflowMigrationResult } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import type { User } from '@n8n/db';
+import type { User, WorkflowEntity } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { calculateWorkflowChecksum } from 'n8n-workflow';
 import type { INode } from 'n8n-workflow';
@@ -15,20 +15,14 @@ import { WorkflowService } from '@/workflows/workflow.service';
 import { MigrationRegistry } from './breaking-changes.migration-registry.service';
 import { RuleRegistry } from './breaking-changes.rule-registry.service';
 import { groupNodesByType } from './group-nodes-by-type';
+import type {
+	NodeMigration,
+	WorkflowMigration,
+	WorkflowMigrationOutput,
+} from './migrations/node-migration';
+import { isWorkflowMigration, WorkflowMigrationNodeError } from './migrations/node-migration';
 
-/**
- * A migration refused a specific node. Carries the node identity in `meta` so the
- * UI can link straight to it.
- */
-export class WorkflowMigrationNodeError extends BadRequestError {
-	constructor(
-		message: string,
-		readonly meta: { nodeId: string; nodeName: string },
-	) {
-		super(message);
-		this.name = 'WorkflowMigrationNodeError';
-	}
-}
+export { WorkflowMigrationNodeError };
 
 @Service()
 export class BreakingChangeMigrationService {
@@ -45,8 +39,8 @@ export class BreakingChangeMigrationService {
 	}
 
 	/**
-	 * Rewrites a single workflow to swap the nodes a rule flags as deprecated for
-	 * their replacement, then saves the result as a new workflow version.
+	 * Rewrites a single workflow so the nodes a rule flags as deprecated stop
+	 * depending on the removed behavior, then saves the result as a new workflow version.
 	 */
 	async migrateWorkflow(
 		ruleId: string,
@@ -87,11 +81,64 @@ export class BreakingChangeMigrationService {
 			throw new BadRequestError('This workflow has no nodes affected by the selected rule.');
 		}
 
+		const applied = isWorkflowMigration(migration)
+			? this.applyWorkflowMigration(migration, workflow, affectedNodeIds)
+			: this.applyNodeMigration(migration, workflow.nodes, affectedNodeIds);
+		const { nodes, connections, migratedNodeIds } = applied;
+		const unmapped = applied.unmapped ?? [];
+		const notes = applied.notes ?? [];
+
+		// Best-effort hint for a one-click re-publish: clean migration of the published
+		// version that still validates for activation. It's a subset of the full activation
+		// gate, so publishing can still fail (handled gracefully in the UI).
+		const republishable =
+			unmapped.length === 0 &&
+			notes.length === 0 &&
+			wasPublishedVersion &&
+			this.workflowValidationService.validateForActivation(
+				Object.fromEntries(nodes.map((node) => [node.name, node])),
+				connections,
+				this.nodeTypes,
+			).isValid;
+
+		// Checksum of the workflow as fetched, so a concurrent edit landing between
+		// this read and the write below is rejected as a conflict rather than clobbered.
+		const expectedChecksum = await calculateWorkflowChecksum(workflow);
+
+		workflow.nodes = nodes;
+		workflow.connections = connections;
+		const updated = await this.workflowService.update(user, workflow, workflowId, {
+			versionName: 'Automated node migration',
+			expectedChecksum,
+		});
+
+		this.logger.info('Applied automated node migration', {
+			ruleId,
+			workflowId,
+			migratedNodeIds,
+		});
+
+		return {
+			workflowId,
+			newVersionId: updated.versionId,
+			migratedNodeIds,
+			unmapped,
+			notes,
+			republishable,
+		};
+	}
+
+	/** Swaps each affected node for its replacement in place; connections are untouched. */
+	private applyNodeMigration(
+		migration: NodeMigration,
+		nodes: INode[],
+		affectedNodeIds: Set<string>,
+	): WorkflowMigrationOutput {
 		const unmapped: string[] = [];
 		const notes: string[] = [];
 		const migratedNodeIds: string[] = [];
 
-		const nodes = workflow.nodes.map((node) => {
+		const migratedNodes = nodes.map((node) => {
 			if (!affectedNodeIds.has(node.id)) return node;
 
 			// A node the migration refuses aborts the whole workflow before any save.
@@ -117,42 +164,24 @@ export class BreakingChangeMigrationService {
 			} satisfies INode;
 		});
 
-		// Best-effort hint for a one-click re-publish: clean migration of the published
-		// version that still validates for activation. It's a subset of the full activation
-		// gate, so publishing can still fail (handled gracefully in the UI).
-		const republishable =
-			unmapped.length === 0 &&
-			notes.length === 0 &&
-			wasPublishedVersion &&
-			this.workflowValidationService.validateForActivation(
-				Object.fromEntries(nodes.map((node) => [node.name, node])),
-				workflow.connections,
-				this.nodeTypes,
-			).isValid;
+		return { nodes: migratedNodes, connections: {}, migratedNodeIds, unmapped, notes };
+	}
 
-		// Checksum of the workflow as fetched, so a concurrent edit landing between
-		// this read and the write below is rejected as a conflict rather than clobbered.
-		const expectedChecksum = await calculateWorkflowChecksum(workflow);
-
-		workflow.nodes = nodes;
-		const updated = await this.workflowService.update(user, workflow, workflowId, {
-			versionName: 'Automated node migration',
-			expectedChecksum,
-		});
-
-		this.logger.info('Applied automated node migration', {
-			ruleId,
-			workflowId,
-			migratedNodeIds,
-		});
-
-		return {
-			workflowId,
-			newVersionId: updated.versionId,
-			migratedNodeIds,
-			unmapped,
-			notes,
-			republishable,
-		};
+	/** Hands the whole graph to the migration so it can add nodes and rewire edges. */
+	private applyWorkflowMigration(
+		migration: WorkflowMigration,
+		workflow: WorkflowEntity,
+		affectedNodeIds: Set<string>,
+	): WorkflowMigrationOutput {
+		try {
+			return migration.migrateWorkflow({
+				nodes: workflow.nodes,
+				connections: workflow.connections,
+				affectedNodeIds,
+			});
+		} catch (error) {
+			if (error instanceof WorkflowMigrationNodeError) throw error;
+			throw new BadRequestError(error instanceof Error ? error.message : 'Migration failed.');
+		}
 	}
 }

--- a/packages/cli/src/modules/breaking-changes/migrations/__tests__/execute-workflow-each-to-loop.migration.test.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/__tests__/execute-workflow-each-to-loop.migration.test.ts
@@ -59,8 +59,9 @@ describe('executeWorkflowEachToLoop migration', () => {
 					combinator: 'and',
 					conditions: [
 						{
-							leftValue: '={{ $json }}',
-							operator: { type: 'object', operation: 'notEmpty', singleValue: true },
+							leftValue: '={{ Object.keys($json).length + Object.keys($binary ?? {}).length }}',
+							rightValue: 0,
+							operator: { type: 'number', operation: 'gt' },
 						},
 					],
 				},
@@ -125,7 +126,7 @@ describe('executeWorkflowEachToLoop migration', () => {
 	it('handles several predecessors and several successors', () => {
 		const a = createNode('A', 'n8n-nodes-base.set');
 		const b = createNode('B', 'n8n-nodes-base.set');
-		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each', ...NO_WAIT });
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
 		const c = createNode('C', 'n8n-nodes-base.set');
 		const d = createNode('D', 'n8n-nodes-base.set');
 		const connections: IConnections = {
@@ -140,6 +141,22 @@ describe('executeWorkflowEachToLoop migration', () => {
 			A: { main: [[edge('Loop Over Items')]] },
 			// B's edge to C is unrelated and stays.
 			B: { main: [[edge('Loop Over Items'), edge('C')]] },
+			'Loop Over Items': { main: [[edge('Drop empty results')], [edge('Sub')]] },
+			Sub: { main: [[edge('Loop Over Items')]] },
+			// All former successors, with their input indexes, hang off the filter.
+			'Drop empty results': { main: [[edge('C'), edge('D', 1)]] },
+		});
+	});
+
+	it('handles several successors in fire-and-forget mode without a filter', () => {
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each', ...NO_WAIT });
+		const c = createNode('C', 'n8n-nodes-base.set');
+		const d = createNode('D', 'n8n-nodes-base.set');
+		const connections: IConnections = { Sub: { main: [[edge('C'), edge('D', 1)]] } };
+
+		const result = migrate([sub, c, d], connections, [sub]);
+
+		expect(result.connections).toEqual({
 			'Loop Over Items': { main: [[edge('C'), edge('D', 1)], [edge('Sub')]] },
 			Sub: { main: [[edge('Loop Over Items')]] },
 		});

--- a/packages/cli/src/modules/breaking-changes/migrations/__tests__/execute-workflow-each-to-loop.migration.test.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/__tests__/execute-workflow-each-to-loop.migration.test.ts
@@ -1,0 +1,192 @@
+import type { IConnections, INode } from 'n8n-workflow';
+
+import { createNode } from '../../__tests__/test-helpers';
+import { executeWorkflowEachToLoop } from '../execute-workflow-each-to-loop.migration';
+
+const EXECUTE_WORKFLOW = 'n8n-nodes-base.executeWorkflow';
+const LOOP = 'n8n-nodes-base.splitInBatches';
+
+const edge = (node: string, index = 0) => ({ node, type: 'main' as const, index });
+
+const migrate = (nodes: INode[], connections: IConnections, affected: INode[]) =>
+	executeWorkflowEachToLoop.migrateWorkflow({
+		nodes,
+		connections,
+		affectedNodeIds: new Set(affected.map((n) => n.id)),
+	});
+
+describe('executeWorkflowEachToLoop migration', () => {
+	it('is keyed by the each-mode rule id', () => {
+		expect(executeWorkflowEachToLoop.ruleId).toBe('execute-workflow-each-mode-v3');
+	});
+
+	it('wraps a flagged node in a Loop Over Items on a linear chain', () => {
+		const trigger = createNode('Trigger', 'n8n-nodes-base.manualTrigger');
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each', workflowId: 'abc' });
+		sub.position = [400, 200];
+		const set = createNode('Set', 'n8n-nodes-base.set');
+		const connections: IConnections = {
+			Trigger: { main: [[edge('Sub')]] },
+			Sub: { main: [[edge('Set')]] },
+		};
+
+		const result = migrate([trigger, sub, set], connections, [sub]);
+
+		// The loop is inserted right before the node it wraps.
+		expect(result.nodes.map((n) => n.name)).toEqual(['Trigger', 'Loop Over Items', 'Sub', 'Set']);
+		const loop = result.nodes[1];
+		expect(loop).toMatchObject({
+			type: LOOP,
+			typeVersion: 3,
+			parameters: { batchSize: 1, options: {} },
+			position: [400, 200],
+		});
+		expect(loop.id).toEqual(expect.any(String));
+		// The sub-workflow node switches mode, keeps its identity, and moves into the loop body.
+		const migratedSub = result.nodes[2];
+		expect(migratedSub).toMatchObject({
+			id: sub.id,
+			name: 'Sub',
+			type: EXECUTE_WORKFLOW,
+			parameters: { mode: 'once', workflowId: 'abc' },
+			position: [640, 380],
+		});
+
+		expect(result.connections).toEqual({
+			Trigger: { main: [[edge('Loop Over Items')]] },
+			'Loop Over Items': { main: [[edge('Set')], [edge('Sub')]] },
+			Sub: { main: [[edge('Loop Over Items')]] },
+		});
+		expect(result.migratedNodeIds).toEqual([sub.id]);
+		expect(result.notes).toBeUndefined();
+		expect(result.unmapped).toBeUndefined();
+	});
+
+	it('does not mutate its input', () => {
+		const trigger = createNode('Trigger', 'n8n-nodes-base.manualTrigger');
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		const nodes = [trigger, sub];
+		const connections: IConnections = { Trigger: { main: [[edge('Sub')]] } };
+		const nodesSnapshot = structuredClone(nodes);
+		const connectionsSnapshot = structuredClone(connections);
+
+		migrate(nodes, connections, [sub]);
+
+		expect(nodes).toEqual(nodesSnapshot);
+		expect(connections).toEqual(connectionsSnapshot);
+	});
+
+	it('handles several predecessors and several successors', () => {
+		const a = createNode('A', 'n8n-nodes-base.set');
+		const b = createNode('B', 'n8n-nodes-base.set');
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		const c = createNode('C', 'n8n-nodes-base.set');
+		const d = createNode('D', 'n8n-nodes-base.set');
+		const connections: IConnections = {
+			A: { main: [[edge('Sub')]] },
+			B: { main: [[edge('Sub'), edge('C')]] },
+			Sub: { main: [[edge('C'), edge('D', 1)]] },
+		};
+
+		const result = migrate([a, b, sub, c, d], connections, [sub]);
+
+		expect(result.connections).toEqual({
+			A: { main: [[edge('Loop Over Items')]] },
+			// B's edge to C is unrelated and stays.
+			B: { main: [[edge('Loop Over Items'), edge('C')]] },
+			'Loop Over Items': { main: [[edge('C'), edge('D', 1)], [edge('Sub')]] },
+			Sub: { main: [[edge('Loop Over Items')]] },
+		});
+	});
+
+	it('wraps a flagged node that has no successors', () => {
+		const trigger = createNode('Trigger', 'n8n-nodes-base.manualTrigger');
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		const connections: IConnections = { Trigger: { main: [[edge('Sub')]] } };
+
+		const result = migrate([trigger, sub], connections, [sub]);
+
+		expect(result.connections).toEqual({
+			Trigger: { main: [[edge('Loop Over Items')]] },
+			'Loop Over Items': { main: [[], [edge('Sub')]] },
+			Sub: { main: [[edge('Loop Over Items')]] },
+		});
+	});
+
+	it('gives each wrapped node its own uniquely named loop and skips unaffected nodes', () => {
+		const existingLoop = createNode('Loop Over Items', LOOP);
+		const first = createNode('First', EXECUTE_WORKFLOW, { mode: 'each' });
+		const second = createNode('Second', EXECUTE_WORKFLOW, { mode: 'each' });
+		const untouched = createNode('Untouched', EXECUTE_WORKFLOW, { mode: 'once' });
+		// First (each) → Second (each) → Untouched (once)
+		const connections: IConnections = {
+			First: { main: [[edge('Second')]] },
+			Second: { main: [[edge('Untouched')]] },
+		};
+
+		const result = migrate([existingLoop, first, second, untouched], connections, [first, second]);
+
+		expect(result.nodes.map((n) => n.name)).toEqual([
+			'Loop Over Items',
+			'Loop Over Items1',
+			'First',
+			'Loop Over Items2',
+			'Second',
+			'Untouched',
+		]);
+		expect(result.nodes.find((n) => n.name === 'Untouched')).toBe(untouched);
+		expect(result.connections).toEqual({
+			'Loop Over Items1': { main: [[edge('Loop Over Items2')], [edge('First')]] },
+			First: { main: [[edge('Loop Over Items1')]] },
+			'Loop Over Items2': { main: [[edge('Untouched')], [edge('Second')]] },
+			Second: { main: [[edge('Loop Over Items2')]] },
+		});
+		expect(result.migratedNodeIds).toEqual([first.id, second.id]);
+	});
+
+	it('keeps the error output wired and warns that failed items leave the loop', () => {
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		sub.onError = 'continueErrorOutput';
+		const ok = createNode('Ok', 'n8n-nodes-base.set');
+		const failed = createNode('Failed', 'n8n-nodes-base.set');
+		const connections: IConnections = {
+			Sub: { main: [[edge('Ok')], [edge('Failed')]] },
+		};
+
+		const result = migrate([sub, ok, failed], connections, [sub]);
+
+		expect(result.connections.Sub).toEqual({
+			main: [[edge('Loop Over Items')], [edge('Failed')]],
+		});
+		expect(result.connections['Loop Over Items']).toEqual({ main: [[edge('Ok')], [edge('Sub')]] });
+		expect(result.notes).toEqual([expect.stringContaining('error output')]);
+	});
+
+	it('warns when "Execute Once" is enabled on the wrapped node', () => {
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		sub.executeOnce = true;
+
+		const result = migrate([sub], {}, [sub]);
+
+		expect(result.notes).toEqual([expect.stringContaining('Execute Once')]);
+	});
+
+	it('warns when other nodes read the wrapped node by name in expressions', () => {
+		const sub = createNode('Sub WF', EXECUTE_WORKFLOW, { mode: 'each' });
+		const reader = createNode('Reader', 'n8n-nodes-base.set', {
+			assignments: { assignments: [{ value: "={{ $('Sub WF').all().length }}" }] },
+		});
+		const legacyReader = createNode('Legacy', 'n8n-nodes-base.set', {
+			value: '={{ $node["Sub WF"].json.x }}',
+		});
+		const unrelated = createNode('Unrelated', 'n8n-nodes-base.set', {
+			value: "={{ $('Other').item.json.x }}",
+		});
+
+		const result = migrate([sub, reader, legacyReader, unrelated], {}, [sub]);
+
+		expect(result.notes).toEqual([
+			expect.stringContaining('"Reader", "Legacy" reference "Sub WF"'),
+		]);
+	});
+});

--- a/packages/cli/src/modules/breaking-changes/migrations/__tests__/execute-workflow-each-to-loop.migration.test.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/__tests__/execute-workflow-each-to-loop.migration.test.ts
@@ -5,6 +5,8 @@ import { executeWorkflowEachToLoop } from '../execute-workflow-each-to-loop.migr
 
 const EXECUTE_WORKFLOW = 'n8n-nodes-base.executeWorkflow';
 const LOOP = 'n8n-nodes-base.splitInBatches';
+const FILTER = 'n8n-nodes-base.filter';
+const NO_WAIT = { options: { waitForSubWorkflow: false } };
 
 const edge = (node: string, index = 0) => ({ node, type: 'main' as const, index });
 
@@ -20,7 +22,7 @@ describe('executeWorkflowEachToLoop migration', () => {
 		expect(executeWorkflowEachToLoop.ruleId).toBe('execute-workflow-each-mode-v3');
 	});
 
-	it('wraps a flagged node in a Loop Over Items on a linear chain', () => {
+	it('wraps a waiting node in a loop with an empty-result filter after done', () => {
 		const trigger = createNode('Trigger', 'n8n-nodes-base.manualTrigger');
 		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each', workflowId: 'abc' });
 		sub.position = [400, 200];
@@ -32,9 +34,15 @@ describe('executeWorkflowEachToLoop migration', () => {
 
 		const result = migrate([trigger, sub, set], connections, [sub]);
 
-		// The loop is inserted right before the node it wraps.
-		expect(result.nodes.map((n) => n.name)).toEqual(['Trigger', 'Loop Over Items', 'Sub', 'Set']);
-		const loop = result.nodes[1];
+		// Loop and filter are inserted right before the node they wrap.
+		expect(result.nodes.map((n) => n.name)).toEqual([
+			'Trigger',
+			'Loop Over Items',
+			'Drop empty results',
+			'Sub',
+			'Set',
+		]);
+		const [, loop, filter, migratedSub] = result.nodes;
 		expect(loop).toMatchObject({
 			type: LOOP,
 			typeVersion: 3,
@@ -42,24 +50,62 @@ describe('executeWorkflowEachToLoop migration', () => {
 			position: [400, 200],
 		});
 		expect(loop.id).toEqual(expect.any(String));
-		// The sub-workflow node switches mode, keeps its identity, and moves into the loop body.
-		const migratedSub = result.nodes[2];
+		expect(filter).toMatchObject({
+			type: FILTER,
+			typeVersion: 2.2,
+			position: [640, 200],
+			parameters: {
+				conditions: {
+					combinator: 'and',
+					conditions: [
+						{
+							leftValue: '={{ $json }}',
+							operator: { type: 'object', operation: 'notEmpty', singleValue: true },
+						},
+					],
+				},
+			},
+		});
+		// The sub-workflow node switches mode, keeps its identity, moves into the loop
+		// body, and always emits an item so the loop cannot stall.
 		expect(migratedSub).toMatchObject({
 			id: sub.id,
 			name: 'Sub',
 			type: EXECUTE_WORKFLOW,
 			parameters: { mode: 'once', workflowId: 'abc' },
 			position: [640, 380],
+			alwaysOutputData: true,
 		});
 
+		expect(result.connections).toEqual({
+			Trigger: { main: [[edge('Loop Over Items')]] },
+			'Loop Over Items': { main: [[edge('Drop empty results')], [edge('Sub')]] },
+			Sub: { main: [[edge('Loop Over Items')]] },
+			'Drop empty results': { main: [[edge('Set')]] },
+		});
+		expect(result.migratedNodeIds).toEqual([sub.id]);
+		expect(result.notes).toBeUndefined();
+		expect(result.unmapped).toBeUndefined();
+	});
+
+	it('wraps a fire-and-forget node in a plain loop, without filter or alwaysOutputData', () => {
+		const trigger = createNode('Trigger', 'n8n-nodes-base.manualTrigger');
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each', ...NO_WAIT });
+		const set = createNode('Set', 'n8n-nodes-base.set');
+		const connections: IConnections = {
+			Trigger: { main: [[edge('Sub')]] },
+			Sub: { main: [[edge('Set')]] },
+		};
+
+		const result = migrate([trigger, sub, set], connections, [sub]);
+
+		expect(result.nodes.map((n) => n.name)).toEqual(['Trigger', 'Loop Over Items', 'Sub', 'Set']);
+		expect(result.nodes[2].alwaysOutputData).toBeUndefined();
 		expect(result.connections).toEqual({
 			Trigger: { main: [[edge('Loop Over Items')]] },
 			'Loop Over Items': { main: [[edge('Set')], [edge('Sub')]] },
 			Sub: { main: [[edge('Loop Over Items')]] },
 		});
-		expect(result.migratedNodeIds).toEqual([sub.id]);
-		expect(result.notes).toBeUndefined();
-		expect(result.unmapped).toBeUndefined();
 	});
 
 	it('does not mutate its input', () => {
@@ -79,7 +125,7 @@ describe('executeWorkflowEachToLoop migration', () => {
 	it('handles several predecessors and several successors', () => {
 		const a = createNode('A', 'n8n-nodes-base.set');
 		const b = createNode('B', 'n8n-nodes-base.set');
-		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each', ...NO_WAIT });
 		const c = createNode('C', 'n8n-nodes-base.set');
 		const d = createNode('D', 'n8n-nodes-base.set');
 		const connections: IConnections = {
@@ -108,12 +154,13 @@ describe('executeWorkflowEachToLoop migration', () => {
 
 		expect(result.connections).toEqual({
 			Trigger: { main: [[edge('Loop Over Items')]] },
-			'Loop Over Items': { main: [[], [edge('Sub')]] },
+			'Loop Over Items': { main: [[edge('Drop empty results')], [edge('Sub')]] },
 			Sub: { main: [[edge('Loop Over Items')]] },
+			'Drop empty results': { main: [[]] },
 		});
 	});
 
-	it('gives each wrapped node its own uniquely named loop and skips unaffected nodes', () => {
+	it('gives each wrapped node uniquely named helper nodes and skips unaffected nodes', () => {
 		const existingLoop = createNode('Loop Over Items', LOOP);
 		const first = createNode('First', EXECUTE_WORKFLOW, { mode: 'each' });
 		const second = createNode('Second', EXECUTE_WORKFLOW, { mode: 'each' });
@@ -129,23 +176,27 @@ describe('executeWorkflowEachToLoop migration', () => {
 		expect(result.nodes.map((n) => n.name)).toEqual([
 			'Loop Over Items',
 			'Loop Over Items1',
+			'Drop empty results',
 			'First',
 			'Loop Over Items2',
+			'Drop empty results1',
 			'Second',
 			'Untouched',
 		]);
 		expect(result.nodes.find((n) => n.name === 'Untouched')).toBe(untouched);
 		expect(result.connections).toEqual({
-			'Loop Over Items1': { main: [[edge('Loop Over Items2')], [edge('First')]] },
+			'Loop Over Items1': { main: [[edge('Drop empty results')], [edge('First')]] },
 			First: { main: [[edge('Loop Over Items1')]] },
-			'Loop Over Items2': { main: [[edge('Untouched')], [edge('Second')]] },
+			'Drop empty results': { main: [[edge('Loop Over Items2')]] },
+			'Loop Over Items2': { main: [[edge('Drop empty results1')], [edge('Second')]] },
 			Second: { main: [[edge('Loop Over Items2')]] },
+			'Drop empty results1': { main: [[edge('Untouched')]] },
 		});
 		expect(result.migratedNodeIds).toEqual([first.id, second.id]);
 	});
 
 	it('keeps the error output wired and warns that failed items leave the loop', () => {
-		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each', ...NO_WAIT });
 		sub.onError = 'continueErrorOutput';
 		const ok = createNode('Ok', 'n8n-nodes-base.set');
 		const failed = createNode('Failed', 'n8n-nodes-base.set');
@@ -171,6 +222,15 @@ describe('executeWorkflowEachToLoop migration', () => {
 		expect(result.notes).toEqual([expect.stringContaining('Execute Once')]);
 	});
 
+	it('warns when "Retry On Fail" is enabled on the wrapped node', () => {
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		sub.retryOnFail = true;
+
+		const result = migrate([sub], {}, [sub]);
+
+		expect(result.notes).toEqual([expect.stringContaining('Retry On Fail')]);
+	});
+
 	it('warns when other nodes read the wrapped node by name in expressions', () => {
 		const sub = createNode('Sub WF', EXECUTE_WORKFLOW, { mode: 'each' });
 		const reader = createNode('Reader', 'n8n-nodes-base.set', {
@@ -188,5 +248,22 @@ describe('executeWorkflowEachToLoop migration', () => {
 		expect(result.notes).toEqual([
 			expect.stringContaining('"Reader", "Legacy" reference "Sub WF"'),
 		]);
+		// Points at the node that now carries the aggregated output.
+		expect(result.notes?.[0]).toContain('read from "Drop empty results"');
+	});
+
+	it('detects dot-notation references for identifier-like node names only', () => {
+		const sub = createNode('Sub', EXECUTE_WORKFLOW, { mode: 'each' });
+		const dotted = createNode('Dotted', 'n8n-nodes-base.set', {
+			value: '={{ $node.Sub.all().length }}',
+		});
+		const longerName = createNode('Longer', 'n8n-nodes-base.set', {
+			value: '={{ $node.Sub2.json.x }}',
+		});
+
+		expect(migrate([sub, dotted], {}, [sub]).notes).toEqual([
+			expect.stringContaining('"Dotted" reference "Sub"'),
+		]);
+		expect(migrate([sub, longerName], {}, [sub]).notes).toBeUndefined();
 	});
 });

--- a/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
@@ -86,7 +86,11 @@ const makeLoopNode = (name: string, position: INode['position']): INode => ({
 	parameters: { batchSize: 1, options: {} },
 });
 
-/** Keeps only items whose JSON is not empty, i.e. drops the `alwaysOutputData` placeholders. */
+/**
+ * Drops the `alwaysOutputData` placeholders: items with neither JSON fields nor
+ * binary data. A file returned by the sub-workflow has empty JSON but binary
+ * data, so it passes.
+ */
 const makeFilterNode = (name: string, position: INode['position']): INode => ({
 	id: randomUUID(),
 	name,
@@ -99,9 +103,9 @@ const makeFilterNode = (name: string, position: INode['position']): INode => ({
 			conditions: [
 				{
 					id: randomUUID(),
-					leftValue: '={{ $json }}',
-					rightValue: '',
-					operator: { type: 'object', operation: 'notEmpty', singleValue: true },
+					leftValue: '={{ Object.keys($json).length + Object.keys($binary ?? {}).length }}',
+					rightValue: 0,
+					operator: { type: 'number', operation: 'gt' },
 				},
 			],
 			combinator: 'and',

--- a/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from 'node:crypto';
+import type { IConnection, IConnections, INode, NodeInputConnections } from 'n8n-workflow';
+import { deepCopy, NodeConnectionTypes } from 'n8n-workflow';
+
+import type { WorkflowMigration } from './node-migration';
+
+const LOOP_NODE_TYPE = 'n8n-nodes-base.splitInBatches';
+const LOOP_NODE_VERSION = 3;
+const LOOP_NODE_DEFAULT_NAME = 'Loop Over Items';
+// Loop Over Items v3 outputs: index 0 fires once with every item after the last
+// iteration, index 1 fires per batch with the items of that batch.
+const LOOP_DONE_OUTPUT = 0;
+const LOOP_BATCH_OUTPUT = 1;
+// Puts the sub-workflow node inside the loop body: right of the loop, one row down.
+const LOOP_BODY_OFFSET: [number, number] = [240, 180];
+
+const uniqueNodeName = (base: string, taken: Set<string>): string => {
+	if (!taken.has(base)) return base;
+	for (let i = 1; ; i++) {
+		const candidate = `${base}${i}`;
+		if (!taken.has(candidate)) return candidate;
+	}
+};
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/** Whether any string inside `value` references `nodeName` through `$('…')`, `$node['…']` or `$items('…')`. */
+const referencesNodeByName = (value: unknown, nodeName: string): boolean => {
+	const pattern = new RegExp(
+		String.raw`\$(?:\(|node\[|items\()\s*['"]${escapeRegExp(nodeName)}['"]`,
+	);
+	const visit = (candidate: unknown): boolean => {
+		if (typeof candidate === 'string') return pattern.test(candidate);
+		if (Array.isArray(candidate)) return candidate.some(visit);
+		if (candidate && typeof candidate === 'object') return Object.values(candidate).some(visit);
+		return false;
+	};
+	return visit(value);
+};
+
+const mainConnection = (node: string): IConnection => ({
+	node,
+	type: NodeConnectionTypes.Main,
+	index: 0,
+});
+
+/**
+ * Execute Sub-workflow "Run once for each item" → Loop Over Items (batch size 1)
+ * wrapped around the same node in "Run once with all items" mode.
+ *
+ * Runtime equivalence: `each` ran the sub-workflow once per input item with
+ * `[item]` and concatenated the results; the loop feeds one item per iteration
+ * to the same node in `once` mode, and the loop's done output emits every item
+ * that came back, in order. That holds for both "wait for completion" settings.
+ *
+ * The rewiring for one flagged node E with predecessors P and successors S:
+ *   P → E → S   becomes   P → Loop ─done→ S
+ *                               └─loop→ E → Loop
+ * Other outputs of E (for example an error output) keep their edges.
+ */
+export const executeWorkflowEachToLoop: WorkflowMigration = {
+	ruleId: 'execute-workflow-each-mode-v3',
+	migrateWorkflow: ({ nodes, connections, affectedNodeIds }) => {
+		const nextConnections: IConnections = deepCopy(connections);
+		const takenNames = new Set(nodes.map((node) => node.name));
+		const nextNodes: INode[] = [];
+		const migratedNodeIds: string[] = [];
+		const notes: string[] = [];
+
+		for (const original of nodes) {
+			if (!affectedNodeIds.has(original.id)) {
+				nextNodes.push(original);
+				continue;
+			}
+
+			const loopName = uniqueNodeName(LOOP_NODE_DEFAULT_NAME, takenNames);
+			takenNames.add(loopName);
+
+			const loopNode: INode = {
+				id: randomUUID(),
+				name: loopName,
+				type: LOOP_NODE_TYPE,
+				typeVersion: LOOP_NODE_VERSION,
+				position: [...original.position],
+				parameters: { batchSize: 1, options: {} },
+			};
+			const node: INode = {
+				...original,
+				position: [
+					original.position[0] + LOOP_BODY_OFFSET[0],
+					original.position[1] + LOOP_BODY_OFFSET[1],
+				],
+				parameters: { ...original.parameters, mode: 'once' },
+			};
+
+			// 1. Every main edge that fed the node now feeds the loop.
+			for (const outputs of Object.values(nextConnections)) {
+				for (const targets of outputs[NodeConnectionTypes.Main] ?? []) {
+					for (const target of targets ?? []) {
+						if (target.node === node.name) target.node = loopName;
+					}
+				}
+			}
+
+			// 2. The node's main output goes back into the loop; its old successors hang off "done".
+			const nodeOutputs = nextConnections[node.name] ?? {};
+			const mainOutputs: NodeInputConnections = [...(nodeOutputs[NodeConnectionTypes.Main] ?? [])];
+			const successors = mainOutputs[0] ?? [];
+			mainOutputs[0] = [mainConnection(loopName)];
+			nextConnections[node.name] = { ...nodeOutputs, [NodeConnectionTypes.Main]: mainOutputs };
+
+			const loopOutputs: NodeInputConnections = [];
+			loopOutputs[LOOP_DONE_OUTPUT] = successors;
+			loopOutputs[LOOP_BATCH_OUTPUT] = [mainConnection(node.name)];
+			nextConnections[loopName] = { [NodeConnectionTypes.Main]: loopOutputs };
+
+			// 3. Behavior that the loop form cannot reproduce exactly.
+			if (node.onError === 'continueErrorOutput') {
+				notes.push(
+					`"${node.name}" routes failed items to its error output. Inside the loop those items no longer flow back, so the loop's "done" output only carries the items that succeeded.`,
+				);
+			}
+			if (node.executeOnce) {
+				notes.push(
+					`"${node.name}" has "Execute Once" enabled, which used to limit it to the first item. Inside the loop it now runs for every item; disable the loop or the setting if that is not intended.`,
+				);
+			}
+			const referencing = nodes
+				.filter(
+					(other) => other.id !== node.id && referencesNodeByName(other.parameters, node.name),
+				)
+				.map((other) => other.name);
+			if (referencing.length > 0) {
+				notes.push(
+					`${referencing.map((name) => `"${name}"`).join(', ')} reference "${node.name}" in expressions. It now runs once per loop iteration, so \`$('${node.name}').all()\` returns only the last iteration's output; read from "${loopName}" instead.`,
+				);
+			}
+
+			nextNodes.push(loopNode, node);
+			migratedNodeIds.push(node.id);
+		}
+
+		return {
+			nodes: nextNodes,
+			connections: nextConnections,
+			migratedNodeIds,
+			notes: notes.length > 0 ? notes : undefined,
+		};
+	},
+};

--- a/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
@@ -11,8 +11,14 @@ const LOOP_NODE_DEFAULT_NAME = 'Loop Over Items';
 // iteration, index 1 fires per batch with the items of that batch.
 const LOOP_DONE_OUTPUT = 0;
 const LOOP_BATCH_OUTPUT = 1;
-// Puts the sub-workflow node inside the loop body: right of the loop, one row down.
-const LOOP_BODY_OFFSET: [number, number] = [240, 180];
+
+const FILTER_NODE_TYPE = 'n8n-nodes-base.filter';
+const FILTER_NODE_VERSION = 2.2;
+const FILTER_NODE_DEFAULT_NAME = 'Drop empty results';
+
+// One canvas column to the right; one row down puts a node inside the loop body.
+const COLUMN_OFFSET = 240;
+const ROW_OFFSET = 180;
 
 const uniqueNodeName = (base: string, taken: Set<string>): string => {
 	if (!taken.has(base)) return base;
@@ -22,14 +28,35 @@ const uniqueNodeName = (base: string, taken: Set<string>): string => {
 	}
 };
 
-/** Whether any string inside `value` references `nodeName` through `$('…')`, `$node['…']` or `$items('…')`. */
+const JS_IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+const JS_IDENTIFIER_CHAR = /[\w$]/;
+
+/**
+ * Whether any string inside `value` references `nodeName` the way expressions
+ * do: `$('…')`, `$node['…']`, `$items('…')`, or `$node.Name` for names that are
+ * valid identifiers. Mirrors the access patterns the node-rename logic handles.
+ */
 const referencesNodeByName = (value: unknown, nodeName: string): boolean => {
-	const needles = ['$(', '$node[', '$items('].flatMap((prefix) => [
+	const quoted = ['$(', '$node[', '$items('].flatMap((prefix) => [
 		`${prefix}'${nodeName}'`,
 		`${prefix}"${nodeName}"`,
 	]);
+	const dotted = JS_IDENTIFIER.test(nodeName) ? `$node.${nodeName}` : undefined;
+
+	const matches = (text: string): boolean => {
+		if (quoted.some((needle) => text.includes(needle))) return true;
+		if (!dotted) return false;
+		// `$node.Sub` must not match `$node.Sub2`.
+		for (let from = 0; ; ) {
+			const at = text.indexOf(dotted, from);
+			if (at === -1) return false;
+			const next = text[at + dotted.length];
+			if (next === undefined || !JS_IDENTIFIER_CHAR.test(next)) return true;
+			from = at + dotted.length;
+		}
+	};
 	const visit = (candidate: unknown): boolean => {
-		if (typeof candidate === 'string') return needles.some((needle) => candidate.includes(needle));
+		if (typeof candidate === 'string') return matches(candidate);
 		if (Array.isArray(candidate)) return candidate.some(visit);
 		if (candidate && typeof candidate === 'object') return Object.values(candidate).some(visit);
 		return false;
@@ -43,6 +70,79 @@ const mainConnection = (node: string): IConnection => ({
 	index: 0,
 });
 
+/** "Wait for sub-workflow completion" is on unless the option is explicitly off. */
+const waitsForSubWorkflow = (node: INode): boolean => {
+	const options = node.parameters.options;
+	if (!options || typeof options !== 'object') return true;
+	return (options as { waitForSubWorkflow?: unknown }).waitForSubWorkflow !== false;
+};
+
+const makeLoopNode = (name: string, position: INode['position']): INode => ({
+	id: randomUUID(),
+	name,
+	type: LOOP_NODE_TYPE,
+	typeVersion: LOOP_NODE_VERSION,
+	position,
+	parameters: { batchSize: 1, options: {} },
+});
+
+/** Keeps only items whose JSON is not empty, i.e. drops the `alwaysOutputData` placeholders. */
+const makeFilterNode = (name: string, position: INode['position']): INode => ({
+	id: randomUUID(),
+	name,
+	type: FILTER_NODE_TYPE,
+	typeVersion: FILTER_NODE_VERSION,
+	position,
+	parameters: {
+		conditions: {
+			options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 2 },
+			conditions: [
+				{
+					id: randomUUID(),
+					leftValue: '={{ $json }}',
+					rightValue: '',
+					operator: { type: 'object', operation: 'notEmpty', singleValue: true },
+				},
+			],
+			combinator: 'and',
+		},
+		options: {},
+	},
+});
+
+/**
+ * Behavior the loop form cannot reproduce exactly. Any note blocks the one-click
+ * re-publish, so the user reviews the workflow first. `tailName` is the node that
+ * now carries the aggregated output.
+ */
+const driftNotes = (node: INode, allNodes: INode[], tailName: string): string[] => {
+	const notes: string[] = [];
+	if (node.onError === 'continueErrorOutput') {
+		notes.push(
+			`"${node.name}" routes failed items to its error output. Inside the loop those items no longer flow back, so the loop's "done" output only carries the items that succeeded.`,
+		);
+	}
+	if (node.executeOnce) {
+		notes.push(
+			`"${node.name}" has "Execute Once" enabled, which used to limit it to the first item. Inside the loop it now runs for every item; disable the loop or the setting if that is not intended.`,
+		);
+	}
+	if (node.retryOnFail) {
+		notes.push(
+			`"${node.name}" has "Retry On Fail" enabled. A failure used to retry the sub-workflow for every item; inside the loop only the failing item is retried.`,
+		);
+	}
+	const referencing = allNodes
+		.filter((other) => other.id !== node.id && referencesNodeByName(other.parameters, node.name))
+		.map((other) => other.name);
+	if (referencing.length > 0) {
+		notes.push(
+			`${referencing.map((name) => `"${name}"`).join(', ')} reference "${node.name}" in expressions. It now runs once per loop iteration, so \`$('${node.name}').all()\` returns only the last iteration's output; read from "${tailName}" instead.`,
+		);
+	}
+	return notes;
+};
+
 /**
  * Execute Sub-workflow "Run once for each item" → Loop Over Items (batch size 1)
  * wrapped around the same node in "Run once with all items" mode.
@@ -50,18 +150,31 @@ const mainConnection = (node: string): IConnection => ({
  * Runtime equivalence: `each` ran the sub-workflow once per input item with
  * `[item]` and concatenated the results; the loop feeds one item per iteration
  * to the same node in `once` mode, and the loop's done output emits every item
- * that came back, in order. That holds for both "wait for completion" settings.
+ * that came back, in order.
  *
  * The rewiring for one flagged node E with predecessors P and successors S:
- *   P → E → S   becomes   P → Loop ─done→ S
+ *   P → E → S   becomes   P → Loop ─done→ [Filter →] S
  *                               └─loop→ E → Loop
  * Other outputs of E (for example an error output) keep their edges.
+ *
+ * The engine only continues past a node that produced at least one item. When E
+ * waits for the sub-workflow and that run returns nothing for an item, the loop
+ * would stall and never reach done. So in that mode E gets `alwaysOutputData`,
+ * which emits one `{}` placeholder instead, and a Filter after done drops items
+ * whose JSON is empty. A sub-workflow that legitimately returns `{}` items loses
+ * them; that is the one known drift of this construct. In fire-and-forget mode E
+ * echoes its input item, so neither is needed.
  */
 export const executeWorkflowEachToLoop: WorkflowMigration = {
 	ruleId: 'execute-workflow-each-mode-v3',
 	migrateWorkflow: ({ nodes, connections, affectedNodeIds }) => {
 		const nextConnections: IConnections = deepCopy(connections);
 		const takenNames = new Set(nodes.map((node) => node.name));
+		const claimName = (base: string) => {
+			const name = uniqueNodeName(base, takenNames);
+			takenNames.add(name);
+			return name;
+		};
 		const nextNodes: INode[] = [];
 		const migratedNodeIds: string[] = [];
 		const notes: string[] = [];
@@ -72,70 +185,50 @@ export const executeWorkflowEachToLoop: WorkflowMigration = {
 				continue;
 			}
 
-			const loopName = uniqueNodeName(LOOP_NODE_DEFAULT_NAME, takenNames);
-			takenNames.add(loopName);
+			const [x, y] = original.position;
+			const waits = waitsForSubWorkflow(original);
 
-			const loopNode: INode = {
-				id: randomUUID(),
-				name: loopName,
-				type: LOOP_NODE_TYPE,
-				typeVersion: LOOP_NODE_VERSION,
-				position: [...original.position],
-				parameters: { batchSize: 1, options: {} },
-			};
+			const loopNode = makeLoopNode(claimName(LOOP_NODE_DEFAULT_NAME), [x, y]);
+			const filterNode = waits
+				? makeFilterNode(claimName(FILTER_NODE_DEFAULT_NAME), [x + COLUMN_OFFSET, y])
+				: undefined;
 			const node: INode = {
 				...original,
-				position: [
-					original.position[0] + LOOP_BODY_OFFSET[0],
-					original.position[1] + LOOP_BODY_OFFSET[1],
-				],
+				position: [x + COLUMN_OFFSET, y + ROW_OFFSET],
 				parameters: { ...original.parameters, mode: 'once' },
+				...(waits ? { alwaysOutputData: true } : {}),
 			};
 
 			// 1. Every main edge that fed the node now feeds the loop.
 			for (const outputs of Object.values(nextConnections)) {
 				for (const targets of outputs[NodeConnectionTypes.Main] ?? []) {
 					for (const target of targets ?? []) {
-						if (target.node === node.name) target.node = loopName;
+						if (target.node === node.name) target.node = loopNode.name;
 					}
 				}
 			}
 
-			// 2. The node's main output goes back into the loop; its old successors hang off "done".
+			// 2. The node's main output goes back into the loop; its old successors hang
+			//    off "done", behind the filter when there is one.
 			const nodeOutputs = nextConnections[node.name] ?? {};
 			const mainOutputs: NodeInputConnections = [...(nodeOutputs[NodeConnectionTypes.Main] ?? [])];
 			const successors = mainOutputs[0] ?? [];
-			mainOutputs[0] = [mainConnection(loopName)];
+			mainOutputs[0] = [mainConnection(loopNode.name)];
 			nextConnections[node.name] = { ...nodeOutputs, [NodeConnectionTypes.Main]: mainOutputs };
 
 			const loopOutputs: NodeInputConnections = [];
-			loopOutputs[LOOP_DONE_OUTPUT] = successors;
+			loopOutputs[LOOP_DONE_OUTPUT] = filterNode ? [mainConnection(filterNode.name)] : successors;
 			loopOutputs[LOOP_BATCH_OUTPUT] = [mainConnection(node.name)];
-			nextConnections[loopName] = { [NodeConnectionTypes.Main]: loopOutputs };
-
-			// 3. Behavior that the loop form cannot reproduce exactly.
-			if (node.onError === 'continueErrorOutput') {
-				notes.push(
-					`"${node.name}" routes failed items to its error output. Inside the loop those items no longer flow back, so the loop's "done" output only carries the items that succeeded.`,
-				);
-			}
-			if (node.executeOnce) {
-				notes.push(
-					`"${node.name}" has "Execute Once" enabled, which used to limit it to the first item. Inside the loop it now runs for every item; disable the loop or the setting if that is not intended.`,
-				);
-			}
-			const referencing = nodes
-				.filter(
-					(other) => other.id !== node.id && referencesNodeByName(other.parameters, node.name),
-				)
-				.map((other) => other.name);
-			if (referencing.length > 0) {
-				notes.push(
-					`${referencing.map((name) => `"${name}"`).join(', ')} reference "${node.name}" in expressions. It now runs once per loop iteration, so \`$('${node.name}').all()\` returns only the last iteration's output; read from "${loopName}" instead.`,
-				);
+			nextConnections[loopNode.name] = { [NodeConnectionTypes.Main]: loopOutputs };
+			if (filterNode) {
+				nextConnections[filterNode.name] = { [NodeConnectionTypes.Main]: [successors] };
 			}
 
-			nextNodes.push(loopNode, node);
+			notes.push(...driftNotes(node, nodes, (filterNode ?? loopNode).name));
+
+			nextNodes.push(loopNode);
+			if (filterNode) nextNodes.push(filterNode);
+			nextNodes.push(node);
 			migratedNodeIds.push(node.id);
 		}
 

--- a/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
@@ -90,6 +90,14 @@ const makeLoopNode = (name: string, position: INode['position']): INode => ({
  * Drops the `alwaysOutputData` placeholders: items with neither JSON fields nor
  * binary data. A file returned by the sub-workflow has empty JSON but binary
  * data, so it passes.
+ *
+ * A real item with empty JSON and no binary is indistinguishable from the
+ * placeholder and is dropped too. This is deliberate: the engine fixes the
+ * placeholder shape, and no downstream node runs when the wrapped node emits
+ * nothing, so there is no way to tag the placeholder. We also do not report it
+ * as a drift note, because nearly every each-mode node waits for the
+ * sub-workflow and a note would block one-click publish for almost all
+ * migrations to protect an item that carries no data.
  */
 const makeFilterNode = (name: string, position: INode['position']): INode => ({
 	id: randomUUID(),

--- a/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/execute-workflow-each-to-loop.migration.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from 'node:crypto';
 import type { IConnection, IConnections, INode, NodeInputConnections } from 'n8n-workflow';
 import { deepCopy, NodeConnectionTypes } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
 
 import type { WorkflowMigration } from './node-migration';
 
@@ -22,15 +22,14 @@ const uniqueNodeName = (base: string, taken: Set<string>): string => {
 	}
 };
 
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
 /** Whether any string inside `value` references `nodeName` through `$('…')`, `$node['…']` or `$items('…')`. */
 const referencesNodeByName = (value: unknown, nodeName: string): boolean => {
-	const pattern = new RegExp(
-		String.raw`\$(?:\(|node\[|items\()\s*['"]${escapeRegExp(nodeName)}['"]`,
-	);
+	const needles = ['$(', '$node[', '$items('].flatMap((prefix) => [
+		`${prefix}'${nodeName}'`,
+		`${prefix}"${nodeName}"`,
+	]);
 	const visit = (candidate: unknown): boolean => {
-		if (typeof candidate === 'string') return pattern.test(candidate);
+		if (typeof candidate === 'string') return needles.some((needle) => candidate.includes(needle));
 		if (Array.isArray(candidate)) return candidate.some(visit);
 		if (candidate && typeof candidate === 'object') return Object.values(candidate).some(visit);
 		return false;

--- a/packages/cli/src/modules/breaking-changes/migrations/index.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/index.ts
@@ -1,5 +1,6 @@
 import { aiTransformToCode } from './ai-transform-to-code.migration';
-import type { NodeMigration } from './node-migration';
+import { executeWorkflowEachToLoop } from './execute-workflow-each-to-loop.migration';
+import type { Migration } from './node-migration';
 
-// All registered node migrations. A rule is auto-migratable only if it appears here.
-export const nodeMigrations: NodeMigration[] = [aiTransformToCode];
+// All registered migrations. A rule is auto-migratable only if it appears here.
+export const nodeMigrations: Migration[] = [aiTransformToCode, executeWorkflowEachToLoop];

--- a/packages/cli/src/modules/breaking-changes/migrations/node-migration.ts
+++ b/packages/cli/src/modules/breaking-changes/migrations/node-migration.ts
@@ -1,4 +1,20 @@
-import type { INode } from 'n8n-workflow';
+import type { IConnections, INode } from 'n8n-workflow';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+/**
+ * A migration refused a specific node. Carries the node identity in `meta` so the
+ * UI can link straight to it.
+ */
+export class WorkflowMigrationNodeError extends BadRequestError {
+	constructor(
+		message: string,
+		readonly meta: { nodeId: string; nodeName: string },
+	) {
+		super(message);
+		this.name = 'WorkflowMigrationNodeError';
+	}
+}
 
 export interface NodeMigrationResult {
 	// The replacement node's type/version/parameters. The rewrite engine keeps
@@ -19,3 +35,35 @@ export interface NodeMigration {
 	// Pure, per node. Return the replacement node; throw to abort with an error.
 	migrate(node: INode): NodeMigrationResult;
 }
+
+export interface WorkflowMigrationInput {
+	nodes: INode[];
+	connections: IConnections;
+	// Ids of the nodes the rule flagged. Detection decides what gets migrated.
+	affectedNodeIds: Set<string>;
+}
+
+export interface WorkflowMigrationOutput {
+	nodes: INode[];
+	connections: IConnections;
+	// Ids of the flagged nodes that were rewritten (not the nodes added around them).
+	migratedNodeIds: string[];
+	unmapped?: string[];
+	notes?: string[];
+}
+
+/**
+ * A whole-workflow transform for changes a node-for-node swap cannot express,
+ * such as inserting nodes and rewiring connections. Must not mutate its input:
+ * return new `nodes` and `connections`. Throw `WorkflowMigrationNodeError` to
+ * refuse a specific node, or any other Error to abort the workflow.
+ */
+export interface WorkflowMigration {
+	ruleId: string;
+	migrateWorkflow(input: WorkflowMigrationInput): WorkflowMigrationOutput;
+}
+
+export type Migration = NodeMigration | WorkflowMigration;
+
+export const isWorkflowMigration = (migration: Migration): migration is WorkflowMigration =>
+	'migrateWorkflow' in migration;


### PR DESCRIPTION
## Summary

Introduce a workflow-level auto-migration for replace with run-once-for-each-item sub-workflow execution mode with a Loop node.

This builds on the existing auto-migration tooling that was built per-node, and extends it to changes that modify the workflow as a whole.

Demo: [Loom](https://www.loom.com/share/bde2587b90ac461d8c78e79a85973fd6)

### Validation

- All 302 tests in the breaking-changes module pass.
- ESLint passes for the three changed files.
- Package typecheck reports the same 98 errors on the unmodified PR and this revision. The isolated worktree uses dependencies from the current checkout.
- Package-wide lint reports errors outside the three changed files. CI must validate this revision with its own dependency build.

## How to test

1. Set `MIGRATION_REPORT_TARGET_VERSION = 'v3'` in `packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts`. Build and start n8n.
2. Import the two workflows below. Replace `SUB_WORKFLOW_ID` with the imported sub-workflow ID. Publish both workflows.
3. Call `GET /webhook/spike-each`. Record the output.
4. Open **Settings → Migration report → Execute Sub-workflow "Run once for each item" mode removed**. Click **Migrate** for the parent workflow.
5. Check that the result asks for review and testing. Check that it does not offer **Publish**.
6. Open the parent. Check the loop and Always Output Data setting. Check that the loop connects directly to the original successors. Test the draft before publishing it through the editor.
7. Repeat with Wait For Sub-Workflow Completion disabled. Check that the migration leaves Always Output Data unchanged and still requires review.
8. Make one child execution return zero items. Check that the remaining inputs are processed and the output includes an extra empty item.
9. Make the child return an item with empty JSON and no binary data. Check that the item reaches the loop output. Repeat with binary data and check that the item also reaches the output.
10. Invoke the migrated node twice from an outer loop. Check that each invocation processes its inputs.
11. Check the additional notes for Retry On Fail, Execute Once, error-output routing, and expressions that reference the wrapped node. Review index-sensitive expressions and pinned data manually.

<details>
<summary>Sub-workflow</summary>

```json
{
  "name": "[test] sub",
  "nodes": [
    {
      "parameters": { "inputSource": "passthrough" },
      "id": "11111111-1111-4111-8111-111111111111",
      "name": "When Executed by Another Workflow",
      "type": "n8n-nodes-base.executeWorkflowTrigger",
      "typeVersion": 1.1,
      "position": [0, 0]
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            { "id": "a1", "name": "doubled", "value": "={{ $json.list * 2 }}", "type": "number" },
            { "id": "a2", "name": "itemsInThisRun", "value": "={{ $input.all().length }}", "type": "number" }
          ]
        },
        "includeOtherFields": true,
        "options": {}
      },
      "id": "22222222-2222-4222-8222-222222222222",
      "name": "Compute",
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [220, 0]
    }
  ],
  "connections": {
    "When Executed by Another Workflow": { "main": [[{ "node": "Compute", "type": "main", "index": 0 }]] }
  },
  "settings": { "executionOrder": "v1" }
}
```

</details>

<details>
<summary>Parent workflow</summary>

```json
{
  "name": "[test] parent",
  "nodes": [
    {
      "parameters": { "path": "spike-each", "responseMode": "lastNode", "responseData": "allEntries", "options": {} },
      "id": "33333333-3333-4333-8333-333333333333",
      "name": "Webhook",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 2.1,
      "position": [0, 0],
      "webhookId": "44444444-4444-4444-8444-444444444444"
    },
    {
      "parameters": {
        "assignments": { "assignments": [{ "id": "b1", "name": "list", "value": "={{ [1, 2, 3] }}", "type": "array" }] },
        "options": {}
      },
      "id": "55555555-5555-4555-8555-555555555555",
      "name": "Seed",
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [220, 0]
    },
    {
      "parameters": { "fieldToSplitOut": "list", "options": {} },
      "id": "66666666-6666-4666-8666-666666666666",
      "name": "Split Out",
      "type": "n8n-nodes-base.splitOut",
      "typeVersion": 1,
      "position": [440, 0]
    },
    {
      "parameters": {
        "source": "database",
        "workflowId": { "__rl": true, "value": "SUB_WORKFLOW_ID", "mode": "id" },
        "mode": "each",
        "options": {}
      },
      "id": "77777777-7777-4777-8777-777777777777",
      "name": "Execute Sub-workflow",
      "type": "n8n-nodes-base.executeWorkflow",
      "typeVersion": 1.3,
      "position": [660, 0]
    },
    {
      "parameters": {},
      "id": "88888888-8888-4888-8888-888888888888",
      "name": "End",
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [880, 0]
    }
  ],
  "connections": {
    "Webhook": { "main": [[{ "node": "Seed", "type": "main", "index": 0 }]] },
    "Seed": { "main": [[{ "node": "Split Out", "type": "main", "index": 0 }]] },
    "Split Out": { "main": [[{ "node": "Execute Sub-workflow", "type": "main", "index": 0 }]] },
    "Execute Sub-workflow": { "main": [[{ "node": "End", "type": "main", "index": 0 }]] }
  },
  "settings": { "executionOrder": "v1" }
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-4214
- https://linear.app/n8n/issue/NODE-5504
- Builds on #34803

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
