### PR TITLE
refactor(core): Turn the three cli seams `otel` uses into DI ports (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/index.ts
+++ b/packages/@n8n/backend-common/src/index.ts
@@ -6,7 +6,10 @@ export { isObjectLiteral } from './utils/is-object-literal';
 export { Logger } from './logging/logger';
 export { ModuleRegistry } from './modules/module-registry';
 export { InstanceVersion } from './modules/ports/instance-version';
-export { ModulePubSubPublisher } from './modules/ports/module-pubsub-publisher';
+export {
+	ModulePubSubPublisher,
+	type ModulePubSubCommand,
+} from './modules/ports/module-pubsub-publisher';
 export {
 	WorkflowProjectLookup,
 	type WorkflowProjectSummary,

--- a/packages/@n8n/backend-common/src/index.ts
+++ b/packages/@n8n/backend-common/src/index.ts
@@ -5,6 +5,12 @@ export { inDevelopment, inProduction, inTest } from './environment';
 export { isObjectLiteral } from './utils/is-object-literal';
 export { Logger } from './logging/logger';
 export { ModuleRegistry } from './modules/module-registry';
+export { InstanceVersion } from './modules/ports/instance-version';
+export { ModulePubSubPublisher } from './modules/ports/module-pubsub-publisher';
+export {
+	WorkflowProjectLookup,
+	type WorkflowProjectSummary,
+} from './modules/ports/workflow-project-lookup';
 export type { ModuleName } from './modules/modules.config';
 export { ModulesConfig } from './modules/modules.config';
 export {

--- a/packages/@n8n/backend-common/src/modules/ports/instance-version.ts
+++ b/packages/@n8n/backend-common/src/modules/ports/instance-version.ts
@@ -1,0 +1,10 @@
+/**
+ * Port that reports the version of the running n8n instance.
+ *
+ * The host binds the value at bootstrap, because the host package is the only
+ * one that can read its own `package.json`. A module that re-derived the
+ * version would risk reporting a different one.
+ */
+export abstract class InstanceVersion {
+	abstract readonly version: string;
+}

--- a/packages/@n8n/backend-common/src/modules/ports/module-pubsub-publisher.ts
+++ b/packages/@n8n/backend-common/src/modules/ports/module-pubsub-publisher.ts
@@ -1,0 +1,12 @@
+import type { PubSubEventName } from '@n8n/decorators';
+
+/**
+ * Port that lets a module broadcast a command to the other instances of a
+ * scaling-mode deployment, without depending on the host's pubsub transport.
+ *
+ * The host binds an implementation at bootstrap. Only payload-less commands
+ * cross this port; commands that carry a payload stay host-side.
+ */
+export abstract class ModulePubSubPublisher {
+	abstract publishCommand(msg: { command: PubSubEventName }): Promise<void>;
+}

--- a/packages/@n8n/backend-common/src/modules/ports/module-pubsub-publisher.ts
+++ b/packages/@n8n/backend-common/src/modules/ports/module-pubsub-publisher.ts
@@ -1,12 +1,24 @@
-import type { PubSubEventName } from '@n8n/decorators';
+/**
+ * A command that a module may broadcast.
+ *
+ * Every member must name a host command that carries no payload. The map from
+ * command name to payload lives in the host, so a port typed over the whole
+ * `PubSubEventName` union accepts `{ command: 'stop-execution' }` — a
+ * payload-bearing command, with no payload, and no error at the publish site.
+ *
+ * The union holds message shapes rather than names, so the host binds it
+ * straight to its publisher and lets the compiler check each name against the
+ * payload map. A payload-bearing name added here breaks the host build instead
+ * of the wire.
+ */
+export type ModulePubSubCommand = { command: 'reload-otel-config' };
 
 /**
  * Port that lets a module broadcast a command to the other instances of a
  * scaling-mode deployment, without depending on the host's pubsub transport.
  *
- * The host binds an implementation at bootstrap. Only payload-less commands
- * cross this port; commands that carry a payload stay host-side.
+ * The host binds an implementation at bootstrap.
  */
 export abstract class ModulePubSubPublisher {
-	abstract publishCommand(msg: { command: PubSubEventName }): Promise<void>;
+	abstract publishCommand(msg: ModulePubSubCommand): Promise<void>;
 }

--- a/packages/@n8n/backend-common/src/modules/ports/workflow-project-lookup.ts
+++ b/packages/@n8n/backend-common/src/modules/ports/workflow-project-lookup.ts
@@ -1,0 +1,16 @@
+/** The part of a project a module may read through {@link WorkflowProjectLookup}. */
+export interface WorkflowProjectSummary {
+	id: string;
+	customTelemetryTags?: Array<{ key: string; value: string }>;
+}
+
+/**
+ * Port that resolves the project which owns a workflow.
+ *
+ * The host binds an implementation at bootstrap. The port stays this narrow on
+ * purpose: the host's ownership service also writes config and sets up owners,
+ * which is not a module concern.
+ */
+export abstract class WorkflowProjectLookup {
+	abstract getWorkflowProjectCached(workflowId: string): Promise<WorkflowProjectSummary>;
+}

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import picocolors from 'picocolors';
 import { z, ZodError } from 'zod';
 
+import { bindModulePorts } from './modules/module-ports';
 import './zod-alias-support';
 
 /**
@@ -27,6 +28,9 @@ export class CommandRegistry {
 	}
 
 	async execute() {
+		// Before any module is loaded, so no module can resolve an unbound port.
+		bindModulePorts();
+
 		if (this.commandName === '--help' || this.commandName === '-h') {
 			await this.listAllCommands();
 			return process.exit(0);

--- a/packages/cli/src/modules/__tests__/module-ports.test.ts
+++ b/packages/cli/src/modules/__tests__/module-ports.test.ts
@@ -1,0 +1,63 @@
+import { InstanceVersion, ModulePubSubPublisher, WorkflowProjectLookup } from '@n8n/backend-common';
+import type { Project } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { mock } from 'vitest-mock-extended';
+
+import { N8N_VERSION } from '@/constants';
+import { Publisher } from '@/scaling/pubsub/publisher.service';
+import { OwnershipService } from '@/services/ownership.service';
+
+import { bindModulePorts } from '../module-ports';
+
+describe('bindModulePorts', () => {
+	const publisher = mock<Publisher>();
+	const ownershipService = mock<OwnershipService>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		Container.set(Publisher, publisher);
+		Container.set(OwnershipService, ownershipService);
+	});
+
+	it('binds every port that a module resolves', () => {
+		bindModulePorts();
+
+		expect(Container.get(ModulePubSubPublisher)).toBeDefined();
+		expect(Container.get(WorkflowProjectLookup)).toBeDefined();
+		expect(Container.get(InstanceVersion)).toBeDefined();
+	});
+
+	it('constructs no service while binding', () => {
+		const getSpy = vi.spyOn(Container, 'get');
+
+		bindModulePorts();
+
+		expect(getSpy).not.toHaveBeenCalled();
+		getSpy.mockRestore();
+	});
+
+	it('delegates publishCommand to the publisher', async () => {
+		bindModulePorts();
+
+		await Container.get(ModulePubSubPublisher).publishCommand({ command: 'reload-otel-config' });
+
+		expect(publisher.publishCommand).toHaveBeenCalledWith({ command: 'reload-otel-config' });
+	});
+
+	it('delegates getWorkflowProjectCached to the ownership service', async () => {
+		bindModulePorts();
+		const project = mock<Project>({ id: 'project-1' });
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(project);
+
+		const result = await Container.get(WorkflowProjectLookup).getWorkflowProjectCached('wf-1');
+
+		expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
+		expect(result).toBe(project);
+	});
+
+	it('reports the cli version', () => {
+		bindModulePorts();
+
+		expect(Container.get(InstanceVersion).version).toBe(N8N_VERSION);
+	});
+});

--- a/packages/cli/src/modules/__tests__/module-ports.test.ts
+++ b/packages/cli/src/modules/__tests__/module-ports.test.ts
@@ -47,12 +47,28 @@ describe('bindModulePorts', () => {
 	it('delegates getWorkflowProjectCached to the ownership service', async () => {
 		bindModulePorts();
 		const project = mock<Project>({ id: 'project-1' });
+		// Assigned after construction: the mock helper deep-proxies nested values.
+		project.customTelemetryTags = [{ key: 'team', value: 'core' }];
 		ownershipService.getWorkflowProjectCached.mockResolvedValue(project);
 
 		const result = await Container.get(WorkflowProjectLookup).getWorkflowProjectCached('wf-1');
 
 		expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
-		expect(result).toBe(project);
+		expect(result).toEqual({
+			id: 'project-1',
+			customTelemetryTags: [{ key: 'team', value: 'core' }],
+		});
+	});
+
+	it('passes no field the project port does not declare', async () => {
+		bindModulePorts();
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-1', name: 'Team project', type: 'team' }),
+		);
+
+		const result = await Container.get(WorkflowProjectLookup).getWorkflowProjectCached('wf-1');
+
+		expect(Object.keys(result).sort()).toEqual(['customTelemetryTags', 'id']);
 	});
 
 	it('reports the cli version', () => {

--- a/packages/cli/src/modules/module-ports.ts
+++ b/packages/cli/src/modules/module-ports.ts
@@ -3,7 +3,6 @@ import { Container } from '@n8n/di';
 
 import { N8N_VERSION } from '@/constants';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
-import type { PubSub } from '@/scaling/pubsub/pubsub.types';
 import { OwnershipService } from '@/services/ownership.service';
 
 /**
@@ -16,15 +15,19 @@ import { OwnershipService } from '@/services/ownership.service';
  */
 export function bindModulePorts() {
 	Container.set(ModulePubSubPublisher, {
-		// The port carries payload-less commands only. `PubSub.Command` demands the
-		// payload that belongs to each command name, and that map stays in cli.
-		publishCommand: async (msg) =>
-			await Container.get(Publisher).publishCommand(msg as PubSub.Command),
+		// No cast: `ModulePubSubCommand` names payload-less commands only, so tsc
+		// checks each name here against the payload map in `PubSub.Command`.
+		publishCommand: async (msg) => await Container.get(Publisher).publishCommand(msg),
 	});
 
 	Container.set(WorkflowProjectLookup, {
-		getWorkflowProjectCached: async (workflowId) =>
-			await Container.get(OwnershipService).getWorkflowProjectCached(workflowId),
+		// Destructured, so the ORM entity does not cross the port at runtime and a
+		// module cannot read a field that the port never promised.
+		getWorkflowProjectCached: async (workflowId) => {
+			const { id, customTelemetryTags } =
+				await Container.get(OwnershipService).getWorkflowProjectCached(workflowId);
+			return { id, customTelemetryTags };
+		},
 	});
 
 	Container.set(InstanceVersion, { version: N8N_VERSION });

--- a/packages/cli/src/modules/module-ports.ts
+++ b/packages/cli/src/modules/module-ports.ts
@@ -1,0 +1,31 @@
+import { InstanceVersion, ModulePubSubPublisher, WorkflowProjectLookup } from '@n8n/backend-common';
+import { Container } from '@n8n/di';
+
+import { N8N_VERSION } from '@/constants';
+import { Publisher } from '@/scaling/pubsub/publisher.service';
+import type { PubSub } from '@/scaling/pubsub/pubsub.types';
+import { OwnershipService } from '@/services/ownership.service';
+
+/**
+ * Binds the cli implementations behind the ports that backend modules depend
+ * on, so that a module never reaches into cli internals.
+ *
+ * Each binding resolves its service on call, not on bind. Binding eagerly would
+ * open a Redis publisher client and build the repository graph in every CLI
+ * command, including the ones that never publish or read a project.
+ */
+export function bindModulePorts() {
+	Container.set(ModulePubSubPublisher, {
+		// The port carries payload-less commands only. `PubSub.Command` demands the
+		// payload that belongs to each command name, and that map stays in cli.
+		publishCommand: async (msg) =>
+			await Container.get(Publisher).publishCommand(msg as PubSub.Command),
+	});
+
+	Container.set(WorkflowProjectLookup, {
+		getWorkflowProjectCached: async (workflowId) =>
+			await Container.get(OwnershipService).getWorkflowProjectCached(workflowId),
+	});
+
+	Container.set(InstanceVersion, { version: N8N_VERSION });
+}

--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -1,4 +1,4 @@
-import type { LicenseState, Logger } from '@n8n/backend-common';
+import type { LicenseState, Logger, WorkflowProjectLookup } from '@n8n/backend-common';
 import type {
 	NodeExecuteAfterContext,
 	NodeExecuteBeforeContext,
@@ -8,8 +8,6 @@ import type {
 import { mock } from 'vitest-mock-extended';
 import { Workflow } from 'n8n-workflow';
 import type { INodeTypes, IRun, IRunExecutionData, WorkflowExecuteMode } from 'n8n-workflow';
-
-import type { OwnershipService } from '@/services/ownership.service';
 
 import type { ExecutionLevelTracer } from '../execution-level-tracer';
 import { OtelLifecycleHandler, countInputItems, countOutputItems } from '../otel-lifecycle-handler';
@@ -66,7 +64,7 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		let otelSettingsService = makeOtelSettingsService();
-		const ownershipService = mock<OwnershipService>();
+		const workflowProjectLookup = mock<WorkflowProjectLookup>();
 		const logger = mock<Logger>();
 		const licenseState = mock<LicenseState>();
 		let handler: OtelLifecycleHandler;
@@ -106,22 +104,26 @@ describe('OtelLifecycleHandler', () => {
 				traceContextService,
 				mock<OtelService>(),
 				otelSettingsService,
-				ownershipService,
+				workflowProjectLookup,
 				logger,
 				licenseState,
 			);
 			licenseState.isOtelCustomSpanAttributesLicensed.mockReturnValue(true);
 			tracer.startWorkflow.mockReturnValue(generatedSpanContext);
-			ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-default' } as never);
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValue({
+				id: 'proj-default',
+			} as never);
 		});
 
-		it('should look up project via OwnershipService and pass id to the tracer', async () => {
+		it('should look up project via WorkflowProjectLookup and pass id to the tracer', async () => {
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({ id: 'proj-1' } as never);
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValueOnce({
+				id: 'proj-1',
+			} as never);
 
 			await handler.onWorkflowStart(baseCtx);
 
-			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
+			expect(workflowProjectLookup.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
 			expect(tracer.startWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ project: { id: 'proj-1' } }),
 			);
@@ -129,7 +131,7 @@ describe('OtelLifecycleHandler', () => {
 
 		it('should pass project customAttributes to the tracer when project has telemetry tags', async () => {
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValueOnce({
 				id: 'proj-1',
 				customTelemetryTags: [
 					{ key: 'env', value: 'production' },
@@ -152,7 +154,7 @@ describe('OtelLifecycleHandler', () => {
 		it('should omit project and workflow customAttributes when custom OTel span attributes are not licensed', async () => {
 			licenseState.isOtelCustomSpanAttributesLicensed.mockReturnValue(false);
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValueOnce({
 				id: 'proj-1',
 				customTelemetryTags: [{ key: 'env', value: 'production' }],
 			} as never);
@@ -177,7 +179,7 @@ describe('OtelLifecycleHandler', () => {
 
 		it('should pass undefined customAttributes when project has no telemetry tags', async () => {
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValueOnce({
 				id: 'proj-empty',
 				customTelemetryTags: [],
 			} as never);
@@ -193,7 +195,7 @@ describe('OtelLifecycleHandler', () => {
 
 		it('should start workflow span without project if project lookup fails', async () => {
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockRejectedValueOnce(new Error('DB error'));
+			workflowProjectLookup.getWorkflowProjectCached.mockRejectedValueOnce(new Error('DB error'));
 
 			await expect(handler.onWorkflowStart(baseCtx)).resolves.not.toThrow();
 
@@ -402,7 +404,7 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		let otelSettingsService = makeOtelSettingsService();
-		const ownershipService = mock<OwnershipService>();
+		const workflowProjectLookup = mock<WorkflowProjectLookup>();
 		const logger = mock<Logger>();
 		const licenseState = mock<LicenseState>();
 		let handler: OtelLifecycleHandler;
@@ -422,18 +424,20 @@ describe('OtelLifecycleHandler', () => {
 				traceContextService,
 				mock<OtelService>(),
 				otelSettingsService,
-				ownershipService,
+				workflowProjectLookup,
 				logger,
 				licenseState,
 			);
 			licenseState.isOtelCustomSpanAttributesLicensed.mockReturnValue(true);
 			tracer.startWorkflow.mockReturnValue(resumedSpanContext);
-			ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-default' } as never);
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValue({
+				id: 'proj-default',
+			} as never);
 		});
 
-		it('should look up project via OwnershipService on resume', async () => {
+		it('should look up project via WorkflowProjectLookup on resume', async () => {
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValueOnce({
 				id: 'resume-proj',
 			} as never);
 
@@ -445,7 +449,7 @@ describe('OtelLifecycleHandler', () => {
 				executionId: 'exec-resume',
 			} as never);
 
-			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
+			expect(workflowProjectLookup.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
 			expect(tracer.startWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ project: { id: 'resume-proj' } }),
 			);
@@ -453,7 +457,7 @@ describe('OtelLifecycleHandler', () => {
 
 		it('should pass project customAttributes on resume when project has telemetry tags', async () => {
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValueOnce({
 				id: 'resume-proj-tags',
 				customTelemetryTags: [{ key: 'env', value: 'staging' }],
 			} as never);
@@ -479,7 +483,7 @@ describe('OtelLifecycleHandler', () => {
 		it('should omit project customAttributes on resume when custom OTel span attributes are not licensed', async () => {
 			licenseState.isOtelCustomSpanAttributesLicensed.mockReturnValue(false);
 			traceContextService.get.mockResolvedValueOnce(undefined);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({
+			workflowProjectLookup.getWorkflowProjectCached.mockResolvedValueOnce({
 				id: 'resume-proj-tags',
 				customTelemetryTags: [{ key: 'env', value: 'staging' }],
 			} as never);
@@ -511,7 +515,7 @@ describe('OtelLifecycleHandler', () => {
 		});
 
 		it('should start workflow span without project if project lookup fails on resume', async () => {
-			ownershipService.getWorkflowProjectCached.mockRejectedValueOnce(new Error('DB error'));
+			workflowProjectLookup.getWorkflowProjectCached.mockRejectedValueOnce(new Error('DB error'));
 
 			await expect(
 				handler.onWorkflowResume({
@@ -576,7 +580,7 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		let otelSettingsService = makeOtelSettingsService();
-		const ownershipService = mock<OwnershipService>();
+		const workflowProjectLookup = mock<WorkflowProjectLookup>();
 		const logger = mock<Logger>();
 		const licenseState = mock<LicenseState>();
 		let handler: OtelLifecycleHandler;
@@ -589,7 +593,7 @@ describe('OtelLifecycleHandler', () => {
 				traceContextService,
 				mock<OtelService>(),
 				otelSettingsService,
-				ownershipService,
+				workflowProjectLookup,
 				logger,
 				licenseState,
 			);
@@ -654,7 +658,7 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		let otelSettingsService = makeOtelSettingsService();
-		const ownershipService = mock<OwnershipService>();
+		const workflowProjectLookup = mock<WorkflowProjectLookup>();
 		const logger = mock<Logger>();
 		const licenseState = mock<LicenseState>();
 		let handler: OtelLifecycleHandler;
@@ -700,7 +704,7 @@ describe('OtelLifecycleHandler', () => {
 				traceContextService,
 				mock<OtelService>(),
 				otelSettingsService,
-				ownershipService,
+				workflowProjectLookup,
 				logger,
 				licenseState,
 			);
@@ -714,7 +718,7 @@ describe('OtelLifecycleHandler', () => {
 				traceContextService,
 				mock<OtelService>(),
 				otelSettingsService,
-				ownershipService,
+				workflowProjectLookup,
 				logger,
 				licenseState,
 			);
@@ -811,7 +815,7 @@ describe('productionExecutionsOnly filter', () => {
 	const tracer = mock<ExecutionLevelTracer>();
 	const traceContextService = mock<TraceContextService>();
 	let otelSettingsService = makeOtelSettingsService();
-	const ownershipService = mock<OwnershipService>();
+	const workflowProjectLookup = mock<WorkflowProjectLookup>();
 	const logger = mock<Logger>();
 	const licenseState = mock<LicenseState>();
 	let handler: OtelLifecycleHandler;
@@ -910,14 +914,14 @@ describe('productionExecutionsOnly filter', () => {
 			productionExecutionsOnly: true,
 			includeNodeSpans: true,
 		});
-		ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-1' } as never);
+		workflowProjectLookup.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-1' } as never);
 		traceContextService.get.mockResolvedValue(undefined);
 		handler = new OtelLifecycleHandler(
 			tracer,
 			traceContextService,
 			mock<OtelService>(),
 			otelSettingsService,
-			ownershipService,
+			workflowProjectLookup,
 			logger,
 			licenseState,
 		);
@@ -1009,7 +1013,7 @@ describe('onReloadOtelConfig', () => {
 			mock<TraceContextService>(),
 			otelService,
 			makeOtelSettingsService(),
-			mock<OwnershipService>(),
+			mock<WorkflowProjectLookup>(),
 			mock<Logger>(),
 			licenseState,
 		);

--- a/packages/cli/src/modules/otel/__tests__/otel-settings.controller.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-settings.controller.test.ts
@@ -1,4 +1,4 @@
-import type { ModuleRegistry } from '@n8n/backend-common';
+import type { ModulePubSubPublisher, ModuleRegistry } from '@n8n/backend-common';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
@@ -11,8 +11,6 @@ import type {
 } from '../otel-settings.service';
 import type { OtelConfig } from '../otel.config';
 import type { OtelService } from '../otel.service';
-
-import type { Publisher } from '@/scaling/pubsub/publisher.service';
 
 const req = mock<AuthenticatedRequest>();
 const res = mock<Response>();
@@ -38,7 +36,7 @@ describe('OtelSettingsController', () => {
 	let otelService: ReturnType<typeof mock<OtelService>>;
 	let otelLifecycleHandler: ReturnType<typeof mock<OtelLifecycleHandler>>;
 	let moduleRegistry: ReturnType<typeof mock<ModuleRegistry>>;
-	let publisher: ReturnType<typeof mock<Publisher>>;
+	let publisher: ReturnType<typeof mock<ModulePubSubPublisher>>;
 	let controller: OtelSettingsController;
 
 	beforeEach(() => {
@@ -47,7 +45,7 @@ describe('OtelSettingsController', () => {
 		otelService = mock<OtelService>();
 		otelLifecycleHandler = mock<OtelLifecycleHandler>();
 		moduleRegistry = mock<ModuleRegistry>();
-		publisher = mock<Publisher>();
+		publisher = mock<ModulePubSubPublisher>();
 		controller = new OtelSettingsController(
 			otelSettingsService,
 			otelService,

--- a/packages/cli/src/modules/otel/__tests__/otel.service.grpc-deps.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel.service.grpc-deps.test.ts
@@ -48,6 +48,7 @@ describe('OtelService with real gRPC dependencies', () => {
 		service = new OtelService(
 			mock<OtelSettingsService>(),
 			mock<InstanceSettings>({ instanceId: 'inst-1', instanceType: 'main' }),
+			{ version: '1.2.3' },
 			logger,
 			mock<OutboundHttp>(),
 		);

--- a/packages/cli/src/modules/otel/__tests__/otel.service.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel.service.test.ts
@@ -197,7 +197,13 @@ describe('OtelService', () => {
 		waitForReady.mockImplementation((_deadline: number, callback: (error?: Error) => void) =>
 			callback(),
 		);
-		service = new OtelService(otelSettingsService, instanceSettings, logger, outboundHttp);
+		service = new OtelService(
+			otelSettingsService,
+			instanceSettings,
+			{ version: '1.2.3' },
+			logger,
+			outboundHttp,
+		);
 	});
 
 	describe('init', () => {

--- a/packages/cli/src/modules/otel/__tests__/support/otel-integration-utils.ts
+++ b/packages/cli/src/modules/otel/__tests__/support/otel-integration-utils.ts
@@ -18,6 +18,7 @@ import type {
 } from 'n8n-workflow';
 import path from 'path';
 
+import { bindModulePorts } from '@/modules/module-ports';
 import { WorkflowRunner } from '@/workflow-runner';
 import * as utils from '@test-integration/utils';
 
@@ -49,6 +50,7 @@ function loadNodesFromDist(nodeNames: string[]): INodeTypeData {
 export async function initOtelTestEnvironment() {
 	const otel = OtelTestProvider.create();
 
+	bindModulePorts();
 	await testModules.loadModules(['otel']);
 	await testDb.init();
 	await Container.get(ModuleRegistry).initModules('main');

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -1,4 +1,4 @@
-import { LicenseState, Logger } from '@n8n/backend-common';
+import { LicenseState, Logger, WorkflowProjectLookup } from '@n8n/backend-common';
 import { OnLifecycleEvent, OnPubSubEvent } from '@n8n/decorators';
 import type {
 	WorkflowExecuteBeforeContext,
@@ -15,7 +15,6 @@ import type { CustomAttributes } from './execution-level-tracer.types';
 import { OtelSettingsService } from './otel-settings.service';
 import { OtelService } from './otel.service';
 import { TraceContextService } from './tracing-context';
-import { OwnershipService } from '../../services/ownership.service';
 
 const isCustomTelemetryTag = (value: unknown): value is ICustomTelemetryTag =>
 	typeof value === 'object' &&
@@ -43,7 +42,7 @@ export class OtelLifecycleHandler {
 		private readonly traceContextService: TraceContextService,
 		private readonly otelService: OtelService,
 		private readonly otelSettingsService: OtelSettingsService,
-		private readonly ownershipService: OwnershipService,
+		private readonly workflowProjectLookup: WorkflowProjectLookup,
 		private readonly logger: Logger,
 		private readonly licenseState: LicenseState,
 	) {}
@@ -75,7 +74,7 @@ export class OtelLifecycleHandler {
 			: // This will return "null" if there is no traceparent header in the trigger node. (e.g. webhook)
 				await this.traceContextService.get(ctx.executionId);
 
-		const project = await this.ownershipService
+		const project = await this.workflowProjectLookup
 			.getWorkflowProjectCached(ctx.workflow.id)
 			.catch((error: unknown) => {
 				this.logger.warn('Failed to fetch project for OTEL span', {
@@ -115,7 +114,7 @@ export class OtelLifecycleHandler {
 
 		const previousWorkflowExecution = await this.traceContextService.get(ctx.executionId);
 
-		const project = await this.ownershipService
+		const project = await this.workflowProjectLookup
 			.getWorkflowProjectCached(ctx.workflow.id)
 			.catch((error: unknown) => {
 				this.logger.warn('Failed to fetch project for OTEL span', {

--- a/packages/cli/src/modules/otel/otel-settings.controller.ts
+++ b/packages/cli/src/modules/otel/otel-settings.controller.ts
@@ -1,13 +1,11 @@
 import { TestOtelTraceDto, UpdateOtelSettingsDto } from '@n8n/api-types';
-import { ModuleRegistry } from '@n8n/backend-common';
+import { ModulePubSubPublisher, ModuleRegistry } from '@n8n/backend-common';
 import { AuthenticatedRequest } from '@n8n/db';
 import { Body, Get, GlobalScope, Post, Put, RestController } from '@n8n/decorators';
 
 import { OtelLifecycleHandler } from './otel-lifecycle-handler';
 import { OtelSettingsService } from './otel-settings.service';
 import { OtelService } from './otel.service';
-
-import { Publisher } from '@/scaling/pubsub/publisher.service';
 
 @RestController('/otel')
 export class OtelSettingsController {
@@ -16,7 +14,7 @@ export class OtelSettingsController {
 		private readonly otelService: OtelService,
 		private readonly otelLifecycleHandler: OtelLifecycleHandler,
 		private readonly moduleRegistry: ModuleRegistry,
-		private readonly publisher: Publisher,
+		private readonly publisher: ModulePubSubPublisher,
 	) {}
 
 	@Get('/settings')

--- a/packages/cli/src/modules/otel/otel.service.ts
+++ b/packages/cli/src/modules/otel/otel.service.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from '@grpc/grpc-js';
-import { Logger } from '@n8n/backend-common';
+import { InstanceVersion, Logger } from '@n8n/backend-common';
 import { OutboundHttp } from '@n8n/backend-network';
 import { Service } from '@n8n/di';
 import type { DiagLogger } from '@opentelemetry/api';
@@ -22,8 +22,6 @@ import { OtelSettingsService } from './otel-settings.service';
 import { OtelConfig } from './otel.config';
 import { ATTR, OTEL_TEST_SPAN_NAME } from './otel.constants';
 
-import { N8N_VERSION } from '@/constants';
-
 export type OtelTestTraceResult = { success: true } | { success: false; error: string };
 
 const stripEmptyResolutionNote = (message: string) =>
@@ -37,6 +35,7 @@ export class OtelService {
 	constructor(
 		private readonly otelSettingsService: OtelSettingsService,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly instanceVersion: InstanceVersion,
 		private readonly logger: Logger,
 		private readonly outboundHttp: OutboundHttp,
 	) {}
@@ -86,7 +85,7 @@ export class OtelService {
 					provider = new BasicTracerProvider({
 						resource: resourceFromAttributes({
 							[ATTR.OTEL_SERVICE_NAME]: connection.exporterServiceName,
-							[ATTR.OTEL_SERVICE_VERSION]: N8N_VERSION,
+							[ATTR.OTEL_SERVICE_VERSION]: this.instanceVersion.version,
 							[ATTR.INSTANCE_ID]: this.instanceSettings.instanceId,
 							[ATTR.INSTANCE_ROLE]: this.instanceSettings.instanceType,
 						}),
@@ -153,7 +152,7 @@ export class OtelService {
 		this.sdk = new NodeSDK({
 			resource: resourceFromAttributes({
 				[ATTR.OTEL_SERVICE_NAME]: settings.exporterServiceName,
-				[ATTR.OTEL_SERVICE_VERSION]: N8N_VERSION,
+				[ATTR.OTEL_SERVICE_VERSION]: this.instanceVersion.version,
 				[ATTR.INSTANCE_ID]: this.instanceSettings.instanceId,
 				[ATTR.INSTANCE_ROLE]: this.instanceSettings.instanceType,
 			}),

--- a/packages/cli/test/integration/modules/otel-queue-mode-propagation.test.ts
+++ b/packages/cli/test/integration/modules/otel-queue-mode-propagation.test.ts
@@ -16,6 +16,7 @@ import { OtelService } from '@/modules/otel/otel.service';
 import { COMMAND_PUBSUB_CHANNEL } from '@/scaling/constants';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { PubSubEventBus } from '@/scaling/pubsub/pubsub.eventbus';
+import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
 import type { RedisClientService } from '@/services/redis-client.service';
 import { createOwner } from '@test-integration/db/users';
@@ -44,7 +45,7 @@ function createFakeRedisClient() {
 	return mock<SingleNodeClient>({
 		publish: ((channel: string, message: string) => {
 			bus.published.push({ channel, message });
-			for (const client of bus.clients) {
+			for (const client of [...bus.clients]) {
 				if (!client.channels.has(channel)) continue;
 				for (const listener of client.listeners) listener(channel, message);
 			}
@@ -60,14 +61,31 @@ function createFakeRedisClient() {
 			if (event === 'message') state.listeners.push(listener);
 			return undefined as never;
 		}) as never,
-		disconnect: (() => {}) as never,
+		// A disconnected client receives nothing more, so it leaves the bus.
+		disconnect: (() => {
+			const index = bus.clients.indexOf(state);
+			if (index !== -1) bus.clients.splice(index, 1);
+		}) as never,
 	});
 }
+
+const redisClientService = mock<RedisClientService>({
+	createClient: () => createFakeRedisClient(),
+});
 
 const REDIS_PREFIX = 'n8n';
 const MAIN_HOST_ID = 'main-testhost';
 const WORKER_HOST_ID = 'worker-testhost';
 const commandChannel = `${REDIS_PREFIX}:${COMMAND_PUBSUB_CHANNEL}`;
+
+/** The subscriber debounces every command that `IMMEDIATE_COMMANDS` does not name. */
+const DEBOUNCE_MS = 300;
+
+const workerInstanceSettings = mock<InstanceSettings>({
+	hostId: WORKER_HOST_ID,
+	instanceType: 'worker',
+	instanceRole: 'unset',
+});
 
 const validSettings = {
 	enabled: false,
@@ -87,8 +105,8 @@ describe('reload-otel-config propagation in queue mode', () => {
 	let owner: User;
 	let workerEventBus: PubSubEventBus;
 	let workerSubscriber: Subscriber;
-	/** Calls of the worker-side `reload-otel-config` handler. */
-	let workerHandlerCalls = 0;
+	/** Deliveries of `reload-otel-config` to the worker's event bus. */
+	let workerDeliveries = 0;
 
 	// Declared before `setupTestServer` on purpose: this hook must run before the
 	// test server constructs the otel controller, so that on any revision the
@@ -98,10 +116,6 @@ describe('reload-otel-config propagation in queue mode', () => {
 		const queueConfig = Container.get(ExecutionsConfig);
 		queueConfig.mode = 'queue';
 		Container.get(GlobalConfig).redis.prefix = REDIS_PREFIX;
-
-		const redisClientService = mock<RedisClientService>({
-			createClient: () => createFakeRedisClient(),
-		});
 
 		// The main instance's publisher: the real class, on the fake transport.
 		Container.set(
@@ -114,51 +128,23 @@ describe('reload-otel-config propagation in queue mode', () => {
 				Container.get(GlobalConfig),
 			),
 		);
-
-		// A second instance on the same channel, with a worker's host id and type.
-		// Its own event bus keeps its deliveries distinct from the main's.
-		workerEventBus = new PubSubEventBus();
-		workerSubscriber = new Subscriber(
-			Container.get(Logger),
-			mock<InstanceSettings>({
-				hostId: WORKER_HOST_ID,
-				instanceType: 'worker',
-				instanceRole: 'unset',
-			}),
-			workerEventBus,
-			redisClientService,
-			queueConfig,
-			Container.get(GlobalConfig),
-		);
 	});
 
 	const testServer = setupTestServer({ endpointGroups: ['otel'] });
 
 	beforeAll(async () => {
 		await testDb.init();
-		await workerSubscriber.subscribe(commandChannel);
 
-		// Register the worker's `reload-otel-config` handler the way `PubSubRegistry`
-		// does: from the decorator metadata, resolving the handler class from the
-		// container. On a worker this is the only path that reaches otel.
+		// The registration the worker's registry reads. Asserted separately so that
+		// a missing decorator names itself, instead of showing up as no delivery.
 		const handlers = Container.get(PubSubMetadata)
 			.getHandlers()
 			.filter((handler) => handler.eventName === 'reload-otel-config');
 
 		expect(handlers).toHaveLength(1);
-		const [{ eventHandlerClass, methodName, filter }] = handlers;
-		expect(eventHandlerClass).toBe(OtelLifecycleHandler);
-		// No instance-type filter, so the handler registers on a worker too.
-		expect(filter?.instanceType).toBeUndefined();
-
-		const handlerInstance = Container.get(eventHandlerClass) as unknown as Record<
-			string,
-			() => Promise<void>
-		>;
-		workerEventBus.on('reload-otel-config', async () => {
-			workerHandlerCalls++;
-			await handlerInstance[methodName]();
-		});
+		expect(handlers[0].eventHandlerClass).toBe(OtelLifecycleHandler);
+		// No instance-type filter, so a worker's registry registers it too.
+		expect(handlers[0].filter?.instanceType).toBeUndefined();
 	});
 
 	beforeEach(async () => {
@@ -167,15 +153,41 @@ describe('reload-otel-config propagation in queue mode', () => {
 		await Container.get(OtelSettingsService).loadSettings();
 		owner = await createOwner();
 		bus.published.length = 0;
-		workerHandlerCalls = 0;
+		workerDeliveries = 0;
+
+		// A worker instance, rebuilt for each test. `shutdown()` in `afterEach`
+		// cancels the trailing debounce, so a timer armed by one test can never
+		// deliver into the next one.
+		workerEventBus = new PubSubEventBus();
+		workerSubscriber = new Subscriber(
+			Container.get(Logger),
+			workerInstanceSettings,
+			workerEventBus,
+			redisClientService,
+			Container.get(ExecutionsConfig),
+			Container.get(GlobalConfig),
+		);
+		await workerSubscriber.subscribe(commandChannel);
+
+		// The real registry wires the real `@OnPubSubEvent` handler onto this bus.
+		// On a worker this is the only path that reaches otel.
+		const workerRegistry = new PubSubRegistry(
+			Container.get(Logger),
+			workerInstanceSettings,
+			Container.get(PubSubMetadata),
+			workerEventBus,
+		);
+		workerRegistry.init();
+
+		// Observes what the transport delivered. The registry stays under test.
+		workerEventBus.on('reload-otel-config', () => {
+			workerDeliveries++;
+		});
 	});
 
 	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
-	afterAll(() => {
 		workerSubscriber.shutdown();
+		vi.restoreAllMocks();
 	});
 
 	it('publishes reload-otel-config on the command channel with the expected payload', async () => {
@@ -202,10 +214,10 @@ describe('reload-otel-config propagation in queue mode', () => {
 		expect(response.status).toBe(200);
 
 		// 300 ms subscriber debounce, so poll rather than assert once.
-		await vi.waitFor(() => expect(workerHandlerCalls).toBe(1), { timeout: 5_000 });
+		await vi.waitFor(() => expect(workerDeliveries).toBe(1), { timeout: 5_000 });
 
-		// Once for the main's own local reload, once for the worker's.
-		expect(restart).toHaveBeenCalledTimes(2);
+		// Once for the main's own local reload, once through the worker's registry.
+		await vi.waitFor(() => expect(restart).toHaveBeenCalledTimes(2), { timeout: 5_000 });
 	});
 
 	it('does not publish when the write is rejected', async () => {
@@ -216,5 +228,22 @@ describe('reload-otel-config propagation in queue mode', () => {
 
 		expect(response.status).toBe(400);
 		expect(bus.published).toHaveLength(0);
+	});
+
+	it('delivers nothing to a worker that shut down with a debounce armed', async () => {
+		const response = await testServer.authAgentFor(owner).put('/otel/settings').send(validSettings);
+
+		expect(response.status).toBe(200);
+		await vi.waitFor(() => expect(bus.published).toHaveLength(1));
+		// The trailing timer is armed, and it has not fired yet.
+		expect(workerDeliveries).toBe(0);
+
+		workerSubscriber.shutdown();
+
+		// A negative claim over time needs a bounded wait: no event marks the
+		// moment a cancelled timer does not fire.
+		await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS * 2));
+
+		expect(workerDeliveries).toBe(0);
 	});
 });

--- a/packages/cli/test/integration/modules/otel-queue-mode-propagation.test.ts
+++ b/packages/cli/test/integration/modules/otel-queue-mode-propagation.test.ts
@@ -1,0 +1,220 @@
+import { Logger } from '@n8n/backend-common';
+import { testDb } from '@n8n/backend-test-utils';
+import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
+import { SettingsRepository, type User } from '@n8n/db';
+import { PubSubMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { Redis as SingleNodeClient } from 'ioredis';
+import type { InstanceSettings } from 'n8n-core';
+import { jsonParse } from 'n8n-workflow';
+import { vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { OtelLifecycleHandler } from '@/modules/otel/otel-lifecycle-handler';
+import { OTEL_SETTINGS_KEY, OtelSettingsService } from '@/modules/otel/otel-settings.service';
+import { OtelService } from '@/modules/otel/otel.service';
+import { COMMAND_PUBSUB_CHANNEL } from '@/scaling/constants';
+import { Publisher } from '@/scaling/pubsub/publisher.service';
+import { PubSubEventBus } from '@/scaling/pubsub/pubsub.eventbus';
+import { Subscriber } from '@/scaling/pubsub/subscriber.service';
+import type { RedisClientService } from '@/services/redis-client.service';
+import { createOwner } from '@test-integration/db/users';
+import { setupTestServer } from '@test-integration/utils';
+
+/**
+ * An in-memory stand-in for the Redis pubsub transport. Every message crosses it
+ * as the JSON string the real client would carry, so the publish payload and the
+ * subscriber's own parsing, sender filter and debounce all run for real.
+ */
+const bus = {
+	clients: [] as Array<{
+		channels: Set<string>;
+		listeners: Array<(channel: string, message: string) => void>;
+	}>,
+	published: [] as Array<{ channel: string; message: string }>,
+};
+
+function createFakeRedisClient() {
+	const state = {
+		channels: new Set<string>(),
+		listeners: [] as Array<(channel: string, message: string) => void>,
+	};
+	bus.clients.push(state);
+
+	return mock<SingleNodeClient>({
+		publish: ((channel: string, message: string) => {
+			bus.published.push({ channel, message });
+			for (const client of bus.clients) {
+				if (!client.channels.has(channel)) continue;
+				for (const listener of client.listeners) listener(channel, message);
+			}
+			return 1;
+		}) as never,
+		subscribe: (async (channel: string, onSubscribed?: (error: unknown) => void) => {
+			await Promise.resolve();
+			state.channels.add(channel);
+			onSubscribed?.(null);
+			return 1;
+		}) as never,
+		on: ((event: string, listener: (channel: string, message: string) => void) => {
+			if (event === 'message') state.listeners.push(listener);
+			return undefined as never;
+		}) as never,
+		disconnect: (() => {}) as never,
+	});
+}
+
+const REDIS_PREFIX = 'n8n';
+const MAIN_HOST_ID = 'main-testhost';
+const WORKER_HOST_ID = 'worker-testhost';
+const commandChannel = `${REDIS_PREFIX}:${COMMAND_PUBSUB_CHANNEL}`;
+
+const validSettings = {
+	enabled: false,
+	exporterProtocol: 'http/protobuf',
+	exporterEndpoint: 'http://collector.example.com:4318',
+	exporterTracingPath: '/v1/traces',
+	exporterServiceName: 'n8n-prod',
+	exporterHeaders: 'authorization=Bearer my-token',
+	tracesSampleRate: 0.5,
+	startupConnectivityTimeoutMs: 3_000,
+	includeNodeSpans: false,
+	injectOutbound: false,
+	productionExecutionsOnly: false,
+};
+
+describe('reload-otel-config propagation in queue mode', () => {
+	let owner: User;
+	let workerEventBus: PubSubEventBus;
+	let workerSubscriber: Subscriber;
+	/** Calls of the worker-side `reload-otel-config` handler. */
+	let workerHandlerCalls = 0;
+
+	// Declared before `setupTestServer` on purpose: this hook must run before the
+	// test server constructs the otel controller, so that on any revision the
+	// controller sees this queue-mode `Publisher` — whether it captures the
+	// publisher at construction or resolves it per call.
+	beforeAll(() => {
+		const queueConfig = Container.get(ExecutionsConfig);
+		queueConfig.mode = 'queue';
+		Container.get(GlobalConfig).redis.prefix = REDIS_PREFIX;
+
+		const redisClientService = mock<RedisClientService>({
+			createClient: () => createFakeRedisClient(),
+		});
+
+		// The main instance's publisher: the real class, on the fake transport.
+		Container.set(
+			Publisher,
+			new Publisher(
+				Container.get(Logger),
+				redisClientService,
+				mock<InstanceSettings>({ hostId: MAIN_HOST_ID, instanceType: 'main' }),
+				queueConfig,
+				Container.get(GlobalConfig),
+			),
+		);
+
+		// A second instance on the same channel, with a worker's host id and type.
+		// Its own event bus keeps its deliveries distinct from the main's.
+		workerEventBus = new PubSubEventBus();
+		workerSubscriber = new Subscriber(
+			Container.get(Logger),
+			mock<InstanceSettings>({
+				hostId: WORKER_HOST_ID,
+				instanceType: 'worker',
+				instanceRole: 'unset',
+			}),
+			workerEventBus,
+			redisClientService,
+			queueConfig,
+			Container.get(GlobalConfig),
+		);
+	});
+
+	const testServer = setupTestServer({ endpointGroups: ['otel'] });
+
+	beforeAll(async () => {
+		await testDb.init();
+		await workerSubscriber.subscribe(commandChannel);
+
+		// Register the worker's `reload-otel-config` handler the way `PubSubRegistry`
+		// does: from the decorator metadata, resolving the handler class from the
+		// container. On a worker this is the only path that reaches otel.
+		const handlers = Container.get(PubSubMetadata)
+			.getHandlers()
+			.filter((handler) => handler.eventName === 'reload-otel-config');
+
+		expect(handlers).toHaveLength(1);
+		const [{ eventHandlerClass, methodName, filter }] = handlers;
+		expect(eventHandlerClass).toBe(OtelLifecycleHandler);
+		// No instance-type filter, so the handler registers on a worker too.
+		expect(filter?.instanceType).toBeUndefined();
+
+		const handlerInstance = Container.get(eventHandlerClass) as unknown as Record<
+			string,
+			() => Promise<void>
+		>;
+		workerEventBus.on('reload-otel-config', async () => {
+			workerHandlerCalls++;
+			await handlerInstance[methodName]();
+		});
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+		await Container.get(SettingsRepository).delete({ key: OTEL_SETTINGS_KEY });
+		await Container.get(OtelSettingsService).loadSettings();
+		owner = await createOwner();
+		bus.published.length = 0;
+		workerHandlerCalls = 0;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterAll(() => {
+		workerSubscriber.shutdown();
+	});
+
+	it('publishes reload-otel-config on the command channel with the expected payload', async () => {
+		const response = await testServer.authAgentFor(owner).put('/otel/settings').send(validSettings);
+
+		expect(response.status).toBe(200);
+
+		await vi.waitFor(() => expect(bus.published).toHaveLength(1));
+
+		expect(bus.published[0].channel).toBe(commandChannel);
+		expect(jsonParse(bus.published[0].message)).toEqual({
+			command: 'reload-otel-config',
+			senderId: MAIN_HOST_ID,
+			selfSend: false,
+			debounce: true,
+		});
+	});
+
+	it('reaches a worker, which reloads its otel configuration', async () => {
+		const restart = vi.spyOn(Container.get(OtelService), 'restart').mockResolvedValue();
+
+		const response = await testServer.authAgentFor(owner).put('/otel/settings').send(validSettings);
+
+		expect(response.status).toBe(200);
+
+		// 300 ms subscriber debounce, so poll rather than assert once.
+		await vi.waitFor(() => expect(workerHandlerCalls).toBe(1), { timeout: 5_000 });
+
+		// Once for the main's own local reload, once for the worker's.
+		expect(restart).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not publish when the write is rejected', async () => {
+		const response = await testServer
+			.authAgentFor(owner)
+			.put('/otel/settings')
+			.send({ ...validSettings, exporterEndpoint: 'not-a-url' });
+
+		expect(response.status).toBe(400);
+		expect(bus.published).toHaveLength(0);
+	});
+});

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -15,6 +15,7 @@ import { AUTH_COOKIE_NAME } from '@/constants';
 import { ControllerRegistry } from '@/controller.registry';
 import { License } from '@/license';
 import { rawBodyReader, bodyParser } from '@/middlewares';
+import { bindModulePorts } from '@/modules/module-ports';
 import { PostHogClient } from '@/posthog';
 import { Push } from '@/push';
 import { ApiKeyAuthStrategy } from '@/services/api-key-auth.strategy';
@@ -148,6 +149,8 @@ export const setupTestServer = ({
 
 	// eslint-disable-next-line complexity
 	beforeAll(async () => {
+		// Mirrors the production order: the ports are bound before modules load.
+		bindModulePorts();
 		if (modules) await testModules.loadModules(modules);
 		await testDb.init();
 


### PR DESCRIPTION
## Summary

Wave-1 PR-1 of the otel backend extraction. otel touches cli through exactly three seams. Each becomes a narrow DI port in `@n8n/backend-common`, so the module no longer imports a cli-internal path and can move to a workspace package later.

**The ports** (`packages/@n8n/backend-common/src/modules/ports/`)

| Port | Contract | cli implementation |
| --- | --- | --- |
| `ModulePubSubPublisher` | `publishCommand(msg: ModulePubSubCommand)` | `Publisher` |
| `WorkflowProjectLookup` | `getWorkflowProjectCached(workflowId)` → `{ id, customTelemetryTags? }` | `OwnershipService` |
| `InstanceVersion` | `readonly version: string` | `N8N_VERSION` |

`@n8n/backend-common` cannot depend on `@n8n/db` (`@n8n/db` already depends on it), so `WorkflowProjectLookup` returns the two project fields otel reads, not the `Project` entity. `OwnershipService` does not move: it also writes `@/config` and sets up owners.

**The binding** — one function, `packages/cli/src/modules/module-ports.ts`, called at the top of `CommandRegistry.execute()`, before any module loads.

**Folded in:** `packages/cli/test/integration/modules/otel-queue-mode-propagation.test.ts`, cherry-picked from #38133 (author: filter, commit `a878132`). It drives the real `PUT /rest/otel/settings` route, the real `Publisher` and `Subscriber` in queue mode, and a second instance with a worker host id, so the one behaviour this refactor could break now has a test. #38133 is superseded and can be closed.

**`N8N_VERSION`: I took the bootstrap binding, not an accessor in `@n8n/backend-common`.** An accessor there has to re-derive the version by resolving `n8n/package.json`, and the existing precedent in that same package (`module-registry.ts:106`) shows that resolution fails in local dev and needs a second fallback path. That would ship a second source of truth for the version that can silently disagree with `cli/src/constants.ts`. The binding adds no new resolution logic and no new file — the token sits in the ports directory this PR already creates, and the bind is one line next to the other two. Cost is one constructor parameter on `OtelService` and one argument in two test files.

## Review rulings — the two cubic comments

Both hold. Both are applied. Neither was a live bug: otel publishes only `reload-otel-config` and reads only two project fields. They are fixed because this PR is the template the next module copies, and both defects would surface in the next module rather than this one.

**1. `module-pubsub-publisher.ts:11` — the port admitted payload-bearing commands. Applied, and hardened past the suggestion.**

The port took `{ command: PubSubEventName }`. That union also names commands that require a payload (`stop-execution`, `cancel-test-run`) and one worker *response* (`response-to-get-worker-status`), and the binding cast `msg as PubSub.Command` to bridge the gap. A module could publish `{ command: 'cancel-test-run' }` with no `testRunId`: no type error at the publish site, and the failure lands later, in a subscriber on a worker. A type that compiles and lies is the worst version of this bug.

The fix is not a narrower name union but a union of *message shapes* for payload-less commands only:

```ts
export type ModulePubSubCommand = { command: 'reload-otel-config' };
```

Shapes rather than names, because that is what lets the binding drop the cast — and the dropped cast *is* the guard. tsc now checks every name in the port against the host's `PubSubCommandMap` at the binding, so adding a payload-bearing name to the port breaks the host build instead of the wire. A name union plus a cast would have re-admitted the same bug one module later.

Verified, not asserted — with `{ command: 'stop-execution' }` added to the union:

```
n8n:typecheck: src/modules/module-ports.ts(20,80): error TS2345:
  Argument of type 'ModulePubSubCommand' is not assignable to parameter of type 'Command'.
```

This narrows the contract that N8N-362 specified as `publishCommand({ command: PubSubEventName })`. The wording was the spec; the union behind it cannot honour it.

**2. `module-ports.ts:28` — the binding returned the whole `Project`. Applied as suggested.**

The port declares `{ id, customTelemetryTags? }` but the binding returned the ORM entity, so the boundary held only in the type system. A module could reach `name`, `type`, `icon`, or a lazily-loaded relation with one cast, and the port would have promised none of it. The binding destructures the two declared fields.

Two tests replace the old identity assertion, which asserted exactly the behaviour this ruling removes: one pins the returned value, one asserts `Object.keys(result)` is exactly `['customTelemetryTags', 'id']`.

**3. `otel-queue-mode-propagation.test.ts:170` — the guard shared one subscriber. Applied, and reproduced first.**

cubic is right that the shared `Subscriber` leaks across tests. The direction is inverted, though: a fast `beforeEach` is safe, because the next publish re-arms the same trailing timer and the two deliveries coalesce. The window opens when `beforeEach` runs longer than the 300 ms debounce.

Reproduced before the fix, with a 350 ms delay at the end of `beforeEach`:

```
 x reaches a worker, which reloads its otel configuration
AssertionError: expected "restart" to be called 2 times, but got 1 times
```

The stale delivery satisfies the delivery poll before the test's own message arrives, so the poll returns early and the assertion reads one call. The same injected delay passes 4 of 4 after the fix.

The worker is built for each test now. `shutdown()` in `afterEach` cancels the armed timer, and the fake client leaves the bus when it disconnects. A fourth test asserts that a cancelled timer delivers nothing.

**4. `otel-queue-mode-propagation.test.ts:158` — the guard never ran `PubSubRegistry`. Applied as suggested.**

The test read `PubSubMetadata` and called `workerEventBus.on(...)` by hand, so it asserted the registration but never the code that consumes it. A real `PubSubRegistry`, built with the worker's instance settings and event bus, registers the handler now, and the counter only observes the delivery. The metadata assertions stay, so a missing decorator names itself instead of showing up as no delivery.

Rulings are recorded here and not on GitHub, per the workspace protocol.

## Failure modes

- **A port resolves before it is bound.** `@n8n/di` returns `undefined` for an unregistered token when it is resolved as a dependency, so this would surface as a `TypeError` at the first call, not at boot. Defused by binding at the single process entry (`CommandRegistry.execute()`), ahead of `loadModules()`, and by `bindModulePorts()` in the integration test-server `beforeAll` and in `initOtelTestEnvironment()`, which mirrors that order. `module-ports.test.ts` asserts all three tokens resolve.
- **A bound port doing work at bootstrap.** Binding eagerly (`Container.set(port, Container.get(Publisher))`) would open a Redis publisher client and build the repository graph in every CLI command, including `export:workflow`, and would make the bind order-dependent on `dbConnection.init()`. Each binding therefore resolves its service on call. `module-ports.test.ts` asserts `bindModulePorts()` calls `Container.get` zero times.
- **A module publishes a command the host cannot honour.** Was possible: the port's union admitted payload-bearing names and the binding cast them. Now a compile error at the binding, in the host build. See ruling 1.
- **Recovery:** revert. The three commits squash into one, so the ports, the guard test and the rulings revert together. Nothing else consumes the ports yet.

## Telemetry

No new failure path, so no new instrumentation. The one behavior-visible surface is the otel resource attribute `service.version`, which now reads `InstanceVersion.version` instead of the `N8N_VERSION` constant — the same value from the same file.

## Acceptance evidence — the grep in plan §8

```
$ cd packages/cli/src/modules
$ grep -rn "from '@/" otel --include='*.ts' | grep -v __tests__ | sed "s/.*from '//;s/'.*//" | sort | uniq -c | sort -rn
$ grep -rn "from '\.\./\.\./" otel --include='*.ts' | grep -v __tests__
```

**Before**

```
   1 @/scaling/pubsub/publisher.service
   1 @/constants
(count: 2)
--- relative escapes out of the module ---
otel/otel-lifecycle-handler.ts:18:import { OwnershipService } from '../../services/ownership.service';
(count: 1)
```

**After**

```
(count: 0)
--- relative escapes out of the module ---
(count: 0)
```

Three seams → zero. `otel/__tests__/` still imports `@/workflow-runner` and `@/wait-tracker`: that is the cli↔module wiring test, which stays in cli per plan §5.

## How to test

```bash
pnpm turbo typecheck --filter=n8n --filter=@n8n/backend-common

cd packages/cli
# unit
N8N_LOG_LEVEL=silent DB_TYPE=sqlite npx vitest run src/modules/otel src/modules/__tests__
# integration
N8N_LOG_LEVEL=silent DB_TYPE=sqlite npx vitest run --config vitest.config.integration.ts \
  test/integration/modules/otel-queue-mode-propagation.test.ts \
  src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts \
  test/integration/public-api/otel-settings.test.ts
```

Results on this branch: typecheck green; **213 unit tests pass** (9 otel files + `module-ports`, `main-only-modules`); **46 integration tests pass**, including the folded queue-mode guard. eslint, prettier and biome clean on every touched file.

The queue-mode propagation that earlier revisions left as a manual pre-merge check is now covered by the folded test, so nothing here needs checking by hand.

## Related Linear tickets, Github issues, and Community forum posts

To be added

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Guide updates land in PR-3 of the plan. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



