### PR TITLE
chore(editor): Add a lint gate for shell-resident eager modal definitions (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-config/src/rules/index.ts
+++ b/packages/@n8n/eslint-config/src/rules/index.ts
@@ -35,6 +35,7 @@ import { NoOnLeaderTakeoverRule } from './no-on-leader-takeover.js';
 import { NoMisplacedCipherPrimitivesRule } from './no-misplaced-cipher-primitives.js';
 import { NoDeploymentKeyDeleteRule } from './no-deployment-key-delete.js';
 import { NoEncryptionGuardrailDisableRule } from './no-encryption-guardrail-disable.js';
+import { NoShellResidentEagerModalRule } from './no-shell-resident-eager-modal.js';
 
 export const rules = {
 	'no-uncaught-json-parse': NoUncaughtJsonParseRule,
@@ -73,4 +74,5 @@ export const rules = {
 	'no-misplaced-cipher-primitives': NoMisplacedCipherPrimitivesRule,
 	'no-deployment-key-delete': NoDeploymentKeyDeleteRule,
 	'no-encryption-guardrail-disable': NoEncryptionGuardrailDisableRule,
+	'no-shell-resident-eager-modal': NoShellResidentEagerModalRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-config/src/rules/no-shell-resident-eager-modal.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-shell-resident-eager-modal.test.ts
@@ -1,0 +1,170 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { NoShellResidentEagerModalRule } from './no-shell-resident-eager-modal.js';
+
+const ruleTester = new RuleTester();
+
+const MANIFEST = '/repo/packages/frontend/editor-ui/src/app/modals.manifest.ts';
+
+ruleTester.run('no-shell-resident-eager-modal', NoShellResidentEagerModalRule, {
+	valid: [
+		{
+			name: 'a single fragment imported through the alias',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '@/features/core/auth/modals';
+				const eagerModals: ModalDefinition[] = [...AUTH_MODALS];
+			`,
+		},
+		{
+			name: 'several fragments, and an import that follows the declaration',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '@/features/core/auth/modals';
+				const eagerModals: ModalDefinition[] = [...AUTH_MODALS, ...SSO_MODALS];
+				import { SSO_MODALS } from '@/features/settings/sso/modals';
+			`,
+		},
+		{
+			name: 'a relative path into src/features',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '../features/core/auth/modals';
+				const eagerModals: ModalDefinition[] = [...AUTH_MODALS];
+			`,
+		},
+		{
+			name: 'a namespace import from a feature',
+			filename: MANIFEST,
+			code: `
+				import * as authModals from '@/features/core/auth/modals';
+				const eagerModals: ModalDefinition[] = [...authModals.AUTH_MODALS];
+			`,
+		},
+		{
+			name: 'a default import from a feature',
+			filename: MANIFEST,
+			code: `
+				import authModals from '@/features/core/auth/modals';
+				const eagerModals: ModalDefinition[] = [...authModals];
+			`,
+		},
+		{
+			name: 'an empty array is not a reacquisition',
+			filename: MANIFEST,
+			code: 'const eagerModals: ModalDefinition[] = [];',
+		},
+		{
+			name: 'a satisfies assertion around the literal',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '@/features/core/auth/modals';
+				const eagerModals = [...AUTH_MODALS] satisfies ModalDefinition[];
+			`,
+		},
+	],
+
+	invalid: [
+		{
+			// The case this gate exists for: the definition lives in the shell file.
+			name: 'an inline definition in the shell file',
+			filename: MANIFEST,
+			code: `
+				import { SHELL_MODAL_KEY } from '@/app/constants/modals';
+				const eagerModals: ModalDefinition[] = [
+					{
+						key: SHELL_MODAL_KEY,
+						component: async () => await import('./components/ShellModal.vue'),
+						initialState: { open: false },
+					},
+				];
+			`,
+			errors: [{ messageId: 'definedInShell' }],
+		},
+		{
+			name: 'an inline definition next to a legitimate fragment',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '@/features/core/auth/modals';
+				const eagerModals: ModalDefinition[] = [...AUTH_MODALS, { key: 'sneaky', component: {} }];
+			`,
+			errors: [{ messageId: 'definedInShell' }],
+		},
+		{
+			// A shell-resident fragment: defined in the same file, spread like a feature one.
+			name: 'a spread of a fragment declared in the shell file',
+			filename: MANIFEST,
+			code: `
+				const SHELL_MODALS: ModalDefinition[] = [{ key: 'shell', component: {} }];
+				const eagerModals: ModalDefinition[] = [...SHELL_MODALS];
+			`,
+			errors: [{ messageId: 'definedInShell' }],
+		},
+		{
+			// A shell-resident fragment in a sibling shell file.
+			name: 'a spread of a fragment imported from another shell file',
+			filename: MANIFEST,
+			code: `
+				import { SHELL_MODALS } from '@/app/shell-modals';
+				const eagerModals: ModalDefinition[] = [...SHELL_MODALS];
+			`,
+			errors: [
+				{
+					messageId: 'nonFeatureOrigin',
+					data: { imported: 'SHELL_MODALS', source: '@/app/shell-modals' },
+				},
+			],
+		},
+		{
+			name: 'a spread of a fragment imported by a relative shell path',
+			filename: MANIFEST,
+			code: `
+				import { SHELL_MODALS } from './shell-modals';
+				const eagerModals: ModalDefinition[] = [...SHELL_MODALS];
+			`,
+			errors: [{ messageId: 'nonFeatureOrigin' }],
+		},
+		{
+			// A module package is not `src/features/**`. It stays a rejection until the
+			// gate is widened on purpose, in the change that needs it.
+			name: 'a spread of a fragment imported from a module package',
+			filename: MANIFEST,
+			code: `
+				import { OTEL_MODALS } from '@n8n/frontend-module-otel';
+				const eagerModals: ModalDefinition[] = [...OTEL_MODALS];
+			`,
+			errors: [{ messageId: 'nonFeatureOrigin' }],
+		},
+		{
+			name: 'one error per bad entry',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '@/features/core/auth/modals';
+				import { SHELL_MODALS } from '@/app/shell-modals';
+				const eagerModals: ModalDefinition[] = [
+					...AUTH_MODALS,
+					...SHELL_MODALS,
+					{ key: 'inline', component: {} },
+				];
+			`,
+			errors: [{ messageId: 'nonFeatureOrigin' }, { messageId: 'definedInShell' }],
+		},
+		{
+			name: 'an expression that hides the entries from the gate',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '@/features/core/auth/modals';
+				const eagerModals: ModalDefinition[] = AUTH_MODALS.concat(SHELL_MODALS);
+			`,
+			errors: [{ messageId: 'notAnArray' }],
+		},
+		{
+			name: 'the declaration is renamed, so the gate would read nothing',
+			filename: MANIFEST,
+			code: `
+				import { AUTH_MODALS } from '@/features/core/auth/modals';
+				const preLoginModals: ModalDefinition[] = [...AUTH_MODALS];
+			`,
+			errors: [{ messageId: 'missingDeclaration' }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/no-shell-resident-eager-modal.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-shell-resident-eager-modal.ts
@@ -1,0 +1,115 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+import path from 'node:path';
+
+const EAGER_MODALS = 'eagerModals';
+const FEATURE_ALIAS = '@/features/';
+const FEATURE_DIRECTORY = /(?:^|\/)src\/features\//;
+
+const EXAMPLE = 'To see an example, open src/features/core/auth/modals.ts.';
+
+/** `X as ModalDefinition[]` and `X satisfies ModalDefinition[]` wrap the initializer. */
+const unwrapAssertion = (node: TSESTree.Expression): TSESTree.Expression =>
+	node.type === 'TSAsExpression' || node.type === 'TSSatisfiesExpression'
+		? unwrapAssertion(node.expression)
+		: node;
+
+/** `...AUTH_MODALS` → `AUTH_MODALS`; `...authModals.eager` → `authModals`. */
+const rootIdentifier = (node: TSESTree.Node): string | null => {
+	if (node.type === 'Identifier') return node.name;
+	if (node.type === 'MemberExpression') return rootIdentifier(node.object);
+	return null;
+};
+
+const isFeatureOrigin = (source: string, filename: string) => {
+	if (source.startsWith(FEATURE_ALIAS)) return true;
+	if (!source.startsWith('.')) return false;
+
+	const fromDirectory = path.posix.dirname(filename.split(path.win32.sep).join('/'));
+
+	return FEATURE_DIRECTORY.test(path.posix.join(fromDirectory, source));
+};
+
+export const NoShellResidentEagerModalRule = ESLintUtils.RuleCreator.withoutDocs({
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Enforce that every `eagerModals` entry is a modal fragment imported from `src/features/**`.',
+		},
+		messages: {
+			definedInShell:
+				'Do not define an eager modal in the shell. `eagerModals` accepts only a spread of a `ModalDefinition[]` fragment that is imported from `src/features/**`. A definition that lives in the shell gives the shell the modal key back, which is what the extraction gives up. Move the definition to the modals.ts fragment of the feature that owns it, then spread that fragment here. ' +
+				EXAMPLE,
+			nonFeatureOrigin:
+				'Do not spread "{{ imported }}" into `eagerModals`. Its origin "{{ source }}" is not under `src/features/**`, so the shell owns the modal key again. Move the fragment to the feature that owns the modal, then import it from `@/features/...`. ' +
+				EXAMPLE,
+			notAnArray:
+				'Declare `eagerModals` as an array literal of spread fragments, for example `[...AUTH_MODALS]`. This gate reads each entry of that literal. Any other expression hides the origin of the entries from the gate.',
+			missingDeclaration:
+				'This file must declare `eagerModals`. The gate that keeps a shell-resident modal definition out of the eager phase reads that name. A rename turns the gate off without any error. Keep the name, or update `n8n-local-rules/no-shell-resident-eager-modal` in the same change.',
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+	create(context) {
+		const importSources = new Map<string, string>();
+		let declaration: TSESTree.VariableDeclarator | undefined;
+
+		return {
+			// Collected up front: an `import` may follow the declaration in source order.
+			Program(node) {
+				for (const statement of node.body) {
+					if (statement.type !== 'ImportDeclaration') continue;
+
+					for (const specifier of statement.specifiers) {
+						importSources.set(specifier.local.name, statement.source.value);
+					}
+				}
+			},
+
+			VariableDeclarator(node) {
+				if (node.id.type !== 'Identifier' || node.id.name !== EAGER_MODALS) return;
+
+				declaration = node;
+
+				const initializer = node.init ? unwrapAssertion(node.init) : null;
+
+				if (initializer?.type !== 'ArrayExpression') {
+					context.report({ node: node.init ?? node, messageId: 'notAnArray' });
+					return;
+				}
+
+				for (const element of initializer.elements) {
+					if (element === null) continue;
+
+					if (element.type !== 'SpreadElement') {
+						context.report({ node: element, messageId: 'definedInShell' });
+						continue;
+					}
+
+					const local = rootIdentifier(element.argument);
+					const source = local === null ? undefined : importSources.get(local);
+
+					if (local === null || source === undefined) {
+						context.report({ node: element, messageId: 'definedInShell' });
+						continue;
+					}
+
+					if (!isFeatureOrigin(source, context.filename)) {
+						context.report({
+							node: element,
+							messageId: 'nonFeatureOrigin',
+							data: { imported: local, source },
+						});
+					}
+				}
+			},
+
+			'Program:exit'() {
+				if (declaration === undefined) {
+					context.report({ loc: { line: 1, column: 0 }, messageId: 'missingDeclaration' });
+				}
+			},
+		};
+	},
+});

--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -319,6 +319,15 @@ export default defineConfig(
 		},
 	},
 	{
+		// Extraction gate: the eager phase must not become a third way for the shell to
+		// reacquire a modal key. Error level, and only on the manifest — the rule reads
+		// the `eagerModals` literal, so it means nothing anywhere else.
+		files: ['src/app/modals.manifest.ts'],
+		rules: {
+			'n8n-local-rules/no-shell-resident-eager-modal': 'error',
+		},
+	},
+	{
 		files: ['src/features/agents/**/*.ts', 'src/features/agents/**/*.vue'],
 		rules: {
 			'@typescript-eslint/no-restricted-imports': [

--- a/packages/frontend/editor-ui/src/app/modals.manifest.ts
+++ b/packages/frontend/editor-ui/src/app/modals.manifest.ts
@@ -10,6 +10,10 @@ import { AUTH_MODALS } from '@/features/core/auth/modals';
  * preview/demo mode, or a navigation that throws before it (the
  * `MfaRequiredError` redirect still renders Personal Settings). Everything else
  * is module-owned and registers post-login through its descriptor.
+ *
+ * Every entry must be a spread of a fragment imported from `src/features/**`. A
+ * definition that lives in the shell gives the shell back a modal key that the
+ * extraction gives up. `n8n-local-rules/no-shell-resident-eager-modal` rejects one.
  */
 const eagerModals: ModalDefinition[] = [...AUTH_MODALS];
 


### PR DESCRIPTION
## Summary

`eagerModals` in `packages/frontend/editor-ui/src/app/modals.manifest.ts` is the pre-mount half of modal registration. It spreads `AUTH_MODALS` from `@/features/core/auth/modals`. Nothing stopped a future edit from putting a modal definition in the shell file itself, or importing a fragment from a shell path. Such an edit gives the shell back a modal key that a feature extraction gives up. The two existing modal-key ratchets (`src/app/constants/modals.ts` and `src/app/stores/defaults/modals.ts`) do not see that path.

This PR adds the lint rule `n8n-local-rules/no-shell-resident-eager-modal`, next to the other custom rules in `packages/@n8n/eslint-config`.

The rule reads the import origin of each entry of the `eagerModals` array literal:

| Entry | Result |
| --- | --- |
| A spread of a fragment imported from `@/features/**`, or a relative path into `src/features/**` | accepted |
| An inline object definition | rejected — `definedInShell` |
| A spread of a fragment declared in the same shell file | rejected — `definedInShell` |
| A spread of a fragment imported from any other path, for example `@/app/…` or a module package | rejected — `nonFeatureOrigin` |
| A non-literal initializer, for example `A.concat(B)` | rejected — `notAnArray` |
| No `eagerModals` declaration in the file | rejected — `missingDeclaration` |

The last case keeps a rename from turning the gate off silently.

The rule is enabled at **error** level on `src/app/modals.manifest.ts` only, in `packages/frontend/editor-ui/eslint.config.mjs`. It is not in any shared config, so no other file pays for it. `pnpm lint:ci` runs `eslint src --quiet` for editor-ui, so the gate runs in CI on the path it protects.

**Note for reviewers:** a module package such as `@n8n/frontend-module-otel` is a rejection today, because the acceptance criterion is `src/features/**`. If an extracted module ever needs an eager modal, widen `isFeatureOrigin` in that change, on purpose.

## How to test

Unit tests — 16 cases, 7 accepted and 9 rejected:

```bash
pnpm --filter @n8n/eslint-config test src/rules/no-shell-resident-eager-modal.test.ts
```

The gate in the real config. The manifest is clean today:

```bash
pnpm --filter n8n-editor-ui exec eslint src/app/modals.manifest.ts
```

To see a rejection, add a shell-resident definition to `eagerModals` in `src/app/modals.manifest.ts`, then run the same command:

```ts
const eagerModals: ModalDefinition[] = [
  ...AUTH_MODALS,
  { key: 'inlineShellModal', component: async () => await import('./App.vue') },
];
```

```text
21:2  error  Do not define an eager modal in the shell. ...  n8n-local-rules/no-shell-resident-eager-modal
✖ 1 problem (1 error, 0 warnings)
```

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to the review of #36324. Gate 1 of two; the second gate (an `--update` command for the exact-match modal baseline) is a separate PR.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

