### PR TITLE
fix(editor): Restore tag text hidden by zero line-height

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTag/Tag.vue
@@ -51,6 +51,7 @@ withDefaults(defineProps<TagProps>(), {
 
 .text {
 	min-width: 0;
+	line-height: normal;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;


### PR DESCRIPTION
## Summary

Since #37878, every plain-text `N8nTag` renders as an empty box. The migration report severity tags are one visible example.

The tag text span inherits `--tag--line-height: 0`. #37878 added `overflow: hidden` to that span for truncation. A box with zero line-height and hidden overflow clips all of its text.

This PR gives the span `line-height: normal`. The text shows again. The truncation from #37878 still works, because `min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis` and `white-space: nowrap` stay in place. The AIA context chips are not affected: they render through the `tag` slot and set their own line-height.

**Before:**

<img width="2880" height="1800" alt="n8n test_settings_migration-report (1)" src="https://github.com/user-attachments/assets/3b722869-2741-43f9-b96e-0728c68e6357" />

**After:**

<img width="2880" height="1800" alt="n8n test_settings_migration-report" src="https://github.com/user-attachments/assets/f2038e54-72fe-4f76-aded-cc05ad33aadc" />


## How to test

1. Open **Settings > Migration report** on an instance with at least one workflow issue.
2. Check that the severity tag next to each issue title shows its text (Critical / Medium / Low).
3. Open a workflow list with tags and check the tags show text.
4. Open the AI Assistant, add a context chip with a long name, and check that it still truncates with an ellipsis.

## Related Linear tickets, Github issues, and Community forum posts

Regression from #37878.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

