### PR TITLE
fix(core): Re-register the n8n Trigger on every publish through the publication service

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
@@ -85,4 +85,44 @@ describe('computeTriggerDiff', () => {
 	test('returns empty diff for two empty trigger sets', () => {
 		expect(computeTriggerDiff([], [])).toEqual({ toAdd: new Set(), toRemove: new Set() });
 	});
+
+	describe('triggers that observe the publication itself', () => {
+		const n8nTrigger = makeNode('n8n', {
+			type: 'n8n-nodes-base.n8nTrigger',
+			parameters: { events: ['update'] },
+		});
+
+		test('re-registers an unchanged n8n Trigger when the published version changed', () => {
+			const diff = computeTriggerDiff([n8nTrigger], [{ ...n8nTrigger }], { versionChanged: true });
+
+			expect(diff).toEqual({ toAdd: new Set(['n8n']), toRemove: new Set(['n8n']) });
+		});
+
+		test('leaves an unchanged n8n Trigger running when the published version is the same', () => {
+			const diff = computeTriggerDiff([n8nTrigger], [{ ...n8nTrigger }], { versionChanged: false });
+
+			expect(diff).toEqual({ toAdd: new Set(), toRemove: new Set() });
+		});
+
+		test('re-registers the deprecated Workflow Trigger the same way', () => {
+			const workflowTrigger = makeNode('legacy', {
+				type: 'n8n-nodes-base.workflowTrigger',
+				parameters: { events: ['update'] },
+			});
+
+			const diff = computeTriggerDiff([workflowTrigger], [{ ...workflowTrigger }], {
+				versionChanged: true,
+			});
+
+			expect(diff).toEqual({ toAdd: new Set(['legacy']), toRemove: new Set(['legacy']) });
+		});
+
+		test('does not force other unchanged trigger types when the published version changed', () => {
+			const schedule = makeNode('a');
+
+			const diff = computeTriggerDiff([schedule], [{ ...schedule }], { versionChanged: true });
+
+			expect(diff).toEqual({ toAdd: new Set(), toRemove: new Set() });
+		});
+	});
 });

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -757,6 +757,51 @@ describe('WorkflowPublicationApplier', () => {
 		expect(callOrder).toEqual(['remove', 'invalidate', 'advance', 'refresh', 'add']);
 	});
 
