### PR TITLE
fix(Embeddings Google Gemini Node): Correct dimensionality notice and add Output Dimensionality option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
@@ -1,5 +1,7 @@
 import {
 	NodeConnectionTypes,
+	NodeOperationError,
+	type INode,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
@@ -9,6 +11,28 @@ import {
 import { logWrapper, getConnectionHintNoticeField } from '@n8n/ai-utilities';
 
 import { GeminiEmbeddings } from './helpers';
+
+/**
+ * The `minValue` and `numberPrecision` constraints only apply to values typed into the editor, so
+ * an expression can still resolve to a fraction or to a value below 1. Such a value is rejected
+ * here, because the API answers it with a request error that does not name the parameter.
+ */
+function parseOutputDimensionality(node: INode, value: unknown): number | undefined {
+	if (value === undefined || value === null || value === '') return undefined;
+
+	const dimensionality = typeof value === 'string' ? Number(value) : value;
+	if (
+		typeof dimensionality !== 'number' ||
+		!Number.isInteger(dimensionality) ||
+		dimensionality < 1
+	) {
+		throw new NodeOperationError(node, `Invalid output dimensionality: ${JSON.stringify(value)}`, {
+			description: 'The output dimensionality must be a whole number of 1 or more.',
+		});
+	}
+
+	return dimensionality;
+}
 
 export class EmbeddingsGoogleGemini implements INodeType {
 	description: INodeTypeDescription = {
@@ -142,12 +166,12 @@ export class EmbeddingsGoogleGemini implements INodeType {
 			'models/gemini-embedding-001',
 		) as string;
 		const options = this.getNodeParameter('options', itemIndex, {}) as {
-			outputDimensionality?: number;
+			outputDimensionality?: unknown;
 		};
-		const outputDimensionality =
-			options.outputDimensionality && options.outputDimensionality > 0
-				? options.outputDimensionality
-				: undefined;
+		const outputDimensionality = parseOutputDimensionality(
+			this.getNode(),
+			options.outputDimensionality,
+		);
 
 		const credentials = await this.getCredentials('googlePalmApi');
 		const embeddings = new GeminiEmbeddings({

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
@@ -1,4 +1,3 @@
-import { GoogleGenerativeAIEmbeddings } from '@langchain/google-genai';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -8,6 +7,8 @@ import {
 } from 'n8n-workflow';
 
 import { logWrapper, getConnectionHintNoticeField } from '@n8n/ai-utilities';
+
+import { GeminiEmbeddings } from './helpers';
 
 export class EmbeddingsGoogleGemini implements INodeType {
 	description: INodeTypeDescription = {
@@ -52,7 +53,7 @@ export class EmbeddingsGoogleGemini implements INodeType {
 			getConnectionHintNoticeField([NodeConnectionTypes.AiVectorStore]),
 			{
 				displayName:
-					'Each model is using different dimensional density for embeddings. Please make sure to use the same dimensionality for your vector store. The default model is using 768-dimensional embeddings.',
+					'Each model uses a different embedding dimensionality. Make sure your vector store is configured for the same dimensionality. The default model (gemini-embedding-001) returns 3072-dimensional embeddings unless the Output Dimensionality option is set.',
 				name: 'notice',
 				type: 'notice',
 				default: '',
@@ -111,6 +112,25 @@ export class EmbeddingsGoogleGemini implements INodeType {
 				},
 				default: 'models/gemini-embedding-001',
 			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				placeholder: 'Add Option',
+				description: 'Additional options to add',
+				type: 'collection',
+				default: {},
+				options: [
+					{
+						displayName: 'Output Dimensionality',
+						name: 'outputDimensionality',
+						default: undefined,
+						description:
+							'The number of dimensions the returned embeddings should have, e.g. 768, 1536 or 3072 for gemini-embedding-001. Leave unset to use the model default.',
+						type: 'number',
+						typeOptions: { minValue: 1 },
+					},
+				],
+			},
 		],
 	};
 
@@ -121,11 +141,20 @@ export class EmbeddingsGoogleGemini implements INodeType {
 			itemIndex,
 			'models/gemini-embedding-001',
 		) as string;
+		const options = this.getNodeParameter('options', itemIndex, {}) as {
+			outputDimensionality?: number;
+		};
+		const outputDimensionality =
+			options.outputDimensionality && options.outputDimensionality > 0
+				? options.outputDimensionality
+				: undefined;
+
 		const credentials = await this.getCredentials('googlePalmApi');
-		const embeddings = new GoogleGenerativeAIEmbeddings({
+		const embeddings = new GeminiEmbeddings({
 			apiKey: credentials.apiKey as string,
 			baseUrl: credentials.host as string,
 			model: modelName,
+			outputDimensionality,
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
@@ -127,7 +127,7 @@ export class EmbeddingsGoogleGemini implements INodeType {
 						description:
 							'The number of dimensions the returned embeddings should have, e.g. 768, 1536 or 3072 for gemini-embedding-001. Leave unset to use the model default.',
 						type: 'number',
-						typeOptions: { minValue: 1 },
+						typeOptions: { minValue: 1, numberPrecision: 0 },
 					},
 				],
 			},

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/helpers.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/helpers.ts
@@ -1,0 +1,89 @@
+import {
+	GoogleGenerativeAI,
+	type EmbedContentRequest,
+	type GenerativeModel,
+} from '@google/generative-ai';
+import { chunkArray } from '@langchain/core/utils/chunk_array';
+import {
+	GoogleGenerativeAIEmbeddings,
+	type GoogleGenerativeAIEmbeddingsParams,
+} from '@langchain/google-genai';
+
+// The Gemini embedContent API accepts `outputDimensionality` (Matryoshka truncation), but the
+// `@google/generative-ai` request type does not declare it, so we extend the type rather than cast.
+type EmbedContentRequestWithDimensionality = EmbedContentRequest & {
+	outputDimensionality?: number;
+};
+
+export interface GeminiEmbeddingsParams extends GoogleGenerativeAIEmbeddingsParams {
+	/** Truncates the returned embeddings to this many dimensions. Unset keeps the model default. */
+	outputDimensionality?: number;
+}
+
+/**
+ * Gemini embeddings with support for the `outputDimensionality` request field.
+ *
+ * `GoogleGenerativeAIEmbeddings` from `@langchain/google-genai` builds its requests in a private
+ * method and has no way to set `outputDimensionality`, so `gemini-embedding-001` always returns
+ * its 3072-dimensional default. When the option is unset every call is delegated to the base class
+ * unchanged; when it is set the request is built here and sent with the extra field.
+ */
+export class GeminiEmbeddings extends GoogleGenerativeAIEmbeddings {
+	outputDimensionality?: number;
+
+	// The base class keeps its GenerativeModel private, so the requests that carry
+	// `outputDimensionality` go through a second instance created from the same inputs.
+	private readonly embedClient: GenerativeModel;
+
+	constructor(fields: GeminiEmbeddingsParams) {
+		super(fields);
+		this.outputDimensionality = fields.outputDimensionality;
+		// The base constructor has already rejected a missing API key at this point.
+		this.embedClient = new GoogleGenerativeAI(this.apiKey ?? '').getGenerativeModel(
+			{ model: this.model },
+			{ baseUrl: fields.baseUrl },
+		);
+	}
+
+	protected override async _embedQueryContent(text: string): Promise<number[]> {
+		if (!this.outputDimensionality) return await super._embedQueryContent(text);
+
+		const { embedding } = await this.embedClient.embedContent(this.toEmbedContentRequest(text));
+		return embedding.values ?? [];
+	}
+
+	protected override async _embedDocumentsContent(documents: string[]): Promise<number[][]> {
+		if (!this.outputDimensionality) return await super._embedDocumentsContent(documents);
+
+		const chunks = chunkArray(documents, this.maxBatchSize);
+		const results = await Promise.allSettled(
+			chunks.map(
+				async (chunk) =>
+					await this.embedClient.batchEmbedContents({
+						requests: chunk.map((document) => this.toEmbedContentRequest(document)),
+					}),
+			),
+		);
+
+		// Same semantics as the base class: a failed batch yields empty vectors for its inputs so the
+		// output stays aligned with the input positions.
+		return results.flatMap((result, index) =>
+			result.status === 'fulfilled'
+				? result.value.embeddings.map((embedding) => embedding.values ?? [])
+				: Array<number[]>(chunks[index].length).fill([]),
+		);
+	}
+
+	// Mirrors the request the base class builds (its builder is private), plus the dimensionality.
+	private toEmbedContentRequest(text: string): EmbedContentRequestWithDimensionality {
+		return {
+			content: {
+				role: 'user',
+				parts: [{ text: this.stripNewLines ? text.replace(/\n/g, ' ') : text }],
+			},
+			taskType: this.taskType,
+			title: this.title,
+			outputDimensionality: this.outputDimensionality,
+		};
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/helpers.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/helpers.ts
@@ -55,9 +55,10 @@ export class GeminiEmbeddings extends GoogleGenerativeAIEmbeddings {
 	protected override async _embedDocumentsContent(documents: string[]): Promise<number[][]> {
 		if (!this.outputDimensionality) return await super._embedDocumentsContent(documents);
 
-		const chunks = chunkArray(documents, this.maxBatchSize);
-		const results = await Promise.allSettled(
-			chunks.map(
+		// Unlike the base class, a failed batch rejects the whole call instead of being replaced by
+		// empty vectors, so a transient API error cannot end up stored as embeddings.
+		const responses = await Promise.all(
+			chunkArray(documents, this.maxBatchSize).map(
 				async (chunk) =>
 					await this.embedClient.batchEmbedContents({
 						requests: chunk.map((document) => this.toEmbedContentRequest(document)),
@@ -65,12 +66,8 @@ export class GeminiEmbeddings extends GoogleGenerativeAIEmbeddings {
 			),
 		);
 
-		// Same semantics as the base class: a failed batch yields empty vectors for its inputs so the
-		// output stays aligned with the input positions.
-		return results.flatMap((result, index) =>
-			result.status === 'fulfilled'
-				? result.value.embeddings.map((embedding) => embedding.values ?? [])
-				: Array<number[]>(chunks[index].length).fill([]),
+		return responses.flatMap((response) =>
+			response.embeddings.map((embedding) => embedding.values ?? []),
 		);
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/EmbeddingsGoogleGemini.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/EmbeddingsGoogleGemini.test.ts
@@ -100,8 +100,8 @@ describe('EmbeddingsGoogleGemini', () => {
 			);
 		});
 
-		it('ignores a non-positive output dimensionality', async () => {
-			const ctx = setupMockContext({ outputDimensionality: 0 });
+		it('treats an empty output dimensionality as unset', async () => {
+			const ctx = setupMockContext({ outputDimensionality: '' });
 
 			await node.supplyData.call(ctx, 0);
 
@@ -109,5 +109,25 @@ describe('EmbeddingsGoogleGemini', () => {
 				expect.objectContaining({ outputDimensionality: undefined }),
 			);
 		});
+
+		it('accepts an output dimensionality that an expression returns as a string', async () => {
+			const ctx = setupMockContext({ outputDimensionality: '768' });
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedGeminiEmbeddings).toHaveBeenCalledWith(
+				expect.objectContaining({ outputDimensionality: 768 }),
+			);
+		});
+
+		it.each([768.5, 0, -1, 'many'])(
+			'rejects the output dimensionality %p before a request is made',
+			async (outputDimensionality) => {
+				const ctx = setupMockContext({ outputDimensionality });
+
+				await expect(node.supplyData.call(ctx, 0)).rejects.toThrow('Invalid output dimensionality');
+				expect(MockedGeminiEmbeddings).not.toHaveBeenCalled();
+			},
+		);
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/EmbeddingsGoogleGemini.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/EmbeddingsGoogleGemini.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, INodeProperties, ISupplyDataFunctions } from 'n8n-workflow';
+import type { Mocked } from 'vitest';
+
+import { EmbeddingsGoogleGemini } from '../EmbeddingsGoogleGemini.node';
+import { GeminiEmbeddings } from '../helpers';
+
+vi.mock('../helpers', () => ({ GeminiEmbeddings: vi.fn() }));
+vi.mock('@n8n/ai-utilities', () => ({
+	logWrapper: vi.fn((value: unknown) => value),
+	getConnectionHintNoticeField: vi.fn(() => ({})),
+}));
+
+const MockedGeminiEmbeddings = vi.mocked(GeminiEmbeddings);
+
+describe('EmbeddingsGoogleGemini', () => {
+	let node: EmbeddingsGoogleGemini;
+
+	const mockNode: INode = {
+		id: '1',
+		name: 'Embeddings Google Gemini',
+		typeVersion: 1,
+		type: '@n8n/n8n-nodes-langchain.embeddingsGoogleGemini',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = (options: Record<string, unknown> = {}) => {
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			mockNode,
+		) as Mocked<ISupplyDataFunctions>;
+
+		ctx.getCredentials = vi.fn().mockResolvedValue({
+			apiKey: 'test-key',
+			host: 'https://generativelanguage.googleapis.com',
+		});
+		ctx.getNode = vi.fn().mockReturnValue(mockNode);
+		ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+			if (paramName === 'modelName') return 'models/gemini-embedding-001';
+			if (paramName === 'options') return options;
+			return undefined;
+		});
+		ctx.logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+		return ctx;
+	};
+
+	const findProperty = (name: string): INodeProperties | undefined =>
+		node.description.properties.find((property) => property.name === name);
+
+	beforeEach(() => {
+		node = new EmbeddingsGoogleGemini();
+		vi.clearAllMocks();
+	});
+
+	describe('node description', () => {
+		it('describes the dimensionality of the default model correctly', () => {
+			const notice = findProperty('notice');
+
+			expect(findProperty('modelName')?.default).toBe('models/gemini-embedding-001');
+			expect(notice?.displayName).toContain('3072-dimensional');
+			expect(notice?.displayName).not.toContain('768-dimensional');
+		});
+
+		it('exposes an Output Dimensionality option', () => {
+			const optionsProperty = findProperty('options');
+
+			expect(optionsProperty?.type).toBe('collection');
+			expect(optionsProperty?.options).toContainEqual(
+				expect.objectContaining({ name: 'outputDimensionality', type: 'number' }),
+			);
+		});
+	});
+
+	describe('supplyData', () => {
+		it('passes credentials and model to the embeddings client', async () => {
+			const ctx = setupMockContext();
+
+			const result = await node.supplyData.call(ctx, 0);
+
+			expect(ctx.getCredentials).toHaveBeenCalledWith('googlePalmApi');
+			expect(MockedGeminiEmbeddings).toHaveBeenCalledWith({
+				apiKey: 'test-key',
+				baseUrl: 'https://generativelanguage.googleapis.com',
+				model: 'models/gemini-embedding-001',
+				outputDimensionality: undefined,
+			});
+			expect(result).toHaveProperty('response');
+		});
+
+		it('passes the configured output dimensionality to the embeddings client', async () => {
+			const ctx = setupMockContext({ outputDimensionality: 768 });
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedGeminiEmbeddings).toHaveBeenCalledWith(
+				expect.objectContaining({ outputDimensionality: 768 }),
+			);
+		});
+
+		it('ignores a non-positive output dimensionality', async () => {
+			const ctx = setupMockContext({ outputDimensionality: 0 });
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedGeminiEmbeddings).toHaveBeenCalledWith(
+				expect.objectContaining({ outputDimensionality: undefined }),
+			);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/GeminiEmbeddings.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/GeminiEmbeddings.test.ts
@@ -79,16 +79,18 @@ describe('GeminiEmbeddings', () => {
 			expect(result).toEqual([[0], [1], [0]]);
 		});
 
-		it('returns empty vectors for a failed batch to keep positions aligned with the input', async () => {
-			const { embeddings, ownClient } = buildEmbeddings({ outputDimensionality: 768 });
+		it('rejects when a batch request fails instead of returning empty vectors', async () => {
+			// maxRetries: 0 keeps the AsyncCaller from retrying the rejected mock with backoff.
+			const { embeddings, ownClient } = buildEmbeddings({
+				outputDimensionality: 768,
+				maxRetries: 0,
+			});
 			embeddings.maxBatchSize = 1;
 			ownClient.batchEmbedContents
 				.mockRejectedValueOnce(new Error('quota exceeded'))
 				.mockResolvedValueOnce({ embeddings: [{ values: [0.5] }] });
 
-			const result = await embeddings.embedDocuments(['a', 'b']);
-
-			expect(result).toEqual([[], [0.5]]);
+			await expect(embeddings.embedDocuments(['a', 'b'])).rejects.toThrow('quota exceeded');
 		});
 
 		it('honours stripNewLines, taskType and title in the request it builds', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/GeminiEmbeddings.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsGoogleGemini/test/GeminiEmbeddings.test.ts
@@ -1,0 +1,159 @@
+import { TaskType, type GenerativeModel } from '@google/generative-ai';
+
+import { GeminiEmbeddings } from '../helpers';
+
+type EmbedFn = ReturnType<typeof vi.fn>;
+
+interface MockClient {
+	embedContent: EmbedFn;
+	batchEmbedContents: EmbedFn;
+}
+
+const createMockClient = (): MockClient => ({
+	embedContent: vi.fn().mockResolvedValue({ embedding: { values: [0.1, 0.2] } }),
+	batchEmbedContents: vi.fn().mockImplementation(
+		async (request: { requests: unknown[] }) =>
+			await Promise.resolve({
+				embeddings: request.requests.map((_, index) => ({ values: [index] })),
+			}),
+	),
+});
+
+describe('GeminiEmbeddings', () => {
+	// Replace both GenerativeModel instances so no request leaves the process and the request
+	// bodies are observable: `embedClient` is ours, `client` belongs to the base class.
+	const buildEmbeddings = (overrides: Record<string, unknown> = {}) => {
+		const embeddings = new GeminiEmbeddings({
+			apiKey: 'test-key',
+			model: 'models/gemini-embedding-001',
+			...overrides,
+		});
+		const ownClient = createMockClient();
+		const baseClient = createMockClient();
+		const instance = embeddings as unknown as {
+			embedClient: GenerativeModel;
+			client: GenerativeModel;
+		};
+		instance.embedClient = ownClient as unknown as GenerativeModel;
+		instance.client = baseClient as unknown as GenerativeModel;
+
+		return { embeddings, ownClient, baseClient };
+	};
+
+	describe('with outputDimensionality set', () => {
+		it('sends outputDimensionality when embedding a query', async () => {
+			const { embeddings, ownClient, baseClient } = buildEmbeddings({ outputDimensionality: 768 });
+
+			const result = await embeddings.embedQuery('What is n8n?');
+
+			expect(result).toEqual([0.1, 0.2]);
+			expect(baseClient.embedContent).not.toHaveBeenCalled();
+			expect(ownClient.embedContent).toHaveBeenCalledTimes(1);
+			expect(ownClient.embedContent.mock.calls[0][0]).toEqual({
+				content: { role: 'user', parts: [{ text: 'What is n8n?' }] },
+				taskType: undefined,
+				title: undefined,
+				outputDimensionality: 768,
+			});
+		});
+
+		it('sends outputDimensionality on every batched document request', async () => {
+			const { embeddings, ownClient, baseClient } = buildEmbeddings({ outputDimensionality: 768 });
+			embeddings.maxBatchSize = 2;
+
+			const result = await embeddings.embedDocuments(['a', 'b', 'c']);
+
+			expect(baseClient.batchEmbedContents).not.toHaveBeenCalled();
+			expect(ownClient.batchEmbedContents).toHaveBeenCalledTimes(2);
+			const [firstBatch, secondBatch] = ownClient.batchEmbedContents.mock.calls.map(
+				(call) => (call[0] as { requests: Array<Record<string, unknown>> }).requests,
+			);
+			expect(firstBatch).toHaveLength(2);
+			expect(secondBatch).toHaveLength(1);
+			for (const request of [...firstBatch, ...secondBatch]) {
+				expect(request).toMatchObject({ outputDimensionality: 768 });
+			}
+			expect(firstBatch[0].content).toEqual({ role: 'user', parts: [{ text: 'a' }] });
+			expect(secondBatch[0].content).toEqual({ role: 'user', parts: [{ text: 'c' }] });
+			// One embedding per input, in input order.
+			expect(result).toEqual([[0], [1], [0]]);
+		});
+
+		it('returns empty vectors for a failed batch to keep positions aligned with the input', async () => {
+			const { embeddings, ownClient } = buildEmbeddings({ outputDimensionality: 768 });
+			embeddings.maxBatchSize = 1;
+			ownClient.batchEmbedContents
+				.mockRejectedValueOnce(new Error('quota exceeded'))
+				.mockResolvedValueOnce({ embeddings: [{ values: [0.5] }] });
+
+			const result = await embeddings.embedDocuments(['a', 'b']);
+
+			expect(result).toEqual([[], [0.5]]);
+		});
+
+		it('honours stripNewLines, taskType and title in the request it builds', async () => {
+			const { embeddings, ownClient } = buildEmbeddings({
+				outputDimensionality: 1536,
+				taskType: TaskType.RETRIEVAL_DOCUMENT,
+				title: 'Docs',
+			});
+			// The base class only exposes stripNewLines as a field, not as a constructor option.
+			embeddings.stripNewLines = false;
+
+			await embeddings.embedQuery('line one\nline two');
+
+			expect(ownClient.embedContent.mock.calls[0][0]).toEqual({
+				content: { role: 'user', parts: [{ text: 'line one\nline two' }] },
+				taskType: TaskType.RETRIEVAL_DOCUMENT,
+				title: 'Docs',
+				outputDimensionality: 1536,
+			});
+		});
+
+		it('replaces newlines with spaces by default', async () => {
+			const { embeddings, ownClient } = buildEmbeddings({ outputDimensionality: 768 });
+
+			await embeddings.embedQuery('line one\nline two');
+
+			expect(ownClient.embedContent.mock.calls[0][0]).toMatchObject({
+				content: { parts: [{ text: 'line one line two' }] },
+			});
+		});
+	});
+
+	describe('without outputDimensionality', () => {
+		it('delegates queries to the base class and sends no outputDimensionality', async () => {
+			const { embeddings, ownClient, baseClient } = buildEmbeddings();
+
+			const result = await embeddings.embedQuery('What is n8n?');
+
+			expect(result).toEqual([0.1, 0.2]);
+			expect(ownClient.embedContent).not.toHaveBeenCalled();
+			expect(baseClient.embedContent).toHaveBeenCalledTimes(1);
+			expect(baseClient.embedContent.mock.calls[0][0]).not.toHaveProperty('outputDimensionality');
+		});
+
+		it('delegates documents to the base class and sends no outputDimensionality', async () => {
+			const { embeddings, ownClient, baseClient } = buildEmbeddings();
+
+			await embeddings.embedDocuments(['a', 'b']);
+
+			expect(ownClient.batchEmbedContents).not.toHaveBeenCalled();
+			expect(baseClient.batchEmbedContents).toHaveBeenCalledTimes(1);
+			const { requests } = baseClient.batchEmbedContents.mock.calls[0][0] as {
+				requests: Array<Record<string, unknown>>;
+			};
+			expect(requests).toHaveLength(2);
+			for (const request of requests) {
+				expect(request).not.toHaveProperty('outputDimensionality');
+			}
+		});
+	});
+
+	it('strips the models/ prefix from the model name like the base class', () => {
+		const { embeddings } = buildEmbeddings({ outputDimensionality: 768 });
+
+		expect(embeddings.model).toBe('gemini-embedding-001');
+		expect(embeddings.outputDimensionality).toBe(768);
+	});
+});


### PR DESCRIPTION
## Summary

The Embeddings Google Gemini node shows a notice that says the default model returns 768-dimensional embeddings. Since #26977 changed the default model from `text-embedding-004` to `gemini-embedding-001`, that statement has been wrong: `gemini-embedding-001` returns 3072 dimensions by default, and the node never sends `outputDimensionality`, so a 768-dimensional vector cannot be produced through the node at all. A user who sizes a vector store index to 768 based on the notice gets a dimension mismatch on the first insert.

This PR:

- Corrects the notice so it names the default model and its actual dimensionality (3072).
- Adds an **Options > Output Dimensionality** setting that is sent as `outputDimensionality` on every `embedContent` / `batchEmbedContents` request, so the recommended sizes for `gemini-embedding-001` (768, 1536, 3072) are reachable. This is the same kind of option the OpenAI, Azure OpenAI and NVIDIA embeddings nodes already expose as `Dimensions`.

Implementation notes:

- `@langchain/google-genai` (both the pinned 2.1.24 and the current 2.3.0) has no way to set `outputDimensionality`; its request builder is private. The new `GeminiEmbeddings` helper extends `GoogleGenerativeAIEmbeddings` and only takes over the two protected request methods when the option is set. When the option is unset it delegates to the base class, so existing workflows behave exactly as before.
- The `@google/generative-ai` SDK serialises the request object as-is, so the extra field reaches the API without any change to the dependency. The request type is extended with an intersection type rather than a cast.
- When the option is set, a failed batch request rejects the call instead of being replaced by empty vectors (the upstream class does the latter), so a transient API error cannot be stored as embeddings.
- No node version bump: an optional collection with an empty default does not change the behaviour of existing workflows, following the precedent of #11773, which added the `Dimensions` option to the OpenAI and Azure OpenAI embeddings nodes the same way.
- As documented by Google, `gemini-embedding-001` returns unit-normalised vectors only at 3072 dimensions; truncated outputs are not re-normalised by the API (newer models do this automatically). This matches the behaviour of the other embeddings nodes, which pass the provider output through unchanged, so it is left to the vector store's similarity metric.

## How to test

Unit tests (13 new, no network access needed):

```
cd packages/@n8n/nodes-langchain
pnpm test nodes/embeddings/EmbeddingsGoogleGemini
```

To see the regression tests fail against master, revert the node file only and run the node test:

```
git checkout master -- nodes/embeddings/EmbeddingsGoogleGemini/EmbeddingsGoogleGemini.node.ts
pnpm test nodes/embeddings/EmbeddingsGoogleGemini/test/EmbeddingsGoogleGemini.test.ts
```

The `node description` tests fail with `expected 'Each model is using different dimensi…' to contain '3072-dimensional'` and the `supplyData` tests fail because no dimensionality is passed to the embeddings client.

Manual test with a workflow:

1. Add a Simple Vector Store node (Insert mode) with an Embeddings Google Gemini sub-node and a Default Data Loader, feed it any text item.
2. Leave the model at the default (`models/gemini-embedding-001`) and run. In the embeddings sub-node output, the returned vectors have 3072 values, matching the corrected notice.
3. Open the embeddings sub-node, add the **Output Dimensionality** option, set it to `768`, and run again. The returned vectors now have 768 values.
4. Set the option to `1536` and run once more; the vectors have 1536 values. Remove the option and the output returns to 3072.

## Related Linear tickets, Github issues, and Community forum posts

closes #37577

Follow-up to #26977, which updated the default model but not the notice describing it.

Docs: n8n-io/n8n-docs#5356

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
