### PR TITLE
perf(core): Install sandbox dependencies from the npm cache again

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -270,6 +270,13 @@ describe('PACKAGE_JSON', () => {
 		expect(packageJson.dependencies.tsx).toBeDefined();
 	});
 });
+/** npm install commands issued, ignoring how cwd/options were passed. */
+function installCommandsFrom(runInSandbox: RunInSandboxMock): string[] {
+	return runInSandbox.mock.calls
+		.map(([, command]) => command)
+		.filter((command) => command.startsWith('npm install'));
+}
+
 describe('setupSandboxWorkspace', () => {
 	afterEach(() => {
 		vi.doUnmock('../sandbox-fs');
@@ -384,11 +391,7 @@ describe('setupSandboxWorkspace', () => {
 		);
 
 		expect(initialized).toBe(false);
-		expect(runInSandbox).not.toHaveBeenCalledWith(
-			expect.anything(),
-			'npm install --ignore-scripts --no-audit --no-fund --prefer-online',
-			'/sandbox',
-		);
+		expect(installCommandsFrom(runInSandbox)).toEqual([]);
 		const writtenPaths = writeFile.mock.calls.map(([path]) => path);
 		expect(writtenPaths.some((p) => p.includes('/knowledge-base/templates/'))).toBe(true);
 	});
@@ -486,6 +489,89 @@ describe('setupSandboxWorkspace', () => {
 			'/home/daytona/workspace/.sandbox-initialized',
 			expect.any(String),
 			{ recursive: true },
+		]);
+	});
+
+	it('retries npm install with fresh registry metadata when the cached install fails', async () => {
+		const runInSandbox: RunInSandboxMock =
+			vi.fn<
+				(
+					...args: [SandboxWorkspace, string, string?]
+				) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+			>();
+		// Only the cache-first attempt fails, the way a packument too old to resolve the
+		// pinned SDK version does.
+		runInSandbox.mockImplementation(async (_workspace, command) => {
+			await Promise.resolve();
+			if (command.startsWith('npm install') && command.includes('--prefer-offline')) {
+				return { exitCode: 1, stdout: '', stderr: 'npm error code ETARGET' };
+			}
+			return { exitCode: 0, stdout: '', stderr: '' };
+		});
+		const readFileViaSandbox: ReadFileViaSandboxMock =
+			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
+		readFileViaSandbox.mockResolvedValue(null);
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
+			runInSandbox,
+			readFileViaSandbox,
+		);
+		const writeFile = vi.fn<
+			(...args: [string, string | Buffer, { recursive?: boolean }?]) => Promise<void>
+		>(async () => {});
+
+		const initialized = await setupSandboxWorkspace(
+			createFilesystemWorkspace(writeFile),
+			createSetupContext(),
+		);
+
+		expect(initialized).toBe(true);
+		expect(installCommandsFrom(runInSandbox)).toEqual([
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-offline',
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-online',
+		]);
+		expect(writeFile.mock.calls).toContainEqual([
+			'/home/daytona/workspace/.sandbox-initialized',
+			expect.any(String),
+			{ recursive: true },
+		]);
+	});
+
+	it('does not retry the install when the step budget is already spent', async () => {
+		let clock = 0;
+		vi.spyOn(Date, 'now').mockImplementation(() => clock);
+		const runInSandbox: RunInSandboxMock =
+			vi.fn<
+				(
+					...args: [SandboxWorkspace, string, string?]
+				) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+			>();
+		// The sandbox terminates a command at its own timeout and reports that as a
+		// non-zero exit code, so a timed-out attempt looks the same as a failed one.
+		runInSandbox.mockImplementation(async (_workspace, command) => {
+			await Promise.resolve();
+			if (command.startsWith('npm install')) {
+				clock += 180_000;
+				return { exitCode: 124, stdout: '', stderr: 'command timed out' };
+			}
+			return { exitCode: 0, stdout: '', stderr: '' };
+		});
+		const readFileViaSandbox: ReadFileViaSandboxMock =
+			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
+		readFileViaSandbox.mockResolvedValue(null);
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
+			runInSandbox,
+			readFileViaSandbox,
+		);
+		const writeFile = vi.fn<
+			(...args: [string, string | Buffer, { recursive?: boolean }?]) => Promise<void>
+		>(async () => {});
+
+		await expect(
+			setupSandboxWorkspace(createFilesystemWorkspace(writeFile), createSetupContext()),
+		).rejects.toThrow('Sandbox npm install failed');
+
+		expect(installCommandsFrom(runInSandbox)).toEqual([
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-offline',
 		]);
 	});
 

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
@@ -197,7 +197,7 @@ describe('SnapshotManager.ensureImage', () => {
 			'mkdir -p /home/daytona/workspace/src /home/daytona/workspace/chunks /home/daytona/workspace/node-types',
 		);
 		expect(image.dockerfile).toContain(
-			'npm install --ignore-scripts --no-audit --no-fund --prefer-online',
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-offline',
 		);
 
 		const stagingDir = image.contextList[0]?.sourcePath;

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -99,10 +99,30 @@ function resolveHostDepVersion(name: string): string {
  * `--no-audit` matters most: npm otherwise posts the whole tree to the registry's
  * advisories endpoint and blocks until it answers or its 300s fetch timeout expires,
  * so a slow registry turns a 10s install into minutes. Nobody reads the audit or
- * funding output in a sandbox. Refresh registry metadata so a cached sandbox
- * can install a newly published SDK version.
+ * funding output in a sandbox. `--prefer-offline` lets a warm npm cache skip
+ * freshness checks against the registry.
  */
-export const NPM_INSTALL_FLAGS = '--ignore-scripts --no-audit --no-fund --prefer-online';
+export const NPM_INSTALL_FLAGS = '--ignore-scripts --no-audit --no-fund --prefer-offline';
+
+/**
+ * Same flags, but revalidate registry metadata. The snapshot bake populates the
+ * sandbox's npm cache, so a sandbox created from an older snapshot holds a packument
+ * that predates a newly published SDK version. `--prefer-offline` trusts that stale
+ * packument and fails to resolve the pinned version. Used only to retry a failed
+ * install, never as the first attempt.
+ */
+export const NPM_INSTALL_FLAGS_REFRESH_METADATA =
+	'--ignore-scripts --no-audit --no-fund --prefer-online';
+
+/**
+ * Budget for the whole install step, both attempts together. A healthy install runs
+ * in under a second and the sandbox gateway already cuts a single command at 30s, so
+ * this is generous. It exists for the fault case: the sandbox terminates a command at
+ * its own timeout and reports that as a non-zero exit code, so without a shared
+ * deadline a timed-out first attempt would hand a second, equally long attempt to the
+ * retry below.
+ */
+const INSTALL_STEP_BUDGET_MS = 120_000;
 
 /**
  * Versions pinned from the host's installed packages. Pinning is load-bearing
@@ -492,7 +512,26 @@ export async function setupSandboxWorkspace(
 
 	// npm install (must run after package.json is in place)
 	await setupStep('install-dependencies', async () => {
-		const npmResult = await runInSandbox(workspace, `npm install ${NPM_INSTALL_FLAGS}`, root);
+		// One deadline covers both attempts. The signal stops us waiting; it does not kill
+		// the remote command, which the sandbox collects at its own timeout.
+		const deadline = Date.now() + INSTALL_STEP_BUDGET_MS;
+		const install = async (flags: string) =>
+			await runInSandbox(workspace, `npm install ${flags}`, {
+				cwd: root,
+				abortSignal: AbortSignal.timeout(Math.max(1, deadline - Date.now())),
+			});
+
+		let npmResult = await install(NPM_INSTALL_FLAGS);
+		if (npmResult.exitCode !== 0 && Date.now() < deadline) {
+			// The cached packument can be too old to resolve the pinned SDK version. That is
+			// the one failure the cache causes, and refreshing metadata is the only way out,
+			// so retry once with whatever budget is left.
+			context.logger.warn('Sandbox npm install failed against the cache; refreshing metadata', {
+				stderr: npmResult.stderr.slice(0, 500),
+				remainingMs: deadline - Date.now(),
+			});
+			npmResult = await install(NPM_INSTALL_FLAGS_REFRESH_METADATA);
+		}
 		if (npmResult.exitCode !== 0) {
 			throw new Error(`Sandbox npm install failed: ${npmResult.stderr}`);
 		}


### PR DESCRIPTION
## Summary

The runtime `install-dependencies` step runs against a tree the snapshot already baked, and `PACKAGE_JSON` pins every dependency to an exact version, so the step normally has nothing to do. Measured on a cold Daytona sandbox:

```
Sandbox npm install starting   command: npm install --ignore-scripts --no-audit --no-fund --prefer-online
Sandbox npm install finished   summary: "up to date in 333ms"
step: install-dependencies     durationMs: 645
```

`--prefer-online` makes npm revalidate every cached packument against the registry before concluding that. It turns a step that needs no network into one whose duration tracks registry latency.

That matters because the call goes through the sandbox proxy, which aborts an upstream request after 30s of socket inactivity (`SANDBOX_PROXY_UPSTREAM_TIMEOUT_MS`, `proxyTimeout` in `sandbox-proxy.config.ts`) and returns a gateway error to the agent as a tool failure. A step that does no network work cannot reach that limit. We have a production trace where `install-dependencies` died on a Cloudflare 502 after ~31.7s against that 645ms baseline.

So: **cache first, refresh only on failure.**

```ts
let npmResult = await runInSandbox(workspace, `npm install ${NPM_INSTALL_FLAGS}`, root);
if (npmResult.exitCode !== 0) {
    // retry once with --prefer-online
}
```

## Why the retry is needed

[#36740](https://github.com/n8n-io/n8n/pull/36740) flipped this flag to `--prefer-online` deliberately, to fix a real failure:

> Refresh sandbox package metadata before installation. Cached npm metadata can omit a newly published SDK version and stop workflow builds.

and from the author:

> It seems that SDK 0.32.0 did not exist but was published on npm. So it was using a cached list of versions and crashing.

Failing run: https://github.com/n8n-io/n8n/actions/runs/34206622799/job/101999266027

The mechanism is real, and it is self-inflicted: the snapshot bake populates the sandbox's npm cache, so a sandbox created from an older snapshot carries a packument that predates any SDK published since. `--prefer-offline` trusts that packument and fails with `ETARGET`. Most likely on `master`, where the host SDK pin routinely runs ahead of the snapshot built from the last release tag.

Retrying once with `--prefer-online` keeps that path working. The fast path does no registry round-trip, and the stale-cache path recovers on the second attempt instead of failing setup.

Note this only bites at **runtime**, not during the snapshot bake: the bake starts with no packument for `@n8n/workflow-sdk` at all, and `--prefer-offline` still fetches data the cache is *missing* — it only skips freshness checks on what the cache already holds. The bake creates the staleness; the runtime suffers it; the fix belongs at runtime. `snapshot-manager.ts:230` therefore keeps sharing `NPM_INSTALL_FLAGS` unchanged.

Thanks to @cubic-dev-ai for landing on the same conclusion in review.

## Tests

New: `retries npm install with fresh registry metadata when the cached install fails` — the cache-first attempt returns `ETARGET`, the retry succeeds, and setup completes and writes the marker. Verified in both directions:

| | result |
| --- | --- |
| retry removed | ✗ fails — `SandboxWorkspaceSetupError … install-dependencies: Sandbox npm install failed: npm error code ETARGET` |
| retry in place | ✓ passes |

The existing `does not write the initialized marker when npm install fails` now also covers the both-attempts-fail case, since its mock fails every invocation.

Full `src/workspace` suite: 185/185. Typecheck and eslint clean.

## How to test

1. Start an instance with the Daytona sandbox on, against a snapshot whose baked SDK version matches the host pin.
2. With `N8N_LOG_LEVEL=debug`, start a thread and ask for a workflow build.
3. Confirm `install-dependencies` stays sub-second and no `refreshing metadata` warning appears.
4. Stale-cache path: point a host pinning a newly published `@n8n/workflow-sdk` at a snapshot baked before that publish. Confirm the warning appears once and setup still completes.

## Notes

- No behaviour change to `--ignore-scripts`, `--no-audit` or `--no-fund`. `--no-audit` is the flag that actually rescued this step in [#37864](https://github.com/n8n-io/n8n/pull/37864) and is untouched.
- The retry logs a `warn` with the failing stderr (truncated to 500 chars), so a snapshot that has genuinely drifted is visible rather than silently absorbed.

## Related Linear tickets, Github issues, and Community forum posts

Keeps the fix from https://linear.app/n8n/issue/INS-1164 working while removing its cost from the common path. Found while investigating sandbox setup gateway timeouts.

Related to https://linear.app/n8n/issue/INS-1298 investigation

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- no docs surface -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)