### PR TITLE
test(core): Cover reload-otel-config propagation in queue mode (no-changelog)

### DIFF
--- a/packages/cli/test/integration/modules/otel-queue-mode-propagation.test.ts
+++ b/packages/cli/test/integration/modules/otel-queue-mode-propagation.test.ts
@@ -1,0 +1,220 @@
+import { Logger } from '@n8n/backend-common';
+import { testDb } from '@n8n/backend-test-utils';
+import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
+import { SettingsRepository, type User } from '@n8n/db';
+import { PubSubMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { Redis as SingleNodeClient } from 'ioredis';
+import type { InstanceSettings } from 'n8n-core';
+import { jsonParse } from 'n8n-workflow';
+import { vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { OtelLifecycleHandler } from '@/modules/otel/otel-lifecycle-handler';
+import { OTEL_SETTINGS_KEY, OtelSettingsService } from '@/modules/otel/otel-settings.service';
+import { OtelService } from '@/modules/otel/otel.service';
+import { COMMAND_PUBSUB_CHANNEL } from '@/scaling/constants';
+import { Publisher } from '@/scaling/pubsub/publisher.service';
+import { PubSubEventBus } from '@/scaling/pubsub/pubsub.eventbus';
+import { Subscriber } from '@/scaling/pubsub/subscriber.service';
+import type { RedisClientService } from '@/services/redis-client.service';
+import { createOwner } from '@test-integration/db/users';
+import { setupTestServer } from '@test-integration/utils';
+
+/**
+ * An in-memory stand-in for the Redis pubsub transport. Every message crosses it
+ * as the JSON string the real client would carry, so the publish payload and the
+ * subscriber's own parsing, sender filter and debounce all run for real.
+ */
+const bus = {
+	clients: [] as Array<{
+		channels: Set<string>;
+		listeners: Array<(channel: string, message: string) => void>;
+	}>,
+	published: [] as Array<{ channel: string; message: string }>,
+};
+
+function createFakeRedisClient() {
+	const state = {
+		channels: new Set<string>(),
+		listeners: [] as Array<(channel: string, message: string) => void>,
+	};
+	bus.clients.push(state);
+
+	return mock<SingleNodeClient>({
+		publish: ((channel: string, message: string) => {
+			bus.published.push({ channel, message });
+			for (const client of bus.clients) {
+				if (!client.channels.has(channel)) continue;
+				for (const listener of client.listeners) listener(channel, message);
+			}
+			return 1;
+		}) as never,
+		subscribe: (async (channel: string, onSubscribed?: (error: unknown) => void) => {
+			await Promise.resolve();
+			state.channels.add(channel);
+			onSubscribed?.(null);
+			return 1;
+		}) as never,
+		on: ((event: string, listener: (channel: string, message: string) => void) => {
+			if (event === 'message') state.listeners.push(listener);
+			return undefined as never;
+		}) as never,
+		disconnect: (() => {}) as never,
+	});
+}
+
+const REDIS_PREFIX = 'n8n';
+const MAIN_HOST_ID = 'main-testhost';
+const WORKER_HOST_ID = 'worker-testhost';
+const commandChannel = `${REDIS_PREFIX}:${COMMAND_PUBSUB_CHANNEL}`;
+
+const validSettings = {
+	enabled: false,
+	exporterProtocol: 'http/protobuf',
+	exporterEndpoint: 'http://collector.example.com:4318',
+	exporterTracingPath: '/v1/traces',
+	exporterServiceName: 'n8n-prod',
+	exporterHeaders: 'authorization=Bearer my-token',
+	tracesSampleRate: 0.5,
+	startupConnectivityTimeoutMs: 3_000,
+	includeNodeSpans: false,
+	injectOutbound: false,
+	productionExecutionsOnly: false,
+};
+
+describe('reload-otel-config propagation in queue mode', () => {
+	let owner: User;
+	let workerEventBus: PubSubEventBus;
+	let workerSubscriber: Subscriber;
+	/** Calls of the worker-side `reload-otel-config` handler. */
+	let workerHandlerCalls = 0;
+
+	// Declared before `setupTestServer` on purpose: this hook must run before the
+	// test server constructs the otel controller, so that on any revision the
+	// controller sees this queue-mode `Publisher` — whether it captures the
+	// publisher at construction or resolves it per call.
+	beforeAll(() => {
+		const queueConfig = Container.get(ExecutionsConfig);
+		queueConfig.mode = 'queue';
+		Container.get(GlobalConfig).redis.prefix = REDIS_PREFIX;
+
+		const redisClientService = mock<RedisClientService>({
+			createClient: () => createFakeRedisClient(),
+		});
+
+		// The main instance's publisher: the real class, on the fake transport.
+		Container.set(
+			Publisher,
+			new Publisher(
+				Container.get(Logger),
+				redisClientService,
+				mock<InstanceSettings>({ hostId: MAIN_HOST_ID, instanceType: 'main' }),
+				queueConfig,
+				Container.get(GlobalConfig),
+			),
+		);
+
+		// A second instance on the same channel, with a worker's host id and type.
+		// Its own event bus keeps its deliveries distinct from the main's.
+		workerEventBus = new PubSubEventBus();
+		workerSubscriber = new Subscriber(
+			Container.get(Logger),
+			mock<InstanceSettings>({
+				hostId: WORKER_HOST_ID,
+				instanceType: 'worker',
+				instanceRole: 'unset',
+			}),
+			workerEventBus,
+			redisClientService,
+			queueConfig,
+			Container.get(GlobalConfig),
+		);
+	});
+
+	const testServer = setupTestServer({ endpointGroups: ['otel'] });
+
+	beforeAll(async () => {
+		await testDb.init();
+		await workerSubscriber.subscribe(commandChannel);
+
+		// Register the worker's `reload-otel-config` handler the way `PubSubRegistry`
+		// does: from the decorator metadata, resolving the handler class from the
+		// container. On a worker this is the only path that reaches otel.
+		const handlers = Container.get(PubSubMetadata)
+			.getHandlers()
+			.filter((handler) => handler.eventName === 'reload-otel-config');
+
+		expect(handlers).toHaveLength(1);
+		const [{ eventHandlerClass, methodName, filter }] = handlers;
+		expect(eventHandlerClass).toBe(OtelLifecycleHandler);
+		// No instance-type filter, so the handler registers on a worker too.
+		expect(filter?.instanceType).toBeUndefined();
+
+		const handlerInstance = Container.get(eventHandlerClass) as unknown as Record<
+			string,
+			() => Promise<void>
+		>;
+		workerEventBus.on('reload-otel-config', async () => {
+			workerHandlerCalls++;
+			await handlerInstance[methodName]();
+		});
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+		await Container.get(SettingsRepository).delete({ key: OTEL_SETTINGS_KEY });
+		await Container.get(OtelSettingsService).loadSettings();
+		owner = await createOwner();
+		bus.published.length = 0;
+		workerHandlerCalls = 0;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterAll(() => {
+		workerSubscriber.shutdown();
+	});
+
+	it('publishes reload-otel-config on the command channel with the expected payload', async () => {
+		const response = await testServer.authAgentFor(owner).put('/otel/settings').send(validSettings);
+
+		expect(response.status).toBe(200);
+
+		await vi.waitFor(() => expect(bus.published).toHaveLength(1));
+
+		expect(bus.published[0].channel).toBe(commandChannel);
+		expect(jsonParse(bus.published[0].message)).toEqual({
+			command: 'reload-otel-config',
+			senderId: MAIN_HOST_ID,
+			selfSend: false,
+			debounce: true,
+		});
+	});
+
+	it('reaches a worker, which reloads its otel configuration', async () => {
+		const restart = vi.spyOn(Container.get(OtelService), 'restart').mockResolvedValue();
+
+		const response = await testServer.authAgentFor(owner).put('/otel/settings').send(validSettings);
+
+		expect(response.status).toBe(200);
+
+		// 300 ms subscriber debounce, so poll rather than assert once.
+		await vi.waitFor(() => expect(workerHandlerCalls).toBe(1), { timeout: 5_000 });
+
+		// Once for the main's own local reload, once for the worker's.
+		expect(restart).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not publish when the write is rejected', async () => {
+		const response = await testServer
+			.authAgentFor(owner)
+			.put('/otel/settings')
+			.send({ ...validSettings, exporterEndpoint: 'not-a-url' });
+
+		expect(response.status).toBe(400);
+		expect(bus.published).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

QA gap closure for #38128. `PUT /rest/otel/settings` publishes `reload-otel-config` so the other instances of a scaling-mode deployment reload their otel configuration. No automated test covered that path, so #38128 asked for a manual check before merge. This test replaces the manual check.

Base is `agent/valve/60f49fb324d9`, so the diff is the one new test file. Fold it into #38128 or land it after — either works.

**What the test exercises**

- The real internal REST route, through the integration test server (`endpointGroups: ['otel']`).
- The real `Publisher` and the real `Subscriber`, in queue mode, over an in-memory stand-in for the Redis transport. Every message crosses it as the JSON string the real client would carry, so the publish payload, the subscriber's parse, its sender filter and its 300 ms debounce all run for real.
- A second instance that carries a worker host id and instance type, with its own `PubSubEventBus`. Its `reload-otel-config` handler is registered the way `PubSubRegistry` does it — from the `@OnPubSubEvent` decorator metadata, with the handler class resolved from the container.

**The three cases**

| Case | Asserts |
| --- | --- |
| publishes the command | channel `n8n:n8n.commands`, payload `{ command: 'reload-otel-config', senderId: <main>, selfSend: false, debounce: true }` |
| reaches a worker | the worker-side handler runs once, and `OtelService.restart` is called twice — once for the main's local reload, once for the worker's |
| a rejected write | a 400 publishes nothing |

**Behavior match with pre-PR**

The test uses no symbol that #38128 adds, so it runs on either revision. On `agent/valve/60f49fb324d9`: 3 passed. With `git revert --no-commit 0495c76ffe` applied to the same tree: 3 passed. Same payload, same delivery — the refactor changes no behavior on this path.

## How to test

```bash
cd packages/cli
N8N_LOG_LEVEL=silent DB_TYPE=sqlite npx vitest run --config vitest.config.integration.ts \
  test/integration/modules/otel-queue-mode-propagation.test.ts
```

Results on this branch: 3 integration tests pass. The neighbouring otel suites stay green — 212 unit tests (`src/modules/otel`, `src/modules/__tests__`) and 45 integration tests. `tsc --noEmit`, eslint and prettier clean.

## Related Linear tickets, Github issues, and Community forum posts

N8N-362 · parent N8N-354 · follows #38128

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

