### PR TITLE
fix(core): Accept numeric pagination tokens from resource locator list methods

### DIFF
--- a/packages/@n8n/api-types/src/dto/dynamic-node-parameters/__tests__/resource-locator-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/dynamic-node-parameters/__tests__/resource-locator-request.dto.test.ts
@@ -53,6 +53,20 @@ describe('ResourceLocatorRequestDto', () => {
 			const result = ResourceLocatorRequestDto.safeParse(request);
 			expect(result.success).toBe(true);
 		});
+
+		test.each([
+			{ name: 'a numeric pagination token', token: 5, expected: '5' },
+			{ name: 'a zero pagination token', token: 0, expected: '0' },
+			{ name: 'a string pagination token', token: '5', expected: '5' },
+		])('should coerce $name to a string', ({ token, expected }) => {
+			const result = ResourceLocatorRequestDto.safeParse({
+				...baseValidRequest,
+				paginationToken: token,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data?.paginationToken).toBe(expected);
+		});
 	});
 
 	describe('Invalid requests', () => {

--- a/packages/@n8n/api-types/src/dto/dynamic-node-parameters/resource-locator-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/dynamic-node-parameters/resource-locator-request.dto.ts
@@ -5,5 +5,7 @@ import { BaseDynamicParametersRequestDto } from './base-dynamic-parameters-reque
 export class ResourceLocatorRequestDto extends BaseDynamicParametersRequestDto.extend({
 	methodName: z.string(),
 	filter: z.string().optional(),
-	paginationToken: z.string().optional(),
+	// Offset-style `listSearch` methods return a numeric token. The client sends the
+	// token back unchanged, so accept a number here and convert it.
+	paginationToken: z.union([z.string(), z.number()]).transform(String).optional(),
 }) {}

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -219,6 +219,26 @@ describe('DynamicNodeParametersService', () => {
 			expect(result.paginationToken).toBeUndefined();
 		});
 
+		it('should not throw when a listSearch method returns nothing', async () => {
+			const listSearchMethod = vi.fn().mockResolvedValue(undefined);
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { listSearch: { searchModels: listSearchMethod } },
+				}),
+			);
+
+			const result = await service.getResourceLocatorResults(
+				'searchModels',
+				'',
+				mock<IWorkflowExecuteAdditionalData>(),
+				{ name: 'TestNode', version: 1 },
+				mock<INodeParameters>(),
+			);
+
+			expect(result).toBeUndefined();
+		});
+
 		it('should acquire and release isolate around getResourceMappingFields', async () => {
 			const resourceMappingMethod = vi.fn().mockResolvedValue({
 				fields: [{ id: '1', displayName: 'F', defaultMatch: false, required: true, display: true }],

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -177,6 +177,48 @@ describe('DynamicNodeParametersService', () => {
 			expect(releaseSpy).toHaveBeenCalledTimes(1);
 		});
 
+		it('should stringify a numeric pagination token returned by a listSearch method', async () => {
+			const listSearchMethod = vi
+				.fn()
+				.mockResolvedValue({ results: [{ name: 'r', value: 'v' }], paginationToken: 0 });
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { listSearch: { searchModels: listSearchMethod } },
+				}),
+			);
+
+			const result = await service.getResourceLocatorResults(
+				'searchModels',
+				'',
+				mock<IWorkflowExecuteAdditionalData>(),
+				{ name: 'TestNode', version: 1 },
+				mock<INodeParameters>(),
+			);
+
+			expect(result.paginationToken).toBe('0');
+		});
+
+		it('should leave an absent pagination token absent', async () => {
+			const listSearchMethod = vi.fn().mockResolvedValue({ results: [{ name: 'r', value: 'v' }] });
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mock<INodeType>({
+					description: { properties: [] },
+					methods: { listSearch: { searchModels: listSearchMethod } },
+				}),
+			);
+
+			const result = await service.getResourceLocatorResults(
+				'searchModels',
+				'',
+				mock<IWorkflowExecuteAdditionalData>(),
+				{ name: 'TestNode', version: 1 },
+				mock<INodeParameters>(),
+			);
+
+			expect(result.paginationToken).toBeUndefined();
+		});
+
 		it('should acquire and release isolate around getResourceMappingFields', async () => {
 			const resourceMappingMethod = vi.fn().mockResolvedValue({
 				fields: [{ id: '1', displayName: 'F', defaultMatch: false, required: true, display: true }],

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -317,7 +317,7 @@ export class DynamicNodeParametersService {
 			// `INodeListSearchResult` types the token as a string, but offset-style
 			// methods return a number. Convert it here so every caller gets a string.
 			// The RLC dropdown and the MCP output schema both require one.
-			const token: unknown = result.paginationToken;
+			const token: unknown = result?.paginationToken;
 			return typeof token === 'number' ? { ...result, paginationToken: String(token) } : result;
 		});
 	}

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -313,7 +313,12 @@ export class DynamicNodeParametersService {
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
 		return await withExpressionIsolate(workflow, async () => {
-			return await method.call(thisArgs, filter, paginationToken);
+			const result = await method.call(thisArgs, filter, paginationToken);
+			// `INodeListSearchResult` types the token as a string, but offset-style
+			// methods return a number. Convert it here so every caller gets a string.
+			// The RLC dropdown and the MCP output schema both require one.
+			const token: unknown = result.paginationToken;
+			return typeof token === 'number' ? { ...result, paginationToken: String(token) } : result;
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -91,7 +91,7 @@ const NODE_API_AUTH_ERROR_MESSAGES = [
 
 interface IResourceLocatorQuery {
 	results: INodeListSearchItems[];
-	nextPageToken: unknown;
+	nextPageToken: string | null;
 	error: boolean;
 	errorDetails?: {
 		message?: string;
@@ -858,7 +858,7 @@ async function loadResources() {
 
 	try {
 		if (cachedResponse) {
-			const nextPageToken = cachedResponse.nextPageToken as string;
+			const nextPageToken = cachedResponse.nextPageToken;
 			if (nextPageToken) {
 				paginationToken = nextPageToken;
 				setResponse(paramsKey, { loading: true });


### PR DESCRIPTION
## Summary

The Resource Locator "From list" dropdown fails to load the next page when a node returns its pagination token as a number.

`INodeListSearchResult` types `paginationToken` as a string, but nothing enforces that type at runtime. Offset-style `listSearch` methods return a number instead. The editor caches the response, then sends the token back verbatim on the next page request. `ResourceLocatorRequestDto` declares the token as a string, so the request gets a 400 response:

```json
{ "code": "invalid_type", "expected": "string", "received": "number", "path": ["paginationToken"] }
```

The dropdown then shows "Could not load list: Expected string, received number" with no items.

This PR makes three changes:

1. **`DynamicNodeParametersService.getResourceLocatorResults`** converts a numeric token to a string. The node result is where the value enters the system, so this gives every consumer a string. The `explore_node_resources` MCP tool needs this too: it declares the token as a string in its `outputSchema` and returns the raw result as `structuredContent`, so a numeric token also fails MCP output validation. A request-level fix cannot reach that path.
2. **`ResourceLocatorRequestDto`** accepts a string or a number and coerces it to a string. The output type stays `string | undefined`, so the service signature and all `listSearch` calls are unchanged. This keeps any client from a 400 response.
3. **`ResourceLocator.vue`** types the cached token as `string | null` and drops the `as string` cast. The cast let a number through without a type error. This also fixes a related edge case: `currentQueryHasMore` reads `!!nextPageToken`, so a numeric `0` token was falsy and pagination stopped after the first page. The string `"0"` is truthy.

### Note on the ticket scope

Part of what ADO-5410 describes is already fixed on master by #31018, which tightened `INodeListSearchResult.paginationToken` from `unknown` to `string` and changed the E2eTest node and TheHiveProject to return `String(...)`. The guarding E2E spec is also already un-quarantined and de-flaked by #33368.

What stayed broken is the contract asymmetry itself. Nothing validates the token at runtime, so a community node that paginates by offset still triggers the same failure. Our typechecker never sees community node code.

## How to test

Automated:

```bash
pnpm --filter @n8n/api-types test resource-locator-request
pnpm --filter n8n test dynamic-node-parameters.service
pnpm --filter n8n-editor-ui test ResourceLocator
```

Manual, to confirm the original report:

1. Change a `listSearch` method to return a numeric token, for example set `paginationToken: offset + pageSize` in `packages/nodes-base/nodes/E2eTest/E2eTest.node.ts`. This restores the pre-#31018 behavior and models a community node.
2. Add the E2E Test node with the "Resource Locator" action.
3. Open the "From list" dropdown. The first page loads 5 items.
4. Close and reopen the dropdown, or scroll to the bottom of the list.
5. The next page loads. Before this PR the list was empty and showed "Could not load list".

No feature flag, license, or extra module is needed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5410

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

