### PR TITLE
feat(engine): Add the control plane client that resolves credentials for the data plane (no-changelog)

### DIFF
--- a/packages/cli/src/modules/engine-v2/__tests__/engine-credentials-client.test.ts
+++ b/packages/cli/src/modules/engine-v2/__tests__/engine-credentials-client.test.ts
@@ -1,0 +1,112 @@
+import type { HttpRequestClient } from '@n8n/backend-network';
+import type { ActionScope } from '@n8n/engine';
+import { OperationalError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { EngineControlPlaneTransport } from '../engine-control-plane-transport';
+import { EngineCredentialsClient } from '../engine-credentials-client';
+import type { ResolveCredentialRequest } from '../engine-credentials.contract';
+
+const request: ResolveCredentialRequest = {
+	credential: { id: 'cred-1', name: 'Header Auth account', type: 'httpHeaderAuth' },
+	execution: { executionId: 'exec-1', workflowId: 'wf-1', mode: 'manual' },
+	context: { userId: 'user-1', projectId: 'project-1' },
+	consumer: { nodeType: 'n8n-nodes-base.httpRequest' },
+};
+
+const decrypted = { name: 'X-Api-Key', value: 'secret' };
+
+describe('EngineCredentialsClient', () => {
+	let http: HttpRequestClient;
+	let requestedScope: ActionScope | undefined;
+	let client: EngineCredentialsClient;
+	let signal: AbortSignal;
+
+	const respondWith = (statusCode: number, body: unknown = { data: decrypted }) => {
+		vi.mocked(http.request).mockResolvedValue({ statusCode, body, headers: {} });
+	};
+
+	beforeEach(() => {
+		http = mock<HttpRequestClient>();
+		const transport = mock<EngineControlPlaneTransport>({
+			forScope: vi.fn((scope: ActionScope) => {
+				requestedScope = scope;
+				return http;
+			}),
+		});
+		client = new EngineCredentialsClient(transport);
+		signal = new AbortController().signal;
+	});
+
+	it('asks the transport for a client scoped to credential reads', () => {
+		expect(requestedScope).toBe('credentials:read');
+	});
+
+	describe('resolve credential', () => {
+		it('posts the request as the body of the credentials resolve endpoint', async () => {
+			respondWith(200);
+
+			await client.resolve(request, signal);
+
+			expect(http.request).toHaveBeenCalledWith(
+				expect.objectContaining({
+					url: '/internal/credentials/resolve',
+					method: 'POST',
+					body: request,
+					json: true,
+				}),
+			);
+		});
+
+		it('does not follow redirects, so the action token reaches only the configured host', async () => {
+			respondWith(200);
+
+			await client.resolve(request, signal);
+
+			expect(http.request).toHaveBeenCalledWith(
+				expect.objectContaining({ disableFollowRedirect: true }),
+			);
+		});
+
+		it("forwards the step's abort signal, so an abandoned step cancels its request", async () => {
+			respondWith(200);
+
+			await client.resolve(request, signal);
+
+			expect(http.request).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: signal }));
+		});
+
+		it('returns the decrypted data of a 200', async () => {
+			respondWith(200);
+
+			await expect(client.resolve(request, signal)).resolves.toEqual(decrypted);
+		});
+
+		it.each([302, 400, 401, 403, 404, 500])(
+			'rejects with the status when the control plane answered %s',
+			async (statusCode) => {
+				respondWith(statusCode, { message: 'details the node must not see' });
+
+				const error = await client.resolve(request, signal).catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(OperationalError);
+				expect((error as Error).message).toContain(String(statusCode));
+				expect((error as Error).message).toContain(request.credential.id);
+				expect((error as Error).message).not.toContain('details the node must not see');
+			},
+		);
+
+		it.each([
+			['an empty body', ''],
+			['a string body', 'ok'],
+			['an object without data', { credential: decrypted }],
+			['a data field that is not an object', { data: 'secret' }],
+			['a data field that is an array', { data: [decrypted] }],
+		])('rejects a 200 with %s', async (_label, body) => {
+			respondWith(200, body);
+
+			await expect(client.resolve(request, signal)).rejects.toThrow(OperationalError);
+			await expect(client.resolve(request, signal)).rejects.toThrow('malformed');
+		});
+	});
+});

