### PR TITLE
feat(core): Add a shared entity file formatter for package exports (no-changelog)

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/entity-file-format-fence.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/entity-file-format-fence.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const MODULE_DIR = path.resolve(__dirname, '..');
+const IO_DIR = path.join(MODULE_DIR, 'io');
+const INLINE_TAB_STRINGIFY = /JSON\.stringify\([^)]*["']\\t["']/;
+
+describe('entity file format fence', () => {
+	it('has no tab-indented JSON.stringify outside io/, so formatEntityFile stays the only formatter', () => {
+		const offenders = readdirSync(MODULE_DIR, { withFileTypes: true, recursive: true })
+			.filter(
+				(entry) =>
+					entry.isFile() &&
+					entry.name.endsWith('.ts') &&
+					!entry.name.endsWith('.test.ts') &&
+					!entry.parentPath.includes('__tests__') &&
+					!entry.parentPath.startsWith(IO_DIR),
+			)
+			.map((entry) => path.join(entry.parentPath, entry.name))
+			.filter((file) => INLINE_TAB_STRINGIFY.test(readFileSync(file, 'utf8')))
+			.map((file) => path.relative(MODULE_DIR, file));
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-git-blob-parity.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-git-blob-parity.integration.test.ts
@@ -1,0 +1,109 @@
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { WorkflowRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { jsonParse } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { simpleGit } from 'simple-git';
+
+import { createOwner } from '@test-integration/db/users';
+
+import { WorkflowSerializer } from '../entities/workflow/workflow.serializer';
+import { formatEntityFile } from '../io/entity-file-format';
+import { N8nPackagesService } from '../n8n-packages.service';
+import { packageManifestSchema } from '../spec/manifest.schema';
+
+/** SHA-1 over git's blob object format: `blob <byte length>\0<content>`. */
+function gitBlobHash(content: string): string {
+	const bytes = Buffer.from(content, 'utf-8');
+	const header = Buffer.from(`blob ${bytes.length}\0`, 'utf-8');
+	return createHash('sha1')
+		.update(Buffer.concat([header, bytes]))
+		.digest('hex');
+}
+
+let service: N8nPackagesService;
+let owner: User;
+let repoDir: string;
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	service = Container.get(N8nPackagesService);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'ProjectRelation', 'Project']);
+	owner = await createOwner();
+	repoDir = await mkdtemp(join(tmpdir(), 'n8n-export-parity-'));
+});
+
+afterEach(async () => {
+	await rm(repoDir, { recursive: true, force: true });
+});
+
+describe('exported files vs git blob hashes', () => {
+	it('hashes a workflow serialized through formatEntityFile to the blob sha git records for its exported file', async () => {
+		const project = await createTeamProject('Parity Project', owner);
+		const workflow = await createWorkflow(
+			{
+				// Non-ASCII content pins the utf-8 byte length in the blob header.
+				name: 'Zürich Parity Flow',
+				nodes: [
+					{
+						id: 'set-greeting',
+						name: 'Set',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3.4,
+						position: [200, 0],
+						parameters: {
+							assignments: {
+								assignments: [{ id: 'a1', name: 'greeting', type: 'string', value: 'grüße ✓' }],
+							},
+						},
+					},
+				],
+				connections: {},
+			},
+			project,
+		);
+
+		await service.exportPackageToDirectory(
+			{ user: owner, workflowIds: [workflow.id] },
+			{ targetDir: repoDir },
+		);
+
+		const git = simpleGit(repoDir);
+		await git.init();
+		await git.addConfig('user.email', 'parity@example.com');
+		await git.addConfig('user.name', 'Parity');
+		await git.addConfig('commit.gpgsign', 'false');
+		await git.add('.');
+		await git.commit('export');
+
+		const manifest = packageManifestSchema.parse(
+			jsonParse(await readFile(join(repoDir, 'manifest.json'), 'utf-8')),
+		);
+		const workflowPath = `${manifest.workflows![0].target}/workflow.json`;
+		const lsTree = await git.raw(['ls-tree', 'HEAD', '--', workflowPath]);
+		const committedHash = lsTree.trim().split('\t')[0].split(' ')[2];
+		expect(committedHash).toBeDefined();
+
+		const persistedWorkflow = await Container.get(WorkflowRepository).findOneOrFail({
+			where: { id: workflow.id },
+			relations: { parentFolder: true, tags: true },
+		});
+		const serialized = Container.get(WorkflowSerializer).serialize(persistedWorkflow, {
+			includeTags: true,
+		});
+
+		expect(gitBlobHash(formatEntityFile(serialized))).toBe(committedHash);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/io/entity-file-format.ts
+++ b/packages/cli/src/modules/n8n-packages/io/entity-file-format.ts
@@ -1,0 +1,8 @@
+/**
+ * The single source of entity-file bytes: exporters write them and the diff
+ * engine hashes them, so both must call this function or their hashes drift
+ * apart and unchanged entities show up as diffs.
+ */
+export function formatEntityFile(serialized: unknown): string {
+	return JSON.stringify(serialized, null, '\t');
+}

--- a/packages/cli/src/modules/n8n-packages/io/manifest-entry.ts
+++ b/packages/cli/src/modules/n8n-packages/io/manifest-entry.ts
@@ -1,3 +1,4 @@
+import { formatEntityFile } from './entity-file-format';
 import type { PackageWriter } from './package-writer';
 import { generateSlug } from './slug.utils';
 import { PackageExportBlockedError } from '../entities/package-export.errors';
@@ -116,9 +117,6 @@ export async function writeManifestEntry(
 ): Promise<ManifestEntry> {
 	const entry = createManifestEntry(collection, baseDir, entity);
 	await writer.writeDirectory(entry.target);
-	await writer.writeFile(
-		entityFilePath(collection, entry.target),
-		JSON.stringify(serialized, null, '\t'),
-	);
+	await writer.writeFile(entityFilePath(collection, entry.target), formatEntityFile(serialized));
 	return entry;
 }

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -35,6 +35,7 @@ import { WorkflowRequirementExporter } from './entities/workflow/workflow-requir
 import { WorkflowExporter } from './entities/workflow/workflow.exporter';
 import { DirectoryPackageReader } from './io/directory/directory-package-reader';
 import { DirectoryPackageWriter } from './io/directory/directory-package-writer';
+import { formatEntityFile } from './io/entity-file-format';
 import type { PackageReader } from './io/package-reader';
 import type { PackageWriter } from './io/package-writer';
 import { TarPackageReader } from './io/tar/tar-package-reader';
@@ -341,7 +342,7 @@ export class N8nPackagesService {
 			...(allProjects.length > 0 ? { projects: allProjects } : {}),
 		});
 
-		await writer.writeFile('manifest.json', JSON.stringify(manifest, null, '\t'));
+		await writer.writeFile('manifest.json', formatEntityFile(manifest));
 
 		const counts: ExportPackageEventCounts = {
 			workflows: allWorkflowsInPackage.length,


### PR DESCRIPTION
## Summary

The diff engine will compare the instance against a branch by hashing what the exporter writes. That only holds if both sides produce the same bytes. This PR makes the guarantee real:

- Extract the entity-file formatting into one exported function: `formatEntityFile` in `n8n-packages/io/entity-file-format.ts`. `writeManifestEntry` and the `manifest.json` write now call it. Export bytes are unchanged.
- Pin it twice:
  - An integration test exports a workflow with non-ASCII content through the real service, commits the export directory in a temporary git repository, and asserts git's `ls-tree` blob SHA equals the SHA-1 of `blob <utf8-byte-length>\0<formatted bytes>` over the shared function's output. The non-ASCII fixture pins the utf-8 byte-length semantics of the blob header.
  - A fence unit test scans the module's non-test sources and fails on any tab-indented `JSON.stringify` outside `io/`.

The diff engine (LIGO-1050) hashes with the same function, so the exporter and the engine cannot drift apart.

## How to test

From `packages/cli`:

```bash
pnpm test:unit src/modules/n8n-packages
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false pnpm test:integration src/modules/n8n-packages/__tests__/export-git-blob-parity.integration.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-1135

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI