### PR TITLE
refactor(core): Load packaged backend modules from a static manifest (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/index.ts
+++ b/packages/@n8n/backend-common/src/index.ts
@@ -5,6 +5,7 @@ export { inDevelopment, inProduction, inTest } from './environment';
 export { isObjectLiteral } from './utils/is-object-literal';
 export { Logger } from './logging/logger';
 export { ModuleRegistry } from './modules/module-registry';
+export type { PackagedModules } from './modules/module-registry';
 export type { ModuleName } from './modules/modules.config';
 export { ModulesConfig } from './modules/modules.config';
 export {

--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -204,13 +204,24 @@ describe('loadModules routes', () => {
 		expect(importOtel).not.toHaveBeenCalled();
 	});
 
-	it('should not import a manifest module that is disabled', async () => {
-		process.env.N8N_DISABLED_MODULES = 'insights';
+	it('should import an eligible manifest module when no names are given', async () => {
 		const importInsights = vi.fn().mockResolvedValue({});
 		const moduleRegistry = newRegistry();
+		vi.spyOn(moduleRegistry, 'eligibleModules', 'get').mockReturnValue(['insights']);
 		moduleRegistry.registerPackagedModules({ insights: importInsights });
 
-		await moduleRegistry.loadModules([]);
+		await moduleRegistry.loadModules(); // no names - the registry reads `eligibleModules`
+
+		expect(importInsights).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not import a manifest module that is ineligible', async () => {
+		const importInsights = vi.fn().mockResolvedValue({});
+		const moduleRegistry = newRegistry();
+		vi.spyOn(moduleRegistry, 'eligibleModules', 'get').mockReturnValue([]);
+		moduleRegistry.registerPackagedModules({ insights: importInsights });
+
+		await moduleRegistry.loadModules();
 
 		expect(importInsights).not.toHaveBeenCalled();
 	});

--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -226,7 +226,7 @@ describe('loadModules routes', () => {
 		expect(importInsights).not.toHaveBeenCalled();
 	});
 
-	it('should preserve the requested load order across both routes', async () => {
+	it('should preserve the requested load order between manifest modules', async () => {
 		const loaded: string[] = [];
 		const recordLoad = (name: string) => async () => {
 			loaded.push(name);
@@ -244,8 +244,46 @@ describe('loadModules routes', () => {
 		expect(loaded).toEqual(['oauth-server', 'mcp']);
 	});
 
+	it('should run a manifest module before a later filesystem module', async () => {
+		const importPackagedModule = vi.fn().mockResolvedValue({});
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importPackagedModule });
+
+		// `otel` is absent from the manifest, so it takes the filesystem route and
+		// throws here. `insights` precedes it, so the manifest entry runs first.
+		await expect(moduleRegistry.loadModules(['insights', 'otel'])).rejects.toThrowError(
+			MissingModuleError,
+		);
+
+		expect(importPackagedModule).toHaveBeenCalledTimes(1);
+	});
+
+	it('should stop at a failing filesystem module before a later manifest module', async () => {
+		const importPackagedModule = vi.fn().mockResolvedValue({});
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importPackagedModule });
+
+		await expect(moduleRegistry.loadModules(['otel', 'insights'])).rejects.toThrowError(
+			MissingModuleError,
+		);
+
+		// One ordered pass serves both routes. A route-first pass would import
+		// `insights` before it ever reached `otel`.
+		expect(importPackagedModule).not.toHaveBeenCalled();
+	});
+
 	it('should wrap a failing manifest import in `PackagedModuleLoadError`', async () => {
 		const importPackagedModule = vi.fn().mockRejectedValue(new Error('Cannot find package'));
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importPackagedModule });
+
+		await expect(moduleRegistry.loadModules(['insights'])).rejects.toThrowError(
+			PackagedModuleLoadError,
+		);
+	});
+
+	it('should wrap a manifest import that rejects with a non-Error', async () => {
+		const importPackagedModule = vi.fn().mockRejectedValue('Cannot find package');
 		const moduleRegistry = newRegistry();
 		moduleRegistry.registerPackagedModules({ insights: importPackagedModule });
 

--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -4,7 +4,9 @@ import path from 'path';
 import { mock } from 'vitest-mock-extended';
 
 import type { LicenseState } from '../../license-state';
+import { MissingModuleError } from '../errors/missing-module.error';
 import { ModuleConfusionError } from '../errors/module-confusion.error';
+import { PackagedModuleLoadError } from '../errors/packaged-module-load.error';
 import { getModuleEntryUrl, ModuleRegistry } from '../module-registry';
 
 beforeEach(() => {
@@ -154,6 +156,91 @@ describe('loadModules', () => {
 		await moduleRegistry.loadModules([]);
 
 		expect(moduleRegistry.entities).toEqual([]);
+	});
+});
+
+describe('loadModules routes', () => {
+	const newRegistry = () => {
+		const ModuleClass = { entities: vi.fn().mockReturnValue([]) };
+		const moduleMetadata = mock<ModuleMetadata>({
+			getClasses: vi.fn().mockReturnValue([ModuleClass]),
+		});
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
+
+		return new ModuleRegistry(moduleMetadata, mock(), mock(), mock(), mock());
+	};
+
+	it('should import a module from the manifest, and skip the filesystem route', async () => {
+		const importPackagedModule = vi.fn().mockResolvedValue({});
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importPackagedModule });
+
+		// The filesystem route has no `dist/modules/insights` to import here, so it
+		// would throw `MissingModuleError`. Resolving proves the name was skipped.
+		await moduleRegistry.loadModules(['insights']);
+
+		expect(importPackagedModule).toHaveBeenCalledTimes(1);
+	});
+
+	it('should use the filesystem route for a name the manifest does not carry', async () => {
+		const importPackagedModule = vi.fn().mockResolvedValue({});
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importPackagedModule });
+
+		await expect(moduleRegistry.loadModules(['otel'])).rejects.toThrowError(MissingModuleError);
+
+		expect(importPackagedModule).not.toHaveBeenCalled();
+	});
+
+	it('should not import a manifest module that is not being loaded', async () => {
+		const importInsights = vi.fn().mockResolvedValue({});
+		const importOtel = vi.fn().mockResolvedValue({});
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importInsights, otel: importOtel });
+
+		await moduleRegistry.loadModules(['insights']);
+
+		expect(importInsights).toHaveBeenCalledTimes(1);
+		expect(importOtel).not.toHaveBeenCalled();
+	});
+
+	it('should not import a manifest module that is disabled', async () => {
+		process.env.N8N_DISABLED_MODULES = 'insights';
+		const importInsights = vi.fn().mockResolvedValue({});
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importInsights });
+
+		await moduleRegistry.loadModules([]);
+
+		expect(importInsights).not.toHaveBeenCalled();
+	});
+
+	it('should preserve the requested load order across both routes', async () => {
+		const loaded: string[] = [];
+		const recordLoad = (name: string) => async () => {
+			loaded.push(name);
+			await Promise.resolve();
+		};
+
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({
+			'oauth-server': recordLoad('oauth-server'),
+			mcp: recordLoad('mcp'),
+		});
+
+		await moduleRegistry.loadModules(['oauth-server', 'mcp']);
+
+		expect(loaded).toEqual(['oauth-server', 'mcp']);
+	});
+
+	it('should wrap a failing manifest import in `PackagedModuleLoadError`', async () => {
+		const importPackagedModule = vi.fn().mockRejectedValue(new Error('Cannot find package'));
+		const moduleRegistry = newRegistry();
+		moduleRegistry.registerPackagedModules({ insights: importPackagedModule });
+
+		await expect(moduleRegistry.loadModules(['insights'])).rejects.toThrowError(
+			PackagedModuleLoadError,
+		);
 	});
 });
 

--- a/packages/@n8n/backend-common/src/modules/errors/packaged-module-load.error.ts
+++ b/packages/@n8n/backend-common/src/modules/errors/packaged-module-load.error.ts
@@ -1,0 +1,9 @@
+import { UserError } from 'n8n-workflow';
+
+export class PackagedModuleLoadError extends UserError {
+	constructor(moduleName: string, errorMsg: string) {
+		super(
+			`Failed to load module "${moduleName}" from its workspace package: ${errorMsg}. Please review the module's entry in n8n's "src/modules/modules.manifest.ts", and confirm the module's package is a declared dependency of n8n.`,
+		);
+	}
+}

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -9,10 +9,17 @@ import { pathToFileURL } from 'url';
 
 import { MissingModuleError } from './errors/missing-module.error';
 import { ModuleConfusionError } from './errors/module-confusion.error';
+import { PackagedModuleLoadError } from './errors/packaged-module-load.error';
 import { ModulesConfig } from './modules.config';
 import type { ModuleName } from './modules.config';
 import { LicenseState } from '../license-state';
 import { Logger } from '../logging/logger';
+
+/**
+ * Modules that live in a workspace package instead of `n8n/dist/modules`, keyed
+ * by module name. Values are thunks, so an ineligible module is never imported.
+ */
+export type PackagedModules = Partial<Record<ModuleName, () => Promise<unknown>>>;
 
 export const getModuleEntryUrl = (modulesDir: string, moduleName: string, isEnterprise = false) =>
 	pathToFileURL(
@@ -78,6 +85,17 @@ export class ModuleRegistry {
 
 	private readonly activeModules: string[] = [];
 
+	private readonly packagedModules: PackagedModules = {};
+
+	/**
+	 * Declares which modules `loadModules` must import from a workspace package
+	 * instead of the `n8n/dist/modules` filesystem path. Call this before
+	 * `loadModules`; cli passes its `src/modules/modules.manifest.ts`.
+	 */
+	registerPackagedModules(packagedModules: PackagedModules) {
+		Object.assign(this.packagedModules, packagedModules);
+	}
+
 	get eligibleModules(): ModuleName[] {
 		const { enabledModules, disabledModules } = this.modulesConfig;
 
@@ -95,44 +113,26 @@ export class ModuleRegistry {
 	 * This only registers the database entities for module and should be done
 	 * before instantiating the datasource.
 	 *
+	 * Each module takes exactly one of two routes: the packaged-module manifest
+	 * (see `registerPackagedModules`) or the `n8n/dist/modules` filesystem path.
+	 * A name in the manifest is skipped on the filesystem route, so a module
+	 * class can never be registered twice.
+	 *
 	 * This will not register routes or do any other kind of module related
 	 * setup.
 	 */
 	async loadModules(modules?: ModuleName[]) {
-		let modulesDir: string;
-
-		try {
-			// docker + tests
-			const n8nPackagePath = require.resolve('n8n/package.json');
-			const n8nRoot = path.dirname(n8nPackagePath);
-			const srcDirExists = existsSync(path.join(n8nRoot, 'src'));
-			const dir = process.env.NODE_ENV === 'test' && srcDirExists ? 'src' : 'dist';
-			modulesDir = path.join(n8nRoot, dir, 'modules');
-		} catch {
-			// local dev
-			// n8n binary is inside the bin folder, so we need to go up two levels
-			modulesDir = path.resolve(process.argv[1], '../../dist/modules');
-		}
+		const modulesDir = this.resolveModulesDir();
 
 		for (const moduleName of modules ?? this.eligibleModules) {
-			try {
-				await import(getModuleEntryUrl(modulesDir, moduleName));
-			} catch (primaryError) {
-				try {
-					await import(getModuleEntryUrl(modulesDir, moduleName, true));
-				} catch (error) {
-					const loggedError =
-						primaryError instanceof Error &&
-						'code' in primaryError &&
-						primaryError.code !== 'MODULE_NOT_FOUND'
-							? primaryError
-							: error;
-					throw new MissingModuleError(
-						moduleName,
-						loggedError instanceof Error ? loggedError.message : '',
-					);
-				}
+			const importPackagedModule = this.packagedModules[moduleName];
+
+			if (importPackagedModule) {
+				await this.loadPackagedModule(moduleName, importPackagedModule);
+				continue; // explicit skip - never also load this name from the filesystem
 			}
+
+			await this.loadFilesystemModule(modulesDir, moduleName);
 		}
 
 		for (const ModuleClass of this.moduleMetadata.getClasses()) {
@@ -145,6 +145,54 @@ export class ModuleRegistry {
 			if (loaders?.length) this.nodeLoaders.push(...loaders);
 
 			await Container.get(ModuleClass).commands?.();
+		}
+	}
+
+	private resolveModulesDir() {
+		try {
+			// docker + tests
+			const n8nPackagePath = require.resolve('n8n/package.json');
+			const n8nRoot = path.dirname(n8nPackagePath);
+			const srcDirExists = existsSync(path.join(n8nRoot, 'src'));
+			const dir = process.env.NODE_ENV === 'test' && srcDirExists ? 'src' : 'dist';
+			return path.join(n8nRoot, dir, 'modules');
+		} catch {
+			// local dev
+			// n8n binary is inside the bin folder, so we need to go up two levels
+			return path.resolve(process.argv[1], '../../dist/modules');
+		}
+	}
+
+	private async loadPackagedModule(
+		moduleName: ModuleName,
+		importPackagedModule: () => Promise<unknown>,
+	) {
+		try {
+			await importPackagedModule();
+			this.logger.debug(`Loaded module "${moduleName}" from its workspace package`);
+		} catch (error) {
+			throw new PackagedModuleLoadError(moduleName, error instanceof Error ? error.message : '');
+		}
+	}
+
+	private async loadFilesystemModule(modulesDir: string, moduleName: ModuleName) {
+		try {
+			await import(getModuleEntryUrl(modulesDir, moduleName));
+		} catch (primaryError) {
+			try {
+				await import(getModuleEntryUrl(modulesDir, moduleName, true));
+			} catch (error) {
+				const loggedError =
+					primaryError instanceof Error &&
+					'code' in primaryError &&
+					primaryError.code !== 'MODULE_NOT_FOUND'
+						? primaryError
+						: error;
+				throw new MissingModuleError(
+					moduleName,
+					loggedError instanceof Error ? loggedError.message : '',
+				);
+			}
 		}
 	}
 

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -7,13 +7,13 @@ import type { NodeLoader } from 'n8n-workflow';
 import path from 'path';
 import { pathToFileURL } from 'url';
 
+import { LicenseState } from '../license-state';
+import { Logger } from '../logging/logger';
 import { MissingModuleError } from './errors/missing-module.error';
 import { ModuleConfusionError } from './errors/module-confusion.error';
 import { PackagedModuleLoadError } from './errors/packaged-module-load.error';
 import { ModulesConfig } from './modules.config';
 import type { ModuleName } from './modules.config';
-import { LicenseState } from '../license-state';
-import { Logger } from '../logging/logger';
 
 /**
  * Modules that live in a workspace package instead of `n8n/dist/modules`, keyed

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -8,6 +8,7 @@ import picocolors from 'picocolors';
 import { z, ZodError } from 'zod';
 
 import './zod-alias-support';
+import { packagedModules } from './modules/modules.manifest';
 
 /**
  * Registry that manages CLI commands, their execution, and metadata.
@@ -24,6 +25,10 @@ export class CommandRegistry {
 		private readonly cliParser: CliParser,
 	) {
 		this.commandName = process.argv[2] ?? 'start';
+
+		// Must precede every `loadModules` call below, so modules that live in a
+		// workspace package take the manifest route instead of the filesystem one.
+		this.moduleRegistry.registerPackagedModules(packagedModules);
 	}
 
 	async execute() {

--- a/packages/cli/src/modules/modules.manifest.ts
+++ b/packages/cli/src/modules/modules.manifest.ts
@@ -1,0 +1,16 @@
+import type { PackagedModules } from '@n8n/backend-common';
+
+/**
+ * Backend modules that live in a workspace package (`packages/modules/<name>/backend`)
+ * instead of `packages/cli/src/modules/<name>`.
+ *
+ * `ModuleRegistry.loadModules` reads this manifest first, and skips the
+ * `dist/modules` filesystem route for every name listed here. Keep the
+ * specifiers static so tsc compiles them, pnpm resolves them, and grep finds
+ * them. Keep the values thunks so an ineligible module is never imported.
+ *
+ * This mirrors the frontend seam in `editor-ui/src/app/modules.manifest.ts`.
+ *
+ * Empty for now - the first backend module package has not landed yet.
+ */
+export const packagedModules: PackagedModules = {};

--- a/packages/modules/README.md
+++ b/packages/modules/README.md
@@ -6,7 +6,9 @@ through Vite aliases.
 
 `<name>/backend` is a reserved path rather than a workspace package — the backend runtime discovers
 modules under `packages/cli/src/modules/<name>`. The extra nesting level is what lets both halves of
-a module sit together later.
+a module sit together later. When a backend half does become a package, its entry goes in
+`packages/cli/src/modules/modules.manifest.ts`, which `ModuleRegistry.loadModules` reads before the
+filesystem route.
 
 The directory is empty until the first module lands, and tracked in the meantime because turbo
 rejects a `--filter` whose directory does not exist. The root `test:ci:*` scripts and the two


### PR DESCRIPTION
## Summary

`ModuleRegistry.loadModules` now reads a static manifest at `packages/cli/src/modules/modules.manifest.ts` before the `n8n/dist/modules` filesystem route. The manifest is **empty**, so runtime behavior does not change.

This is the loading seam a backend module needs to live in a workspace package (`packages/modules/<name>/backend`). It mirrors the frontend seam in `editor-ui/src/app/modules.manifest.ts`, so both stacks keep one mental model.

**How it works**

- `PackagedModules = Partial<Record<ModuleName, () => Promise<unknown>>>` — new type in `@n8n/backend-common`. `ModuleName` stays the single source of truth for module ids.
- `CommandRegistry` passes cli's manifest to the registry via `registerPackagedModules`, before either `loadModules` call. The manifest cannot live in `@n8n/backend-common` itself: it imports module packages, and those depend on `backend-common`.
- `loadModules` walks the requested names in one ordered pass and picks a route per name. A name in the manifest `continue`s past the filesystem route — an explicit skip, not a fallback. That is the single-load guarantee: a module class can never be registered twice.
- The load order across both routes is the requested order. `defaultModules` depends on this (`oauth-server` must precede `mcp`).
- Values are thunks, so a disabled or unlicensed module is never imported.
- A failing manifest import raises the new `PackagedModuleLoadError`. `MissingModuleError`'s hint ("review the entrypoint file name and the directory name") is wrong for a package; the new message points at the manifest entry and the declared dependency instead.

**Failure modes**

| Failure | Detection | Recovery |
| --- | --- | --- |
| Manifest entry names a package that is not resolvable (missing dep, broken docker closure) | `PackagedModuleLoadError` at boot, naming the module and the resolver message | Fix the dep or remove the manifest entry; boot fails loudly, no partial module state |
| Manifest entry throws inside the module body | Same error, carrying the module's own message | Same |
| A name is in the manifest **and** on disk | Impossible by construction — the manifest route `continue`s. Covered by a test that fails if the `continue` is removed | — |
| A module is in the manifest but ineligible | Not imported; nothing to recover | — |

**Telemetry:** one `debug` line per module loaded through the manifest, naming the route. If a module ever loads from an unexpected route, the boot log says so.

## How to test

```bash
pnpm turbo run test --filter=@n8n/backend-common     # 33 tests in module-registry.test.ts, 10 new
pnpm turbo run lint --filter=@n8n/backend-common
pnpm --filter n8n test:unit                          # cli unit suite
pnpm turbo run typecheck --filter=@n8n/backend-common --filter=n8n
```

Behavior is unchanged with the empty manifest, so no manual smoke steps apply. The manifest route is exercised by the new unit tests in `packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts`:

- a manifest hit imports the thunk **and** skips the filesystem route (which would throw `MissingModuleError` here — resolving is the proof);
- a name the manifest does not carry takes the filesystem route;
- an unrequested manifest module is never imported;
- an eligible manifest module is imported when `loadModules()` is called with no names;
- an ineligible manifest module is never imported;
- the requested order is preserved between two manifest modules;
- a manifest module runs before a later filesystem module;
- a failing filesystem module stops the pass before a later manifest module — the mixed-route order case;
- a failing manifest import becomes `PackagedModuleLoadError`, whether it rejects with an `Error` or not.

Mutation-checked in three places:

- delete the `continue` that implements the skip → 4 of these tests fail;
- change `modules ?? this.eligibleModules` to `this.defaultModules` → the eligible/ineligible pair fails;
- split the single pass into a packaged-first pass and a filesystem pass → the mixed-route order test fails, and only that test.

Each mutation is why its test exists. `module-registry.test.ts` went 23 → 33 tests.

Two review corrections are folded in. The first version asserted laziness with `loadModules([])` against a mocked `modulesConfig`, so the loop body never ran and the test could not fail; the eligible/ineligible pair replaces it. The `import-x/order` failure at `module-registry.ts:15` is also fixed — the two parent imports now precede the sibling imports, in the same group, so no blank line is added.

### Patch coverage

Three partial branches remain, all on lines this change **relocated rather than wrote** — they are present verbatim on `master`, and Codecov counts a moved line as a patch line:

| Line | Branch | Why it is not covered here |
| --- | --- | --- |
| `resolveModulesDir` | `NODE_ENV === 'test' && srcDirExists ? 'src' : 'dist'` | The whole `try` needs `require.resolve('n8n/package.json')` to succeed. In `@n8n/backend-common` it throws `MODULE_NOT_FOUND` — there is no `node_modules/n8n` self-symlink in the monorepo source context, which is the same constraint `backend-test-utils/src/test-modules.ts` documents. |
| `loadFilesystemModule` | `primaryError instanceof Error && 'code' in primaryError && …` | Needs a real `dist/modules/<name>/<name>.module.js` on disk whose import fails with a code other than `MODULE_NOT_FOUND`. The directory is derived from `process.argv[1]`, which a unit test does not control. |
| `loadFilesystemModule` | `loggedError instanceof Error ? … : ''` | Same block. A dynamic `import()` of a missing file always rejects with an `Error`, so the `''` arm is unreachable. |

The one partial this change actually introduced — the non-`Error` arm of `loadPackagedModule` — is now covered. Covering the other three would need a seam in production code that exists only for the test, which is not worth it for environment-detection logic this PR did not author.

## Related Linear tickets, Github issues, and Community forum posts

Multica issue N8N-361, under N8N-354 "Create first full-stack module" (plan §3.2 and §6). PR 0 of that plan; the CI filter re-cut is N8N-360.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- packages/modules/README.md points at the manifest; the module guide is PR 3 of the plan -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

**Known gap for the next PR (not this one):** `@n8n/backend-test-utils`'s `loadModules` helper imports module files directly from `cwd/src/modules` and bypasses the registry's import step entirely. It will need a manifest-aware branch when the first real backend module package lands. Flagging it now so PR 2 does not discover it late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



