### PR TITLE
feat(core): Instrument Instance AI sandbox workspace setup (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -378,12 +378,18 @@ describe('setupSandboxWorkspace', () => {
 			archive: makeBuilderTemplatesTarGz([{ name: 'example-workflow.ts', content: 'export {}' }]),
 			version: 'test-sha',
 		};
+		const context = createSetupContext(bundle);
 		const initialized = await setupSandboxWorkspace(
 			createLocalWorkspace(writeFile, undefined, readFile),
-			createSetupContext(bundle),
+			context,
 		);
 
 		expect(initialized).toBe(false);
+		// The reattach path must still report a duration, or it looks like a hang in logs.
+		expect(context.logger.debug).toHaveBeenCalledWith(
+			'Sandbox workspace setup finished',
+			expect.objectContaining({ initializationRan: false }),
+		);
 		expect(runInSandbox).not.toHaveBeenCalledWith(
 			expect.anything(),
 			'npm install --ignore-scripts --no-audit --no-fund --prefer-online',

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -66,17 +66,42 @@ export class SandboxWorkspaceSetupError extends Error {
 	constructor(
 		readonly step: SandboxWorkspaceSetupStep,
 		readonly originalError: unknown,
+		readonly durationMs?: number,
 	) {
-		super(`Sandbox workspace setup failed during ${step}: ${getErrorMessage(originalError)}`);
+		const elapsed = durationMs === undefined ? '' : ` after ${durationMs}ms`;
+		super(
+			`Sandbox workspace setup failed during ${step}${elapsed}: ${getErrorMessage(originalError)}`,
+		);
 		this.name = 'SandboxWorkspaceSetupError';
 	}
 }
 
-async function setupStep<T>(step: SandboxWorkspaceSetupStep, action: () => Promise<T>): Promise<T> {
+/**
+ * Run one setup step and record how long it took. The duration is the signal that
+ * matters: a step killed by a gateway idle timeout looks the same as a genuine
+ * failure until you see that it stopped on a round number of seconds.
+ */
+async function setupStep<T>(
+	step: SandboxWorkspaceSetupStep,
+	action: () => Promise<T>,
+	logger?: Logger,
+): Promise<T> {
+	const startedAt = Date.now();
 	try {
-		return await action();
+		const result = await action();
+		logger?.debug('Sandbox workspace setup step finished', {
+			step,
+			durationMs: Date.now() - startedAt,
+		});
+		return result;
 	} catch (error) {
-		throw new SandboxWorkspaceSetupError(step, error);
+		const durationMs = Date.now() - startedAt;
+		logger?.warn('Sandbox workspace setup step failed', {
+			step,
+			durationMs,
+			error: getErrorMessage(error),
+		});
+		throw new SandboxWorkspaceSetupError(step, error, durationMs);
 	}
 }
 
@@ -103,6 +128,15 @@ function resolveHostDepVersion(name: string): string {
  * can install a newly published SDK version.
  */
 export const NPM_INSTALL_FLAGS = '--ignore-scripts --no-audit --no-fund --prefer-online';
+
+/**
+ * Last non-empty line of `npm install` output — its one-line summary. With audit and
+ * funding output off, nothing else follows it.
+ */
+function npmSummaryLine(stdout: string): string {
+	const lines = stdout.split('\n').filter((line) => line.trim() !== '');
+	return lines.at(-1)?.trim().slice(0, 200) ?? '';
+}
 
 /**
  * Versions pinned from the host's installed packages. Pinning is load-bearing
@@ -409,15 +443,19 @@ async function materializeKnowledgeBaseStep(
 	root: string,
 	context: InstanceAiContext,
 ): Promise<void> {
-	await setupStep('materialize-knowledge-base', async () => {
-		const templatesBundle = (await context.templatesService?.getBundle()) ?? null;
-		await materializeKnowledgeBaseIntoWorkspace({
-			workspace,
-			root,
-			logger: context.logger,
-			templatesArchive: templatesBundle?.archive ?? null,
-		});
-	});
+	await setupStep(
+		'materialize-knowledge-base',
+		async () => {
+			const templatesBundle = (await context.templatesService?.getBundle()) ?? null;
+			await materializeKnowledgeBaseIntoWorkspace({
+				workspace,
+				root,
+				logger: context.logger,
+				templatesArchive: templatesBundle?.archive ?? null,
+			});
+		},
+		context.logger,
+	);
 }
 
 /**
@@ -432,19 +470,39 @@ export async function setupSandboxWorkspace(
 	workspace: SandboxWorkspace,
 	context: InstanceAiContext,
 ): Promise<boolean> {
+	const setupStartedAt = Date.now();
 	const root = await setupStep(
 		'resolve-workspace-root',
 		async () => await getWorkspaceRoot(workspace),
+		context.logger,
 	);
 	const markerFile = joinWorkspacePath(root, '.sandbox-initialized');
+
+	// The pinned versions decide whether the baked snapshot tree still matches. When they
+	// drift from the snapshot, `install-dependencies` stops being a no-op and does a cold
+	// install instead.
+	context.logger.debug('Sandbox workspace setup starting', {
+		root,
+		sdkVersion: SANDBOX_SDK_VERSION,
+		tsxVersion: SANDBOX_TSX_VERSION,
+	});
 
 	// Check marker file for idempotency
 	const marker = await setupStep(
 		'read-initialization-marker',
 		async () => await readWorkspaceFile(workspace, markerFile),
+		context.logger,
 	);
 	if (marker !== null) {
+		context.logger.debug('Sandbox workspace already initialized; skipping setup', { root });
 		await materializeKnowledgeBaseStep(workspace, root, context);
+		// The reattach path still refreshes the knowledge base, so it has a duration worth
+		// measuring. Log it here too, or a reattach shows a start with no end.
+		context.logger.debug('Sandbox workspace setup finished', {
+			root,
+			durationMs: Date.now() - setupStartedAt,
+			initializationRan: false,
+		});
 		return false;
 	}
 
@@ -460,6 +518,7 @@ export async function setupSandboxWorkspace(
 	const nodeTypes = await setupStep(
 		'list-node-types',
 		async () => await context.nodeService.listSearchable(),
+		context.logger,
 	);
 	const catalogLines = nodeTypes.map(formatNodeCatalogLine);
 	files.set('node-types/index.txt', catalogLines.join('\n'));
@@ -487,20 +546,33 @@ export async function setupSandboxWorkspace(
 	await setupStep(
 		'write-workspace-files',
 		async () => await writeWorkspaceFiles(workspace, root, files),
+		context.logger,
 	);
 	await materializeKnowledgeBaseStep(workspace, root, context);
 
 	// npm install (must run after package.json is in place)
-	await setupStep('install-dependencies', async () => {
-		const npmResult = await runInSandbox(workspace, `npm install ${NPM_INSTALL_FLAGS}`, root);
-		if (npmResult.exitCode !== 0) {
-			throw new Error(`Sandbox npm install failed: ${npmResult.stderr}`);
-		}
-	});
+	await setupStep(
+		'install-dependencies',
+		async () => {
+			const command = `npm install ${NPM_INSTALL_FLAGS}`;
+			context.logger.debug('Sandbox npm install starting', { command, cwd: root });
+			const npmResult = await runInSandbox(workspace, command, root);
+			if (npmResult.exitCode !== 0) {
+				throw new Error(`Sandbox npm install failed: ${npmResult.stderr}`);
+			}
+			// npm's summary ("up to date in 1s" vs "added 47 packages in 28s") shows at a glance
+			// whether this step did real work or only revalidated an already-baked tree.
+			context.logger.debug('Sandbox npm install finished', {
+				summary: npmSummaryLine(npmResult.stdout),
+			});
+		},
+		context.logger,
+	);
 
 	await setupStep(
 		'link-workspace-sdk',
 		async () => await linkWorkspaceSdkIfEnabled(workspace, root, context.logger),
+		context.logger,
 	);
 
 	await setupStep(
@@ -511,7 +583,14 @@ export async function setupSandboxWorkspace(
 				root,
 				new Map([['.sandbox-initialized', new Date().toISOString()]]),
 			),
+		context.logger,
 	);
+
+	context.logger.debug('Sandbox workspace setup finished', {
+		root,
+		durationMs: Date.now() - setupStartedAt,
+		initializationRan: true,
+	});
 
 	return true;
 }

--- a/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
+++ b/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
@@ -138,8 +138,11 @@ export async function writeWorkspaceFile(
 			if (isAbortError(error)) throw error;
 			try {
 				await writeFileViaSandbox(workspace, filePath, content, options);
+				// `bytes` is the diagnostic that matters: the multipart upload is sent
+				// chunked, so a truncated body shows up as a size-dependent failure.
 				options?.logger.warn(`${label} filesystem write failed; used command fallback`, {
 					path: filePath,
+					bytes: Buffer.byteLength(content, 'utf-8'),
 					error: formatErrorForLog(error),
 				});
 				return;


### PR DESCRIPTION
## Summary

Sandbox workspace setup had no instrumentation. When a step failed, the error said which step and nothing else — not how long it ran, not what the step was doing. Debugging a gateway timeout in that path meant guessing.

This adds timing to every step, at `debug` level, plus the two facts that turn out to decide most questions about this path.

**Per-step durations.** `setupStep` times each step and logs on success (`debug`) and failure (`warn`).

```
debug  Sandbox workspace setup step finished  { step: "read-initialization-marker", durationMs: 2257 }
debug  Sandbox workspace setup step finished  { step: "write-workspace-files",      durationMs: 1863 }
debug  Sandbox workspace setup finished       { root: "…", durationMs: 7378 }
```

**The duration reaches the error message.** `SandboxWorkspaceSetupError` carries `durationMs` and includes it:

```
Sandbox workspace setup failed during install-dependencies after 30012ms: {…}
```

This is the highest-value part. A step killed by a gateway idle timeout looks identical to a real failure until you see it stopped on a round number of seconds — and because it lands in the message, it reaches the tool error the agent sees and the trace export, so a user report is diagnosable without log access.

**npm's summary line.** `up to date in 333ms` against `added 47 packages in 28s` says at a glance whether the baked snapshot tree matched or the step did a cold install.

**The pinned versions at setup entry** (`sdkVersion`, `tsxVersion`), which decide that match.

**Payload size on the file-write fallback.** Uploads go out chunked, so a size figure separates a truncated body from a size-dependent failure.

## What it already found

Everything below came out of one debug run, in under an hour:

- `install-dependencies` is **645ms** (`up to date in 333ms`), not the expensive step. It is ~9% of setup.
- Setup is **round-trip-bound**: reading one marker file costs 2.3s, writing a one-line marker costs 0.96s. Each toolbox call through the proxy is ~1-2.3s.
- A production `install-dependencies` failure ran ~31.7s against that 645ms baseline — so the call stalled, npm was not slow. That reframed an investigation that had been chasing npm flags.
- The same step measured 1,863ms and 5,874ms for byte-identical input on two runs an hour apart, which makes it a usable read on proxy health.
- The `bytes` field immediately disproved a "large files fail more" theory: a 7,102 B file failed the same way a 54,567 B one did, which pointed at a timing race rather than payload size (fixed separately in ai-assistant-service#604).

## Why keep it rather than revert it

It is `debug` level, a few `Date.now()` calls, and logs no file contents or user data. The one thing it adds to a non-debug build is `durationMs` in an error message that was already being raised. That seems worth keeping permanently for a path that is entirely network-bound and otherwise opaque.

## Tests

No behaviour change, so no new tests. Existing assertions still hold — `toThrow` matches on substring, so `Sandbox workspace setup failed during <step>` still matches with ` after Nms` appended.

`src/workspace`: 184/184. Typecheck and eslint clean.

## How to test

```bash
N8N_LOG_LEVEL=debug pnpm dev:be 2>&1 | tee /tmp/aia-sandbox.log
```

Start a new AI Assistant thread (a new thread is required — a warm sandbox has `.sandbox-initialized` and setup returns at the marker check), then:

```bash
grep -E "Sandbox workspace setup|Sandbox npm install" /tmp/aia-sandbox.log
```

## Notes

- Touches `sandbox-setup.ts`, as do #38135 and #38136. Whichever merges first, the other two need a rebase. The overlap in this one is `setupStep`'s signature and the `install-dependencies` body; conflicts should be mechanical.
- `setupStep`'s `logger` parameter is optional, so the two call sites that predate a context are unaffected.

## Related Linear tickets, Github issues, and Community forum posts

None. Written while investigating sandbox setup gateway timeouts.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- no docs surface -->
- [x] Tests included. <!-- no behaviour change; existing coverage holds -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