--- a/packages/cli/src/modules/engine-v2/engine-credentials-client.ts
+++ b/packages/cli/src/modules/engine-v2/engine-credentials-client.ts
@@ -1,0 +1,62 @@
+import type { HttpRequestClient } from '@n8n/backend-network';
+import { Service } from '@n8n/di';
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { OperationalError } from 'n8n-workflow';
+
+import { EngineControlPlaneTransport } from './engine-control-plane-transport';
+import { isResolveCredentialResponse } from './engine-credentials.contract';
+import type { ResolveCredentialRequest } from './engine-credentials.contract';
+import { CREDENTIALS_RESOLVE_PATH } from './engine-v2.constants';
+
+/**
+ * Asks the control plane server for the decrypted data of one credential.
+ * Over HTTP even in-process, so the data plane never touches the credential
+ * store or the encryption key.
+ */
+@Service()
+export class EngineCredentialsClient {
+	private readonly http: HttpRequestClient;
+
+	constructor(transport: EngineControlPlaneTransport) {
+		this.http = transport.forScope('credentials:read');
+	}
+
+	/**
+	 * Throws on a non-2xx status or a body without `data`. Error messages omit
+	 * the response body, because a server error body could contain credential
+	 * data that would then end up in node output and logs.
+	 */
+	async resolve(
+		request: ResolveCredentialRequest,
+		signal: AbortSignal,
+	): Promise<ICredentialDataDecryptedObject> {
+		const response = await this.http.request<unknown>({
+			url: CREDENTIALS_RESOLVE_PATH,
+			method: 'POST',
+			body: request,
+			json: true,
+			returnFullResponse: true,
+			// Inspect the status here rather than catching a generic request error.
+			ignoreHttpStatusErrors: true,
+			// A redirect would forward the token to whatever host it names.
+			disableFollowRedirect: true,
+			// The step owns the deadline. A client timeout would fire first.
+			abortSignal: signal,
+		});
+
+		// 3xx too: redirects are not followed, so one is a misconfiguration.
+		if (response.statusCode >= 300) {
+			throw new OperationalError(
+				`Control plane refused to resolve credential "${request.credential.id}" with ${response.statusCode}`,
+			);
+		}
+
+		if (!isResolveCredentialResponse(response.body)) {
+			throw new OperationalError(
+				`Control plane returned a malformed response for credential "${request.credential.id}"`,
+			);
+		}
+
+		return response.body.data;
+	}
+}

--- a/packages/cli/src/modules/engine-v2/engine-credentials.contract.ts
+++ b/packages/cli/src/modules/engine-v2/engine-credentials.contract.ts
@@ -40,3 +40,10 @@ export type ResolveCredentialRequest = z.infer<typeof resolveCredentialRequestSc
 export interface ResolveCredentialResponse {
 	data: ICredentialDataDecryptedObject;
 }
+
+/** Narrows a parsed response body. The client trusts nothing else about it. */
+export function isResolveCredentialResponse(body: unknown): body is ResolveCredentialResponse {
+	if (typeof body !== 'object' || body === null || !('data' in body)) return false;
+	const { data } = body;
+	return typeof data === 'object' && data !== null && !Array.isArray(data);
+}


### PR DESCRIPTION
## Summary

Part of the credentials support work for Engine v2. Stacked on #37978: this PR only adds new code and changes nothing that runs today.

New `EngineCredentialsClient` service in the `engine-v2` module. The data plane will use it to ask the control plane server for the decrypted data of one credential, over HTTP even when both run in the same process.

- The constructor takes `EngineControlPlaneTransport` and requests an HTTP client scoped to `credentials:read`.
- `resolve(request, signal)` posts a `ResolveCredentialRequest` to `/internal/credentials/resolve` with redirects disabled and the step's abort signal. It returns the `data` field of the response.
- A status of 300 or above throws an `OperationalError` that names the credential id and the status. A 2xx with a body without an object `data` field throws an `OperationalError` that names the response as malformed. Neither message includes the response body, because a server error body could contain credential data that would then end up in node output and logs.
- `isResolveCredentialResponse` in the contract file narrows the parsed body. It is a type guard rather than a zod schema because any JSON object is valid credential data, so the only possible runtime check is that `data` is a plain object.
- The test mocks the transport and the HTTP client. It covers the requested scope, the request body and path, redirects disabled, the abort signal, the returned data, six refused statuses, and five malformed 200 bodies.

Why: the credentials design keeps the credential store and the encryption key on the control plane side. The data plane needs one component that speaks the resolve contract and that turns a refusal into an error the node can see without leaking what the server sent. The `RemoteCredentialsHelper` in the next PR calls this client and nothing else for credential data.

## How to test

```bash
pnpm --filter n8n test src/modules/engine-v2
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2926

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

