### PR TITLE
test(editor): Cover the two unasserted modal open paths in Playwright (no-changelog)

### DIFF
--- a/packages/testing/playwright/config/intercepts.ts
+++ b/packages/testing/playwright/config/intercepts.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Route } from '@playwright/test';
+import type { APIResponse, BrowserContext, Route } from '@playwright/test';
 import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 
@@ -27,12 +27,26 @@ export function getContextModuleSettings(context: BrowserContext) {
 	return contextModuleSettings.get(context);
 }
 
+/**
+ * Forwards an error response unchanged. The merge below reads `data` off the
+ * body, which an error response does not carry, so rewriting it would drop the
+ * fields the app reads instead — a 401 would lose `mfaRequired` and look like an
+ * expired session.
+ */
+async function passThrough(route: Route, response: APIResponse) {
+	await route.fulfill({ response });
+}
+
 export async function setupDefaultInterceptors(target: BrowserContext) {
 	// Global /rest/settings intercept - always active like Cypress
 	// TODO: Remove this as a global and move it per test
 	await target.route('**/rest/settings', async (route: Route) => {
 		try {
 			const originalResponse = await route.fetch();
+			if (!originalResponse.ok()) {
+				await passThrough(route, originalResponse);
+				return;
+			}
 			const originalJson = await originalResponse.json();
 
 			// Get settings stored for this specific context
@@ -63,6 +77,10 @@ export async function setupDefaultInterceptors(target: BrowserContext) {
 	await target.route('**/rest/module-settings', async (route: Route) => {
 		try {
 			const originalResponse = await route.fetch();
+			if (!originalResponse.ok()) {
+				await passThrough(route, originalResponse);
+				return;
+			}
 			const originalJson = await originalResponse.json();
 
 			const testModuleSettings = getContextModuleSettings(target);

--- a/packages/testing/playwright/helpers/NavigationHelper.ts
+++ b/packages/testing/playwright/helpers/NavigationHelper.ts
@@ -99,13 +99,22 @@ export class NavigationHelper {
 	 * - New workflow: /workflow/new
 	 * - Existing workflow: /workflow/{workflowId}
 	 * - New workflow in a project: /workflow/new?projectId={projectId}
+	 * - Deep link into the editor: /workflow/{workflowId}?settings=1
 	 */
-	async toWorkflow(workflowId: string = 'new', options?: { projectId?: string }): Promise<void> {
-		let url = `/workflow/${workflowId}`;
+	async toWorkflow(
+		workflowId: string = 'new',
+		options?: { projectId?: string; query?: Record<string, string> },
+	): Promise<void> {
+		const params = new URLSearchParams();
 		if (options?.projectId) {
-			url += `?projectId=${options.projectId}`;
+			params.set('projectId', options.projectId);
 		}
-		await this.page.goto(url);
+		for (const [key, value] of Object.entries(options?.query ?? {})) {
+			params.set(key, value);
+		}
+
+		const search = params.toString();
+		await this.page.goto(`/workflow/${workflowId}${search ? `?${search}` : ''}`);
 	}
 
 	/**

--- a/packages/testing/playwright/pages/SecuritySettingsPage.ts
+++ b/packages/testing/playwright/pages/SecuritySettingsPage.ts
@@ -1,4 +1,5 @@
 import type { Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { BasePage } from './BasePage';
 
@@ -23,6 +24,10 @@ export class SecuritySettingsPage extends BasePage {
 		return this.page.getByTestId('enable-redaction-enforcement');
 	}
 
+	getEnforceMfaToggle(): Locator {
+		return this.page.getByTestId('enable-force-mfa');
+	}
+
 	getEnforcementScopeSelect(): Locator {
 		return this.page.getByTestId('redaction-enforcement-scope-select');
 	}
@@ -38,6 +43,21 @@ export class SecuritySettingsPage extends BasePage {
 	async enableEnforcement(): Promise<void> {
 		await this.getEnforcementToggle().click();
 		await this.getConfirmDialog().getByRole('button', { name: 'Enable' }).click();
+	}
+
+	/**
+	 * Turns instance-wide MFA enforcement on. The endpoint rejects a session
+	 * that did not authenticate with MFA, so sign in with a code first. Waits
+	 * for the write instead of the toast, so the caller can act on the new
+	 * instance state immediately.
+	 */
+	async enforceMfa(): Promise<void> {
+		const [response] = await Promise.all([
+			this.waitForRestResponse('/rest/mfa/enforce-mfa', 'POST'),
+			this.getEnforceMfaToggle().click(),
+		]);
+
+		expect(response.ok(), await response.text()).toBe(true);
 	}
 
 	async selectScope(scope: RedactionScope): Promise<void> {

--- a/packages/testing/playwright/pages/SettingsPersonalPage.ts
+++ b/packages/testing/playwright/pages/SettingsPersonalPage.ts
@@ -73,6 +73,22 @@ export class SettingsPersonalPage extends BasePage {
 		await this.saveSettings();
 	}
 
+	getPersonalSettingsPanel(): Locator {
+		return this.page.getByTestId('personal-settings-container');
+	}
+
+	getChangePasswordLink(): Locator {
+		return this.page.getByTestId('change-password-link');
+	}
+
+	getChangePasswordModal(): Locator {
+		return this.page.getByTestId('changePassword-modal');
+	}
+
+	async clickChangePassword(): Promise<void> {
+		await this.getChangePasswordLink().click();
+	}
+
 	getEnableMfaButton(): Locator {
 		return this.page.getByTestId('enable-mfa-button');
 	}

--- a/packages/testing/playwright/tests/e2e/settings/personal/two-factor-authentication.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/personal/two-factor-authentication.spec.ts
@@ -1,6 +1,9 @@
 import { authenticator } from 'otplib';
 
-import { INSTANCE_OWNER_CREDENTIALS } from '../../../../config/test-users';
+import {
+	INSTANCE_MEMBER_CREDENTIALS,
+	INSTANCE_OWNER_CREDENTIALS,
+} from '../../../../config/test-users';
 import { test, expect } from '../../../../fixtures/base';
 
 test.use({ capability: { env: { TEST_ISOLATION: 'two-factor-auth' } } });
@@ -107,6 +110,54 @@ test.describe(
 			await n8n.settingsPersonal.fillMfaCodeAndSave(RECOVERY_CODE);
 
 			await expect(n8n.settingsPersonal.getEnableMfaButton()).toBeVisible();
+		});
+
+		/**
+		 * A user without MFA on an enforced instance is redirected to Personal
+		 * Settings, and `initializeAuthenticatedFeatures` throws `MfaRequiredError`
+		 * on the way there. Post-login modal registration therefore never runs, so
+		 * every modal this page offers has to be registered eagerly, pre-mount.
+		 * Nothing else exercises that path.
+		 *
+		 * Runs last in this serial file: it turns MFA enforcement on for the whole
+		 * instance, and the owner session it needs cannot be reused by the tests
+		 * above.
+		 */
+		test('Should open the Personal Settings modals on the MFA-enforced landing page', async ({
+			n8n,
+			api,
+		}) => {
+			await api.enableFeature('mfaEnforcement');
+
+			try {
+				// The enforce endpoint refuses a session that did not use MFA, so the
+				// owner enrols and signs back in with a code first.
+				await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+				await n8n.sideBar.signOutFromWorkflows();
+				await n8n.mfaComposer.loginWithMfaCode(email, password, mfaSecret!);
+
+				await n8n.securitySettings.goto();
+				await n8n.securitySettings.enforceMfa();
+
+				const memberN8n = await n8n.start.withUser(INSTANCE_MEMBER_CREDENTIALS[0]);
+				await memberN8n.navigate.toHome();
+
+				await expect(memberN8n.page).toHaveURL(/\/settings\/personal/);
+				await expect(memberN8n.settingsPersonal.getPersonalSettingsPanel()).toBeVisible();
+
+				await memberN8n.settingsPersonal.clickChangePassword();
+				await expect(memberN8n.settingsPersonal.getChangePasswordModal()).toBeVisible();
+				await memberN8n.page.keyboard.press('Escape');
+				await expect(memberN8n.settingsPersonal.getChangePasswordModal()).toBeHidden();
+
+				await memberN8n.settingsPersonal.clickEnableMfa();
+				await expect(memberN8n.mfaSetupModal.container).toBeVisible();
+			} finally {
+				// Leave the instance unenforced. Dropping the license is the one lever
+				// that needs no MFA-authenticated session, so it works after a failure
+				// part-way through the flow above.
+				await api.disableFeature('mfaEnforcement');
+			}
 		});
 	},
 );

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/settings-deep-link.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/settings-deep-link.spec.ts
@@ -1,0 +1,35 @@
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../../../fixtures/base';
+
+/**
+ * `?settings=1` on an editor route opens the workflow settings modal from
+ * `NodeView`'s mount hook, then strips the query. `WORKFLOW_SETTINGS_MODAL_KEY`
+ * has the widest consumer set of the keyed modals, so a registration change
+ * that breaks this entry point breaks it silently: no other test observes the
+ * deep link.
+ */
+test.describe(
+	'Workflow settings deep link',
+	{
+		annotation: [{ type: 'owner', description: 'Adore' }],
+	},
+	() => {
+		test('opens the workflow settings modal from the ?settings=1 query', async ({ n8n, api }) => {
+			const workflow = await api.workflows.createWorkflow({
+				name: `Settings deep link ${nanoid(8)}`,
+				nodes: [],
+				connections: {},
+			});
+
+			await n8n.navigate.toWorkflow(workflow.id, { query: { settings: '1' } });
+
+			await expect(n8n.workflowSettingsModal.getModal()).toBeVisible();
+			await expect(n8n.workflowSettingsModal.getErrorWorkflowField()).toBeVisible();
+
+			// The mount hook replaces the route once it has consumed the query, so a
+			// reload does not reopen the modal.
+			await expect(n8n.page).toHaveURL(`/workflow/${workflow.id}`);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Two modal open paths had no test. Later stages of the modal-key sweep move both keys, so a break would be silent.

**1. The MFA-enforced landing page** — added to `two-factor-authentication.spec.ts`.

A user without MFA on an MFA-enforced instance is redirected to Personal Settings. `initializeAuthenticatedFeatures` throws `MfaRequiredError` on the way there (`/rest/projects/*` returns 401 `mfaRequired`), so post-login modal registration never runs. Every modal that page offers therefore depends on the eager, pre-mount registration in `app/modals.manifest.ts`. The spec asserts the landing, then opens the change-password modal and the MFA-setup modal.

**2. `?settings=1` opens the workflow settings modal** — new spec `settings-deep-link.spec.ts`.

`WORKFLOW_SETTINGS_MODAL_KEY` has the widest consumer set in the sweep (six feature directories). `sourceControl=push|pull` and `?diff=` are asserted elsewhere; this deep link was not asserted anywhere.

**Harness fix.** The global `/rest/settings` and `/rest/module-settings` interceptors rewrote every response body, including error bodies. `originalJson.data` is absent on an error response, so a 401 was refulfilled as `{}` — dropping the `mfaRequired` flag. The app then read an expired session and signed the user out, which made path 1 unobservable in Playwright. Error responses now pass through unchanged.

Supporting changes: `SecuritySettingsPage.enforceMfa()`, three locators on `SettingsPersonalPage`, and a `query` option on `NavigationHelper.toWorkflow()`.

No product code changed.

## How to test

```bash
pnpm --filter=n8n-playwright test:container:sqlite tests/e2e/settings/personal/two-factor-authentication.spec.ts
pnpm --filter=n8n-playwright test:local tests/e2e/workflows/editor/workflow-actions/settings-deep-link.spec.ts
```

Verified locally against a built instance on `localhost:5680`: the full 8-test MFA file passes, and the deep-link spec passes.

**Negative controls** (each reverted afterwards):

| Control | Result |
| --- | --- |
| Remove `<ModalRoot :name="WORKFLOW_SETTINGS_MODAL_KEY">` from `Modals.vue` | deep-link spec fails: `getByTestId('workflow-settings-dialog')` not found |
| Move `registerEagerModals()` from `main.ts` (pre-mount) to `initializeAuthenticatedFeatures` (post-login) | the 7 pre-existing MFA tests stay green; only the new spec fails, on `getByTestId('changePassword-modal')` |

The second control is the discriminating one: it leaves the normal MFA flows working and breaks only the enforced landing, which shows the new spec is the only observer of that path.

`pnpm janitor` clean, lint clean, typecheck clean, 82 harness unit tests pass.

## Related Linear tickets, Github issues, and Community forum posts

Parent sweep: [CAT-3973](https://linear.app/n8n/issue/CAT-3973/migrate-the-remaining-55-feature-modal-keys-off-uistore)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