+	describe('n8n Trigger', () => {
+		// Emits "Published Workflow Updated" from `trigger()` itself, so it only fires
+		// when re-registered: the diff must re-apply it on every version change.
+		const n8nTrigger = triggerNode('n8n', {
+			type: 'n8n-nodes-base.n8nTrigger',
+			parameters: { events: ['update'] },
+		});
+
+		test('re-applies an unchanged n8n Trigger when the published version changes', async () => {
+			setTriggerSets([n8nTrigger], [{ ...n8nTrigger }]);
+			workflowTriggerActivator.activate.mockResolvedValue({ activated: ['n8n'], failures: [] });
+
+			const result = await applier.apply(makeRecord(), abort);
+
+			expect(result.type).toBe('completed');
+			expect(workflowTriggerActivator.deactivate).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				oldVersion,
+				new Set(['n8n']),
+				abort,
+			);
+			expect(workflowTriggerActivator.activate).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				newVersion,
+				new Set(['n8n']),
+				'update',
+				abort,
+			);
+		});
+
+		test('leaves an unchanged n8n Trigger running when the record targets the already-published version', async () => {
+			setTriggerSets([n8nTrigger], [{ ...n8nTrigger }]);
+			workflowRepository.findOneBy.mockResolvedValue(makeWorkflow({ activeVersionId: 'v-2' }));
+			workflowPublishedVersionRepository.findOne.mockResolvedValue(
+				makePublishedVersion(newVersion),
+			);
+
+			const result = await applier.apply(makeRecord(), abort);
+
+			expect(result.type).toBe('completed');
+			expect(workflowTriggerActivator.deactivate).not.toHaveBeenCalled();
+			expect(workflowTriggerActivator.activate).not.toHaveBeenCalled();
+		});
+	});
+
 	test('completes carrying external teardown failures from removed triggers, still advancing', async () => {
 		setTriggerSets([triggerNode('a'), triggerNode('b')], [triggerNode('a')]);
 		const failure = { nodeName: 'b', error: new Error('remote unreachable') };

--- a/packages/cli/src/workflows/publication/trigger-diff.ts
+++ b/packages/cli/src/workflows/publication/trigger-diff.ts
@@ -12,6 +12,22 @@ function registrationEqual(base: INode | undefined, target: INode | undefined): 
 	return isEqual(pick(base, registrationProps), pick(target, registrationProps));
 }
 
+// Triggers whose node code observes the publication itself instead of an
+// external event: the n8n Trigger (and its deprecated predecessor) emits
+// "Published Workflow Updated" from `trigger()`, so it only fires when it is
+// (re)registered. The legacy path re-registered every trigger on every publish;
+// keep that for these types on every version change, even when their own
+// registration did not change. Stop-gap until nodes can declare this themselves.
+const ALWAYS_REREGISTER_TRIGGER_TYPES: ReadonlySet<string> = new Set([
+	'n8n-nodes-base.n8nTrigger',
+	'n8n-nodes-base.workflowTrigger',
+]);
+
+export interface TriggerDiffOptions {
+	/** Whether the publish moves to a version other than the one currently running. */
+	versionChanged?: boolean;
+}
+
 /**
  * The trigger nodes that need to be deregistered (`toRemove`) and registered
  * (`toAdd`) to move a workflow's active triggers from `oldTriggerNodes` to
@@ -32,13 +48,14 @@ export interface TriggerDiff {
 export function computeTriggerDiff(
 	oldTriggerNodes: INode[],
 	newTriggerNodes: INode[],
+	{ versionChanged = false }: TriggerDiffOptions = {},
 ): TriggerDiff {
 	const diff = compareWorkflowsNodes(oldTriggerNodes, newTriggerNodes, registrationEqual);
 
 	const toAdd: Set<INode['id']> = new Set();
 	const toRemove: Set<INode['id']> = new Set();
 
-	for (const [nodeId, { status }] of diff) {
+	for (const [nodeId, { status, node }] of diff) {
 		switch (status) {
 			case NodeDiffStatus.Added:
 				toAdd.add(nodeId);
@@ -51,6 +68,10 @@ export function computeTriggerDiff(
 				toAdd.add(nodeId);
 				break;
 			case NodeDiffStatus.Eq:
+				if (versionChanged && ALWAYS_REREGISTER_TRIGGER_TYPES.has(node.type)) {
+					toRemove.add(nodeId);
+					toAdd.add(nodeId);
+				}
 				break;
 		}
 	}

--- a/packages/cli/src/workflows/publication/trigger-diff.ts
+++ b/packages/cli/src/workflows/publication/trigger-diff.ts
@@ -12,12 +12,10 @@ function registrationEqual(base: INode | undefined, target: INode | undefined): 
 	return isEqual(pick(base, registrationProps), pick(target, registrationProps));
 }
 
-// Triggers whose node code observes the publication itself instead of an
-// external event: the n8n Trigger (and its deprecated predecessor) emits
-// "Published Workflow Updated" from `trigger()`, so it only fires when it is
-// (re)registered. The legacy path re-registered every trigger on every publish;
-// keep that for these types on every version change, even when their own
-// registration did not change. Stop-gap until nodes can declare this themselves.
+// Before the workflow publication service, we re-registered every trigger on
+// publication. With the new flow, we only re-register triggers that have been
+// modified. However, some triggers relied on the old behaviour, so we force it
+// for those triggers.
 const ALWAYS_REREGISTER_TRIGGER_TYPES: ReadonlySet<string> = new Set([
 	'n8n-nodes-base.n8nTrigger',
 	'n8n-nodes-base.workflowTrigger',

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -149,7 +149,9 @@ export class WorkflowPublicationApplier {
 		const desiredTriggerNodes = this.workflowTriggerActivator.getEnabledTriggerNodes(newVersion);
 		const triggerKinds = this.workflowTriggerActivator.getTriggerKinds(desiredTriggerNodes);
 
-		const { toAdd, toRemove } = computeTriggerDiff(oldTriggerNodes, desiredTriggerNodes);
+		const { toAdd, toRemove } = computeTriggerDiff(oldTriggerNodes, desiredTriggerNodes, {
+			versionChanged: oldVersion !== null && oldVersion.versionId !== newVersion.versionId,
+		});
 
 		this.logger.debug(
 			`Calculated trigger diff for workflow publication: ${toAdd.size} to add, ${toRemove.size} to remove`,

--- a/packages/testing/playwright/tests/e2e/nodes/n8n-trigger.spec.ts
+++ b/packages/testing/playwright/tests/e2e/nodes/n8n-trigger.spec.ts
@@ -4,6 +4,21 @@ import { nanoid } from 'nanoid';
 
 import { test, expect } from '../../../fixtures/base';
 
+// The node emits from `trigger()` at registration time, so its events depend on
+// how the publication path (re)registers triggers. Run against the publication
+// service, which becomes the default.
+test.use({
+	capability: {
+		env: {
+			TEST_ISOLATION: 'n8n-trigger-publication-service',
+			N8N_USE_WORKFLOW_PUBLICATION_SERVICE: 'true',
+			// Activation is applied asynchronously by the publication outbox
+			// consumer, so poll frequently to keep the test fast.
+			N8N_WORKFLOW_PUBLICATION_OUTBOX_POLL_INTERVAL_MS: '250',
+		},
+	},
+});
+
 type TriggerEventType = 'activate' | 'update';
 
 const makeN8nTriggerWorkflow = (events: TriggerEventType[]) => {


### PR DESCRIPTION
## Summary

The n8n Trigger node emits its **Workflow Published** and **Published Workflow Updated** events from `trigger()` at registration time. It has no event subscription of its own. On the legacy publish path, every republish removed and re-added all triggers with activation mode `update`, so the update event fired on each republish.

The workflow publication service diffs trigger registrations and leaves unchanged triggers running. An unchanged n8n Trigger was therefore never re-registered, and **Published Workflow Updated** never fired again. This is what fails the `n8n-trigger.spec.ts` E2E on #37835, which turns the service on by default.

This PR is a stop-gap that lands before the default flip:

- `computeTriggerDiff` takes a `versionChanged` option. When the publish moves to a different version, trigger types in `ALWAYS_REREGISTER_TRIGGER_TYPES` (`n8nTrigger` and its deprecated predecessor `workflowTrigger`) are treated as modified even when their registration did not change. The applier then re-applies them as remove-then-add with mode `update`, matching the legacy behaviour.
- A record that targets the already-published version (reconciler heals, retries) leaves them running, so drift heals do not fire spurious update events.
- The n8n Trigger E2E spec now runs against the publication service, with an isolated container.

Longer term, nodes should declare that they must be re-registered on publish, instead of a list in core. An investigation of other triggers that relied on the legacy re-registration is tracked in the Linear ticket below.

## How to test

Set `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

1. Create a workflow with an **n8n Trigger** set to **Published Workflow Updated**, connected to a No Op node, and publish it.
2. Add another No Op node (do not touch the trigger) and publish again.
3. An execution runs with `event: "Workflow updated"`. Before this change, nothing ran.
4. Restart the instance. No execution runs for this workflow (the reconciler's startup pass keeps mode `init`).

Unit tests cover the diff option, the applier passing it only when the version changes, and the same-version no-op. The E2E spec `tests/e2e/nodes/n8n-trigger.spec.ts` now exercises the publication path.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4221
Unblocks #37835.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

