### PR TITLE
perf(core): Stop copying user workflows into the Instance AI sandbox

### DIFF
--- a/packages/@n8n/instance-ai/docs/sandboxing.md
+++ b/packages/@n8n/instance-ai/docs/sandboxing.md
@@ -116,7 +116,6 @@ reattached. The setup creates or materializes:
 | `node-types/index.txt` | Searchable node-type catalog |
 | `src/` | Workflow source files |
 | `chunks/` | Reusable source modules |
-| `workflows/` | Existing workflows materialized as WorkflowJSON |
 | `knowledge-base/` | Best-practice, template, and SDK reference material |
 | `.sandbox-initialized` | Setup marker |
 

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -308,7 +308,7 @@ describe('setupSandboxWorkspace', () => {
 		);
 	});
 
-	it('always creates workflows/, src/, and chunks/ even when no workflows exist', async () => {
+	it('always creates src/ and chunks/', async () => {
 		const runInSandbox: RunInSandboxMock =
 			vi.fn<
 				(
@@ -330,16 +330,11 @@ describe('setupSandboxWorkspace', () => {
 			async () => {},
 		);
 
-		// Setup context defaults to an empty workflow list, mirroring a fresh DB.
 		await setupSandboxWorkspace(createFilesystemWorkspace(writeFile, mkdir), createSetupContext());
 
 		const mkdirPaths = mkdir.mock.calls.map(([path]) => path);
 		expect(mkdirPaths).toEqual(
-			expect.arrayContaining([
-				'/home/daytona/workspace/src',
-				'/home/daytona/workspace/chunks',
-				'/home/daytona/workspace/workflows',
-			]),
+			expect.arrayContaining(['/home/daytona/workspace/src', '/home/daytona/workspace/chunks']),
 		);
 	});
 
@@ -420,43 +415,6 @@ describe('setupSandboxWorkspace', () => {
 
 		const writtenPaths = writeFile.mock.calls.map(([path]) => path);
 		expect(writtenPaths.some((p) => p.includes('/knowledge-base/templates/'))).toBe(true);
-	});
-
-	it('rejects setup file paths that escape the workspace root', async () => {
-		const runInSandbox: RunInSandboxMock =
-			vi.fn<
-				(
-					...args: [SandboxWorkspace, string, string?]
-				) => Promise<{ exitCode: number; stdout: string; stderr: string }>
-			>();
-		runInSandbox.mockImplementation(async (_workspace, command) => {
-			await Promise.resolve();
-			if (command.startsWith('cat ')) {
-				return { exitCode: 1, stdout: '', stderr: '' };
-			}
-			return { exitCode: 0, stdout: '/home/daytona\n', stderr: '' };
-		});
-		const readFileViaSandbox: ReadFileViaSandboxMock =
-			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
-		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
-			runInSandbox,
-			readFileViaSandbox,
-		);
-		const writeFile = vi.fn<
-			(...args: [string, string | Buffer, { recursive?: boolean }?]) => Promise<void>
-		>(async () => {});
-		const context = createSetupContext();
-		const workflowService = context.workflowService as unknown as {
-			list: Mock<(...args: [{ limit: number }]) => Promise<{ workflows: Array<{ id: string }> }>>;
-			get: Mock<(...args: [string]) => Promise<Record<string, unknown>>>;
-		};
-		workflowService.list.mockResolvedValue({ workflows: [{ id: '../escape' }] });
-		workflowService.get.mockResolvedValue({ id: '../escape' });
-
-		await expect(
-			setupSandboxWorkspace(createFilesystemWorkspace(writeFile), context),
-		).rejects.toThrow('Sandbox workspace setup failed during write-workspace-files');
 	});
 
 	it('does not write the initialized marker when npm install fails', async () => {

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -12,7 +12,6 @@
  *     package.json                    # @n8n/workflow-sdk dependency
  *     tsconfig.json                   # strict, noEmit, skipLibCheck
  *     node_modules/@n8n/workflow-sdk/ # full SDK with .d.ts types
- *     workflows/                      # existing n8n workflows as JSON
  *     node-types/
  *       index.txt                     # searchable catalog: nodeType | displayName | description | version
  *     src/
@@ -307,7 +306,7 @@ export function formatNodeCatalogLine(node: SearchableNodeDescription): string {
 }
 
 /** Dirs the agent's `list_files` may probe; some providers 404 on missing dirs. */
-const ALWAYS_PRESENT_DIRS: readonly string[] = ['src', 'chunks', 'workflows'];
+const ALWAYS_PRESENT_DIRS: readonly string[] = ['src', 'chunks'];
 
 async function writeWorkspaceFiles(
 	workspace: SandboxWorkspace,
@@ -463,24 +462,6 @@ export async function setupSandboxWorkspace(
 	);
 	const catalogLines = nodeTypes.map(formatNodeCatalogLine);
 	files.set('node-types/index.txt', catalogLines.join('\n'));
-
-	// Existing workflows as JSON (fetch in parallel)
-	try {
-		const { workflows } = await context.workflowService.list({ limit: 100 });
-		const results = await Promise.allSettled(
-			workflows.map(async (summary) => {
-				const detail = await context.workflowService.get(summary.id);
-				return { id: summary.id, json: JSON.stringify(detail, null, 2) };
-			}),
-		);
-		for (const r of results) {
-			if (r.status === 'fulfilled') {
-				files.set(`workflows/${r.value.id}.json`, r.value.json);
-			}
-		}
-	} catch {
-		// Workflow listing failed — continue without syncing
-	}
 
 	// ── Write workspace files ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Sandbox workspace setup fetched up to 100 workflows from the thread's bound project and wrote each one as `workflows/<id>.json` into the sandbox. Almost nothing reads them, because almost nothing can find them. Workflows can also be pretty huge.

The directory is undiscoverable by lack of design, and its existence seems to be for legacy reasons (it's from the earliest AIA merge):

- Not named in the system prompt. `getSandboxWorkspaceSection` describes the workspace as scratch space and lists no paths.
- Not named in any of the 13 `SKILL.md` files, or in any tool description. `node-types/index.txt` *is* named explicitly in `workflow-builder/SKILL.md`, which is why that one gets used.
- `workspace_list_files` is not in `CORE_WORKSPACE_TOOL_NAMES`, so the lazy runtime workspace filters it out. The agent has no directory-listing tool, and only finds the dump by `ls`-ing the workspace root on its own initiative.

The documented route for reading an existing workflow is `workflows(action="get-as-code")`, which writes SDK source into `src/workflows/` and binds it.

### Measured usage

I checked a sample of threads and the usage was

| | threads |
| --- | ---: |
| referenced a seeded `workflows/<id>.json` | 0.08% |
| touched the root `workflows/` dir at all | 0.16% |

Nothing guides the agent into finding these files, but if it happens to see them it tends to rely on reading them - which can be problematic as they are a snapshot from when the thread started.

### What removing it buys

For each cold sandbox:

- up to 100 `workflowService.get()` calls on the host
- up to 100 filesystem round-trips to the sandbox, at roughly 1-2s of latency for each round-trip through the proxy

It also fixes two defects in the current block rather than carrying them forward:

1. `limit: 100` has no ordering guarantee, so a user with more than 100 workflows gets an arbitrary subset, and the agent has no way to know which are missing.
2. `workflowService.get()` returns full node parameters, so the dump carries whatever a user hardcoded into a parameter instead of a credential — for up to 100 workflows, regardless of thread relevance.

`'workflows'` also leaves `ALWAYS_PRESENT_DIRS`, which now matches the snapshot's own `SNAPSHOT_WORKSPACE_LAYOUT_DIRS`. The two had drifted apart, and the mismatch meant a swallowed fetch error still left an empty `workflows/` for an agent to waste a turn on.

### Test removed

`rejects setup file paths that escape the workspace root` is deleted. The workflow id was the only caller-supplied path segment reaching `writeWorkspaceFiles` from setup; every remaining key is a constant. `workspace-paths.test.ts` still covers the traversal guard directly, including the after-root-strip case.

## How to test

1. Start an instance with the Daytona sandbox on and a project holding several workflows.
2. Open a new AI Assistant thread and ask for any workflow build.
3. In the sandbox, confirm `/home/daytona/workspace/workflows/` no longer exists, and that `src/`, `chunks/`, `node-types/index.txt` and `knowledge-base/` are unchanged.
4. Confirm a build against an existing workflow still works through `workflows(action="get-as-code")`.

With `N8N_LOG_LEVEL=debug`, `write-workspace-files` should also get measurably cheaper on a cold sandbox.

## Related Linear tickets, Github issues, and Community forum posts

Related to https://linear.app/n8n/issue/INS-1298 investigation. Found while investigating sandbox workspace setup latency.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- packages/@n8n/instance-ai/docs/sandboxing.md -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)