### PR TITLE
fix(core): Accept an object in the schema fields of the LangChain schema-driven nodes (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/InformationExtractor.node.ts
@@ -2,7 +2,7 @@ import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import type { JSONSchema7 } from 'json-schema';
 import { OutputFixingParser, StructuredOutputParser } from '@langchain/classic/output_parsers';
 import { sleep } from '@n8n/utils/sleep';
-import { jsonParse, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import type {
 	INodeType,
 	INodeTypeDescription,
@@ -18,7 +18,11 @@ import {
 	jsonSchemaExampleField,
 	schemaTypeField,
 } from '@utils/descriptions';
-import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
+import {
+	convertJsonSchemaToZod,
+	generateSchemaFromExample,
+	parseJsonSchemaParameter,
+} from '@utils/schemaParsing';
 import { getBatchingOptionFields } from '@n8n/ai-utilities';
 import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
 
@@ -259,14 +263,14 @@ export class InformationExtractor implements INodeType {
 			let jsonSchema: JSONSchema7;
 
 			if (schemaType === 'fromJson') {
-				const jsonExample = this.getNodeParameter('jsonSchemaExample', 0, '') as string;
+				const jsonExample = this.getNodeParameter('jsonSchemaExample', 0, '') as unknown;
 				// Enforce all fields to be required in the generated schema if the node version is 1.2 or higher
 				const jsonExampleAllFieldsRequired = this.getNode().typeVersion >= 1.2;
 
 				jsonSchema = generateSchemaFromExample(jsonExample, jsonExampleAllFieldsRequired);
 			} else {
-				const inputSchema = this.getNodeParameter('inputSchema', 0, '') as string;
-				jsonSchema = jsonParse<JSONSchema7>(inputSchema);
+				const inputSchema = this.getNodeParameter('inputSchema', 0, '') as unknown;
+				jsonSchema = parseJsonSchemaParameter(inputSchema);
 			}
 
 			const zodSchema = convertJsonSchemaToZod<z.ZodSchema<object>>(jsonSchema);

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -1,8 +1,6 @@
 import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import { PromptTemplate } from '@langchain/core/prompts';
-import type { JSONSchema7 } from 'json-schema';
 import {
-	jsonParse,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
@@ -22,7 +20,11 @@ import {
 	N8nOutputFixingParser,
 	N8nStructuredOutputParser,
 } from '@utils/output_parsers/N8nOutputParser';
-import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
+import {
+	convertJsonSchemaToZod,
+	generateSchemaFromExample,
+	parseJsonSchemaParameter,
+} from '@utils/schemaParsing';
 import { getConnectionHintNoticeField } from '@n8n/ai-utilities';
 
 import { NAIVE_FIX_PROMPT } from './prompt';
@@ -197,23 +199,23 @@ export class OutputParserStructured implements INodeType {
 		const schemaType = this.getNodeParameter('schemaType', itemIndex, '') as 'fromJson' | 'manual';
 		// We initialize these even though one of them will always be empty
 		// it makes it easer to navigate the ternary operator
-		const jsonExample = this.getNodeParameter('jsonSchemaExample', itemIndex, '') as string;
+		const jsonExample = this.getNodeParameter('jsonSchemaExample', itemIndex, '') as unknown;
 
-		let inputSchema: string;
+		let inputSchema: unknown;
 
 		// Enforce all fields to be required in the generated schema if the node version is 1.3 or higher
 		const jsonExampleAllFieldsRequired = this.getNode().typeVersion >= 1.3;
 
 		if (this.getNode().typeVersion <= 1.1) {
-			inputSchema = this.getNodeParameter('jsonSchema', itemIndex, '') as string;
+			inputSchema = this.getNodeParameter('jsonSchema', itemIndex, '') as unknown;
 		} else {
-			inputSchema = this.getNodeParameter('inputSchema', itemIndex, '') as string;
+			inputSchema = this.getNodeParameter('inputSchema', itemIndex, '') as unknown;
 		}
 
 		const jsonSchema =
 			schemaType === 'fromJson'
 				? generateSchemaFromExample(jsonExample, jsonExampleAllFieldsRequired)
-				: jsonParse<JSONSchema7>(inputSchema);
+				: parseJsonSchemaParameter(inputSchema);
 
 		const zodSchema = convertJsonSchemaToZod<z.ZodSchema<object>>(jsonSchema);
 		const nodeVersion = this.getNode().typeVersion;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -1,5 +1,4 @@
 import { DynamicStructuredTool, DynamicTool } from '@langchain/core/tools';
-import type { JSONSchema7 } from 'json-schema';
 import { JsTaskRunnerSandbox } from 'n8n-nodes-base/dist/nodes/Code/JsTaskRunnerSandbox';
 import { PythonTaskRunnerSandbox } from 'n8n-nodes-base/dist/nodes/Code/PythonTaskRunnerSandbox';
 import type {
@@ -12,12 +11,7 @@ import type {
 	ISupplyDataFunctions,
 	SupplyData,
 } from 'n8n-workflow';
-import {
-	jsonParse,
-	NodeConnectionTypes,
-	nodeNameToToolName,
-	NodeOperationError,
-} from 'n8n-workflow';
+import { NodeConnectionTypes, nodeNameToToolName, NodeOperationError } from 'n8n-workflow';
 
 import {
 	buildInputSchemaField,
@@ -25,7 +19,11 @@ import {
 	buildJsonSchemaExampleNotice,
 	schemaTypeField,
 } from '@utils/descriptions';
-import { convertJsonSchemaToZod, generateSchemaFromExample } from '@utils/schemaParsing';
+import {
+	convertJsonSchemaToZod,
+	generateSchemaFromExample,
+	parseJsonSchemaParameter,
+} from '@utils/schemaParsing';
 import { getConnectionHintNoticeField, logAiEvent } from '@n8n/ai-utilities';
 
 import type { DynamicZodObject } from '../../../types/zod.types';
@@ -148,15 +146,15 @@ function getTool(
 		try {
 			// We initialize these even though one of them will always be empty
 			// it makes it easier to navigate the ternary operator
-			const jsonExample = ctx.getNodeParameter('jsonSchemaExample', itemIndex, '') as string;
-			const inputSchema = ctx.getNodeParameter('inputSchema', itemIndex, '') as string;
+			const jsonExample = ctx.getNodeParameter('jsonSchemaExample', itemIndex, '') as unknown;
+			const inputSchema = ctx.getNodeParameter('inputSchema', itemIndex, '') as unknown;
 
 			const schemaType = ctx.getNodeParameter('schemaType', itemIndex) as 'fromJson' | 'manual';
 
 			const jsonSchema =
 				schemaType === 'fromJson'
 					? generateSchemaFromExample(jsonExample, ctx.getNode().typeVersion >= 1.3)
-					: jsonParse<JSONSchema7>(inputSchema);
+					: parseJsonSchemaParameter(inputSchema);
 
 			const zodSchema = convertJsonSchemaToZod<DynamicZodObject>(jsonSchema);
 

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/ToolWorkflowV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v1/ToolWorkflowV1.node.ts
@@ -1,6 +1,5 @@
 import type { CallbackManagerForToolRun } from '@langchain/core/callbacks/manager';
 import { DynamicStructuredTool, DynamicTool } from '@langchain/core/tools';
-import type { JSONSchema7 } from 'json-schema';
 import get from 'lodash/get';
 import isObject from 'lodash/isObject';
 import type { SetField, SetNodeOptions } from 'n8n-nodes-base/dist/nodes/Set/v2/helpers/interfaces';
@@ -26,7 +25,11 @@ import { logAiEvent } from '@n8n/ai-utilities';
 
 import { versionDescription } from './versionDescription';
 import type { DynamicZodObject } from '../../../../types/zod.types';
-import { convertJsonSchemaToZod, generateSchemaFromExample } from '../../../../utils/schemaParsing';
+import {
+	convertJsonSchemaToZod,
+	generateSchemaFromExample,
+	parseJsonSchemaParameter,
+} from '../../../../utils/schemaParsing';
 import { SUB_WORKFLOW_WAITING_PLACEHOLDER } from '../constants';
 
 export class ToolWorkflowV1 implements INodeType {
@@ -221,14 +224,14 @@ export class ToolWorkflowV1 implements INodeType {
 			try {
 				// We initialize these even though one of them will always be empty
 				// it makes it easier to navigate the ternary operator
-				const jsonExample = this.getNodeParameter('jsonSchemaExample', itemIndex, '') as string;
-				const inputSchema = this.getNodeParameter('inputSchema', itemIndex, '') as string;
+				const jsonExample = this.getNodeParameter('jsonSchemaExample', itemIndex, '') as unknown;
+				const inputSchema = this.getNodeParameter('inputSchema', itemIndex, '') as unknown;
 
 				const schemaType = this.getNodeParameter('schemaType', itemIndex) as 'fromJson' | 'manual';
 				const jsonSchema =
 					schemaType === 'fromJson'
 						? generateSchemaFromExample(jsonExample)
-						: jsonParse<JSONSchema7>(inputSchema);
+						: parseJsonSchemaParameter(inputSchema);
 
 				const zodSchema = convertJsonSchemaToZod<DynamicZodObject>(jsonSchema);
 

--- a/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
+++ b/packages/@n8n/nodes-langchain/utils/schemaParsing.ts
@@ -33,11 +33,28 @@ function makeAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
 	return schema;
 }
 
+/**
+ * The editor stores these fields as JSON strings, but generated workflows store
+ * them as raw objects — the node then hands the object to `JSON.parse`, which
+ * throws `'"[object Object]" is not valid JSON'` before the model is ever called.
+ */
+function asSchemaText(raw: unknown): string {
+	if (typeof raw === 'object' && raw !== null) return JSON.stringify(raw);
+	// `String()` is what `JSON.parse` already did to a non-string, so every value
+	// that parsed before still parses the same way.
+	return String(raw);
+}
+
+/** `schemaType: 'manual'` counterpart — the field already holds a JSON Schema. */
+export function parseJsonSchemaParameter(raw: unknown): JSONSchema7 {
+	return jsonParse<JSONSchema7>(asSchemaText(raw));
+}
+
 export function generateSchemaFromExample(
-	exampleJsonString: string,
+	exampleJson: unknown,
 	allFieldsRequired = false,
 ): JSONSchema7 {
-	const parsedExample = jsonParse<SchemaObject>(exampleJsonString);
+	const parsedExample = jsonParse<SchemaObject>(asSchemaText(exampleJson));
 
 	const schema = generateJsonSchema(parsedExample) as JSONSchema7;
 

--- a/packages/@n8n/nodes-langchain/utils/tests/schemaParsing.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/schemaParsing.test.ts
@@ -6,6 +6,7 @@ import type { INode, IExecuteFunctions } from 'n8n-workflow';
 import {
 	generateSchemaFromExample,
 	convertJsonSchemaToZod,
+	parseJsonSchemaParameter,
 	throwIfToolSchema,
 } from './../schemaParsing';
 
@@ -377,5 +378,37 @@ describe('throwIfToolSchema', () => {
 		const error = { message: 'tool input did not match expected schema' } as Error;
 
 		expect(() => throwIfToolSchema(ctx, error)).toThrow(NodeOperationError);
+	});
+});
+
+// Generated workflows store these fields as raw objects; before this the node
+// handed the object straight to JSON.parse and died with
+// '"[object Object]" is not valid JSON' before the model was ever called.
+describe('object-stored schema parameters', () => {
+	const example = { jobs: [{ title: '', company: '' }] };
+
+	it('generateSchemaFromExample accepts an object and matches the string form', () => {
+		expect(generateSchemaFromExample(example, true)).toEqual(
+			generateSchemaFromExample(JSON.stringify(example), true),
+		);
+	});
+
+	it('parseJsonSchemaParameter accepts an object and matches the string form', () => {
+		const schema = { type: 'object', properties: { title: { type: 'string' } } };
+
+		expect(parseJsonSchemaParameter(schema)).toEqual(
+			parseJsonSchemaParameter(JSON.stringify(schema)),
+		);
+	});
+
+	it('still throws on an unset parameter', () => {
+		expect(() => generateSchemaFromExample('')).toThrow();
+		expect(() => parseJsonSchemaParameter(undefined)).toThrow();
+	});
+
+	// JSON.parse coerced a non-string via String() and these parsed fine, so
+	// they must keep parsing fine — nothing that worked before may change.
+	it.each([42, true, null])('keeps accepting the primitive %s', (value) => {
+		expect(generateSchemaFromExample(value)).toEqual(generateSchemaFromExample(String(value)));
 	});
 });


### PR DESCRIPTION
## Summary

Information Extractor, Structured Output Parser, Code Tool and Call n8n Workflow Tool all read `jsonSchemaExample` / `inputSchema` and hand the value straight to `JSON.parse`. The editor writes a JSON **string** there — but generated workflows write a raw **object**, and the node then dies with:

```
"[object Object]" is not valid JSON
```

Two things make this worse than a plain config error:

1. It throws while building the parser — **after** `getInputConnectionData` hands back the language model, but **before** any model call. So the attached model sub-node shows up as never having run, which reads like an infrastructure problem rather than a parameter problem.
2. `wrapLangChainParserError` passes non-parser errors through verbatim, so the raw V8 message surfaces as the node error with no hint about which parameter caused it.

Fixed by coercing in the two shared parse helpers in `utils/schemaParsing.ts` rather than at each of the eight call sites, so both `schemaType: 'fromJson'` and `schemaType: 'manual'` are covered in all four nodes:

- `generateSchemaFromExample` now accepts a string or an object.
- New `parseJsonSchemaParameter` does the same for the `manual` branch, replacing the four bare `jsonParse<JSONSchema7>(inputSchema)` calls.
- The `as string` casts on those eight parameter reads were false for exactly the values that crash, so they are now `as unknown`.

The change is a **strict widening** — every input `master` accepted or rejected behaves identically, and only objects change:

| `jsonSchemaExample` | master | this PR |
|---|---|---|
| `'{"a":1}'` (string) | parses | parses, identical |
| `42` / `true` / `null` | parses (`JSON.parse` coerced via `String()`) | parses, identical |
| `undefined` / `''` | throws | throws |
| `{a:1}` (object) | **throws** | **parses** |

The non-string primitives matter: `JSON.parse` already coerced them via `String()`, so `asSchemaText` keeps doing that rather than rejecting them, and a test pins the equivalence. Nothing that worked before behaves differently, so no node version bump is needed.

Prior art in the repo, which is why this shape is safe: `workflow-sdk`'s `structured-output-parser-validator.ts` already flags object-stored `jsonSchemaExample` (naming this exact error string), but only as a `warning`; `workflow-sdk/src/mock-data/context.ts` reads both string and object forms with the comment *"eval builders sometimes store them as raw objects"*; and `nodes-base/MessageAnAgent/shared.ts` already does this coercion at its own call site.

## How to test

Add an Information Extractor with `schemaType: 'fromJson'` and `jsonSchemaExample` stored as an object rather than a JSON string, attach any chat model, and run it. On `master` the node throws `"[object Object]" is not valid JSON` before calling the model; on this branch it builds the schema and runs.

Directly, against the built package:

```js
const { generateSchemaFromExample, parseJsonSchemaParameter } = require('./dist/utils/schemaParsing.js');
generateSchemaFromExample({ jobs: [{ title: '', company: '' }] }, true);   // master: throws
parseJsonSchemaParameter({ type: 'object', properties: { title: { type: 'string' } } }); // master: throws
```

```bash
cd packages/@n8n/nodes-langchain
pnpm test utils/tests/schemaParsing.test.ts \
  nodes/chains/InformationExtractor nodes/output_parser/OutputParserStructured \
  nodes/tools/ToolCode nodes/tools/ToolWorkflow      # 119 passed
```

New tests assert the object form produces a schema identical to the string form, for both helpers, and that an unset parameter still throws.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-508

Found while diagnosing eval case 286 `career-page-new-jobs-monitor`, whose Information Extractor crashed this way in sweep #121 and was misattributed to the eval mock layer. The harness-side attribution fix is separate.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->