### PR TITLE
fix(API): Report the full route path in public API usage telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/public-api/__tests__/public-api-controller.registry.test.ts
+++ b/packages/cli/src/public-api/__tests__/public-api-controller.registry.test.ts
@@ -47,7 +47,8 @@ describe('PublicApiControllerRegistry', () => {
 			lastActiveAtService,
 			eventService,
 		).activate(router, 'v1');
-		app.use(router);
+		// mirrors the production mount, `apiController.use('/api/v1', ..., controllerRouter)`
+		app.use('/api/v1', router);
 		return app;
 	}
 
@@ -76,7 +77,7 @@ describe('PublicApiControllerRegistry', () => {
 		}
 		markPublicApiController(WidgetsPublicController as Controller, '/widgets');
 
-		const response = await request(activate()).get('/widgets').expect(200);
+		const response = await request(activate()).get('/api/v1/widgets').expect(200);
 
 		expect(response.headers.deprecation).toBe(`@${Math.floor(since.getTime() / 1000)}`);
 	});
@@ -96,7 +97,7 @@ describe('PublicApiControllerRegistry', () => {
 		}
 		markPublicApiController(WidgetsPublicController as Controller, '/widgets');
 
-		const response = await request(activate()).get('/widgets').expect(401);
+		const response = await request(activate()).get('/api/v1/widgets').expect(401);
 
 		expect(response.headers.deprecation).toBe(`@${Math.floor(since.getTime() / 1000)}`);
 	});
@@ -112,7 +113,7 @@ describe('PublicApiControllerRegistry', () => {
 		}
 		markPublicApiController(WidgetsPublicController as Controller, '/widgets');
 
-		const response = await request(activate()).get('/widgets').expect(200);
+		const response = await request(activate()).get('/api/v1/widgets').expect(200);
 
 		expect(response.headers.deprecation).toBeUndefined();
 		expect(eventService.emit).toHaveBeenCalledWith(
@@ -121,7 +122,7 @@ describe('PublicApiControllerRegistry', () => {
 		);
 	});
 
-	it('reports the mounted path for a route below the controller base path', async () => {
+	it('reports the version-less route path for a sub-path route', async () => {
 		@Service()
 		class WidgetsPublicController {
 			@Get('/:widgetId')
@@ -132,7 +133,7 @@ describe('PublicApiControllerRegistry', () => {
 		}
 		markPublicApiController(WidgetsPublicController as Controller, '/widgets');
 
-		await request(activate()).get('/widgets/w-1').expect(200);
+		await request(activate()).get('/api/v1/widgets/w-1').expect(200);
 
 		expect(eventService.emit).toHaveBeenCalledWith(
 			'public-api-invoked',
@@ -158,7 +159,7 @@ describe('PublicApiControllerRegistry', () => {
 			markPublicApiController(WidgetsPublicController as Controller, '/widgets');
 
 			const response = await request(activate())
-				.post('/widgets')
+				.post('/api/v1/widgets')
 				.send({ name: 'w', active: false })
 				.expect(400);
 
@@ -188,7 +189,7 @@ describe('PublicApiControllerRegistry', () => {
 		it('rejects a value that fails its schema with a 400 naming the parameter', async () => {
 			registerValidatedRoute();
 
-			const response = await request(activate()).get('/widgets/abc').expect(400);
+			const response = await request(activate()).get('/api/v1/widgets/abc').expect(400);
 
 			expect(response.body.message).toBe('request/params/widgetId must be a positive integer');
 		});
@@ -196,7 +197,7 @@ describe('PublicApiControllerRegistry', () => {
 		it('hands a passing value to the handler as a string', async () => {
 			registerValidatedRoute();
 
-			const response = await request(activate()).get('/widgets/12').expect(200);
+			const response = await request(activate()).get('/api/v1/widgets/12').expect(200);
 
 			expect(response.body).toEqual({ widgetId: '12' });
 		});
@@ -212,7 +213,7 @@ describe('PublicApiControllerRegistry', () => {
 			}
 			markPublicApiController(WidgetsPublicController as Controller, '/widgets');
 
-			const response = await request(activate()).get('/widgets/abc').expect(200);
+			const response = await request(activate()).get('/api/v1/widgets/abc').expect(200);
 
 			expect(response.body).toEqual({ widgetId: 'abc' });
 		});
@@ -247,7 +248,7 @@ describe('PublicApiControllerRegistry', () => {
 			registerBodyRoute();
 
 			await request(activate())
-				.post('/widgets')
+				.post('/api/v1/widgets')
 				.set('Content-Type', 'application/json')
 				.send({ name: 'a' })
 				.expect(200);
@@ -257,7 +258,7 @@ describe('PublicApiControllerRegistry', () => {
 			registerBodyRoute();
 
 			await request(activate())
-				.post('/widgets')
+				.post('/api/v1/widgets')
 				.set('Content-Type', 'application/json; charset=utf-8')
 				.send({ name: 'a' })
 				.expect(200);
@@ -274,7 +275,7 @@ describe('PublicApiControllerRegistry', () => {
 			registerBodyRoute();
 
 			const response = await request(activate())
-				.post('/widgets')
+				.post('/api/v1/widgets')
 				.set('Content-Type', sent)
 				.send('a')
 				.expect(415);
@@ -286,7 +287,7 @@ describe('PublicApiControllerRegistry', () => {
 			registerBodyRoute();
 
 			const response = await request(activate())
-				.post('/widgets')
+				.post('/api/v1/widgets')
 				.set('Content-Type', 'application/x-www-form-urlencoded')
 				.expect(415);
 
@@ -302,7 +303,7 @@ describe('PublicApiControllerRegistry', () => {
 		];
 
 		function postWithContentType(header: string | undefined) {
-			const pending = request(activate()).post('/widgets');
+			const pending = request(activate()).post('/api/v1/widgets');
 
 			return header === undefined ? pending : pending.set('Content-Type', header);
 		}
@@ -328,7 +329,7 @@ describe('PublicApiControllerRegistry', () => {
 			registerBodyRoute();
 
 			await request(activate())
-				.post('/widgets')
+				.post('/api/v1/widgets')
 				.set('Content-Type', 'application/json; Foo=BAR')
 				.send({ name: 'a' })
 				.expect(200);

--- a/packages/cli/src/public-api/__tests__/public-api-controller.registry.test.ts
+++ b/packages/cli/src/public-api/__tests__/public-api-controller.registry.test.ts
@@ -1,4 +1,5 @@
 import { Z } from '@n8n/api-types';
+import type { AuthenticatedRequest, User } from '@n8n/db';
 import {
 	ApiResponse,
 	Body,
@@ -29,6 +30,7 @@ describe('PublicApiControllerRegistry', () => {
 	const authStrategyRegistry = mock<AuthStrategyRegistry>();
 	const lastActiveAtService = mock<LastActiveAtService>();
 	const eventService = mock<EventService>();
+	const authenticatedUser = mock<User>({ id: 'user-1' });
 
 	function activate(): express.Express {
 		const app = express();
@@ -51,7 +53,12 @@ describe('PublicApiControllerRegistry', () => {
 
 	beforeEach(() => {
 		vi.resetAllMocks();
-		authStrategyRegistry.authenticate.mockResolvedValue(true);
+		// mirrors the real strategies, which set `req.user` on success
+		authStrategyRegistry.authenticate.mockImplementation(async (req: AuthenticatedRequest) => {
+			req.user = authenticatedUser;
+			return true;
+		});
+		lastActiveAtService.updateLastActiveIfStale.mockResolvedValue(undefined);
 		Container.set(ControllerRegistryMetadata, new ControllerRegistryMetadata());
 	});
 
@@ -108,6 +115,29 @@ describe('PublicApiControllerRegistry', () => {
 		const response = await request(activate()).get('/widgets').expect(200);
 
 		expect(response.headers.deprecation).toBeUndefined();
+		expect(eventService.emit).toHaveBeenCalledWith(
+			'public-api-invoked',
+			expect.objectContaining({ method: 'GET', path: '/widgets' }),
+		);
+	});
+
+	it('reports the mounted path for a route below the controller base path', async () => {
+		@Service()
+		class WidgetsPublicController {
+			@Get('/:widgetId')
+			@ApiResponse(200)
+			method() {
+				return { ok: true };
+			}
+		}
+		markPublicApiController(WidgetsPublicController as Controller, '/widgets');
+
+		await request(activate()).get('/widgets/w-1').expect(200);
+
+		expect(eventService.emit).toHaveBeenCalledWith(
+			'public-api-invoked',
+			expect.objectContaining({ method: 'GET', path: '/widgets/w-1' }),
+		);
 	});
 
 	describe('validation failures', () => {

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -37,6 +37,16 @@ function parsePathParam(key: string, schema: ZodTypeAny, params: Request['params
 	return output.data[key];
 }
 
+/**
+ * Express strips the controller mount prefix from `req.path`, so `POST /role-mapping-rules`
+ * arrives as `/`. Prepend the prefix to keep the full route in telemetry, and drop the
+ * trailing slash a base-path route would otherwise add.
+ */
+function fullRoutePath(req: Request): string {
+	const path = req.baseUrl + req.path;
+	return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
 @Service()
 export class PublicApiControllerRegistry {
 	constructor(
@@ -170,7 +180,7 @@ export class PublicApiControllerRegistry {
 				this.lastActiveAtService.updateLastActiveIfStale(userId).catch(() => undefined);
 				this.eventService.emit('public-api-invoked', {
 					userId,
-					path: req.path,
+					path: fullRoutePath(req),
 					method: req.method,
 					apiVersion,
 					userAgent: req.headers['user-agent'],

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -37,13 +37,9 @@ function parsePathParam(key: string, schema: ZodTypeAny, params: Request['params
 	return output.data[key];
 }
 
-/**
- * Express strips the controller mount prefix from `req.path`, so `POST /role-mapping-rules`
- * arrives as `/`. Prepend the prefix to keep the full route in telemetry, and drop the
- * trailing slash a base-path route would otherwise add.
- */
-function fullRoutePath(req: Request): string {
-	const path = req.baseUrl + req.path;
+// Match the legacy version-less route. req.path drops the prefix, req.baseUrl adds /api/v1
+function routePath(prefix: string, req: Request): string {
+	const path = (prefix === '/' ? '' : prefix) + req.path;
 	return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
 }
 
@@ -129,7 +125,7 @@ export class PublicApiControllerRegistry {
 				middlewares.push(deprecated(route.deprecated));
 			}
 
-			middlewares.push(this.createAuthMiddleware(apiVersion));
+			middlewares.push(this.createAuthMiddleware(apiVersion, prefix));
 
 			if (route.apiKeyScope) {
 				middlewares.push(this.createApiKeyScopeMiddleware(route.apiKeyScope));
@@ -164,7 +160,7 @@ export class PublicApiControllerRegistry {
 		}
 	}
 
-	private createAuthMiddleware(apiVersion: string): RequestHandler {
+	private createAuthMiddleware(apiVersion: string, prefix: string): RequestHandler {
 		return async (req, res, next) => {
 			const authenticated = await this.authStrategyRegistry.authenticate(
 				req as AuthenticatedRequest,
@@ -180,7 +176,7 @@ export class PublicApiControllerRegistry {
 				this.lastActiveAtService.updateLastActiveIfStale(userId).catch(() => undefined);
 				this.eventService.emit('public-api-invoked', {
 					userId,
-					path: fullRoutePath(req),
+					path: routePath(prefix, req),
 					method: req.method,
 					apiVersion,
 					userAgent: req.headers['user-agent'],


### PR DESCRIPTION
## Summary

Express removes the controller mount prefix from `req.path` inside a mounted router. The public API controller registry emitted `req.path`, so every endpoint on the `@PublicApiController` pattern reported `POST /` instead of `POST /role-mapping-rules`. All migrated controllers collapsed into the same bucket in telemetry and could not be told apart.

Six controllers are affected. tags (2.32.0), workflows (2.33.0), roles (2.35.0), role-mapping-rules (2.36.0), git-connections (2.37.0), and executions (2.39.0). Executions is the largest route family in the public API and migrated last week, so the loss is still growing.

The legacy public API is not affected. Its emitter runs on a router mounted at `/api/v1`, so `req.path` keeps the resource segment.

| Decision | Why |
| --- | --- |
| Prepend `req.baseUrl` | It holds the mount prefix Express removed |
| Strip a trailing slash | A base-path route gives `baseUrl` of `/widgets` and `path` of `/`, which would emit `/widgets/` |
| Assert in the registry test, not per endpoint | Every controller shares one middleware, so one test covers all current and future controllers |
| Set `req.user` in the test fixture | The middleware skips the emit without it, so the authenticated branch had never run in any test |

There is no backfill. Data for each route starts from the release that carries this fix.

## How to test

Both new assertions fail on `master` and pass here.

```bash
cd packages/cli
pnpm vitest run src/public-api/__tests__/public-api-controller.registry.test.ts
```

Reverting `fullRoutePath(req)` to `req.path` gives `/` for the base-path route and `/w-1` for the sub-path route, which is the reported bug.

To confirm the effect on real data, query `rudder_schema.public_api_usage` for paths equal to `/`. They are zero in every week before 2.32.0 shipped on 20 July 2026, then grow to about 13.5k instances. Over the same period `/tags` volume falls by about 90%. The full query is on the Linear ticket.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-290

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

