### PR TITLE
feat: Show a recording indicator on the toolbar icon

### DIFF
--- a/packages/@n8n/mcp-browser-extension/src/background.silentConnect.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.silentConnect.test.ts
@@ -88,6 +88,7 @@ const chromeMock = {
 	action: {
 		setBadgeText: vi.fn(),
 		setBadgeBackgroundColor: vi.fn(),
+		setTitle: vi.fn(),
 		setPopup: vi.fn(),
 		onClicked: { addListener: vi.fn() },
 	},

--- a/packages/@n8n/mcp-browser-extension/src/background.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.test.ts
@@ -432,6 +432,21 @@ describe('updateRecordingIndicator', () => {
 		expect(chromeMock.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
 		expect(chromeMock.action.setTitle).toHaveBeenCalledWith({ title: 'n8n Browser Use' });
 	});
+
+	it('ignores a tab-count refresh while recording, so it cannot overwrite the red badge', async () => {
+		const { updateRecordingIndicator, updateBadge } = await import('./background');
+		updateRecordingIndicator(true);
+		vi.clearAllMocks();
+
+		// Simulates a tab attaching/activating mid-recording, which today calls
+		// updateBadge() with the latest tab count.
+		updateBadge(2);
+
+		expect(chromeMock.action.setBadgeText).not.toHaveBeenCalled();
+		expect(chromeMock.action.setBadgeBackgroundColor).not.toHaveBeenCalled();
+
+		updateRecordingIndicator(false); // reset shared module state for later tests
+	});
 });
 
 describe('buildRelayWsUrl', () => {

--- a/packages/@n8n/mcp-browser-extension/src/background.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.test.ts
@@ -64,6 +64,7 @@ const chromeMock = {
 	action: {
 		setBadgeText: vi.fn(),
 		setBadgeBackgroundColor: vi.fn(),
+		setTitle: vi.fn(),
 		setPopup: vi.fn(),
 		onClicked: {
 			addListener: vi.fn((fn: () => void) => actionClickedListeners.push(fn)),
@@ -406,6 +407,30 @@ describe('external messages (direct connect flow)', () => {
 		await simulateExternalMessage({ type: 'connect', relayUrl: RELAY_URL }, ALLOWED_ORIGIN);
 
 		expect(firstResult()).toEqual({ connected: false });
+	});
+});
+
+describe('updateRecordingIndicator', () => {
+	it('turns the toolbar icon red while recording', async () => {
+		const { updateRecordingIndicator } = await import('./background');
+
+		updateRecordingIndicator(true);
+
+		expect(chromeMock.action.setBadgeText).toHaveBeenCalledWith({ text: '•' });
+		expect(chromeMock.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#D32F2F' });
+		expect(chromeMock.action.setTitle).toHaveBeenCalledWith({
+			title: 'n8n Browser Use — Recording…',
+		});
+	});
+
+	it('restores the default badge and title once recording stops', async () => {
+		const { updateRecordingIndicator } = await import('./background');
+
+		updateRecordingIndicator(false);
+
+		// No active connection in this test, so the badge falls back to empty/disconnected.
+		expect(chromeMock.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
+		expect(chromeMock.action.setTitle).toHaveBeenCalledWith({ title: 'n8n Browser Use' });
 	});
 });
 

--- a/packages/@n8n/mcp-browser-extension/src/background.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.ts
@@ -59,9 +59,33 @@ function setDrawerEnabled(enabled: boolean): void {
 	void chrome.action.setPopup({ popup: enabled ? DRAWER_PAGE : '' });
 }
 
+// ---------------------------------------------------------------------------
+// Recording indicator — while a recording is capturing, the toolbar icon
+// turns red so the user can tell it's running without opening the popup.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TITLE = 'n8n Browser Use'; // must match manifest.json action.default_title
+const RECORDING_TITLE = 'n8n Browser Use — Recording…';
+const RECORDING_BADGE_TEXT = '•';
+const RECORDING_BADGE_COLOR = '#D32F2F';
+
+export function updateRecordingIndicator(active: boolean): void {
+	void chrome.action.setTitle({ title: active ? RECORDING_TITLE : DEFAULT_TITLE });
+	if (active) {
+		void chrome.action.setBadgeText({ text: RECORDING_BADGE_TEXT });
+		void chrome.action.setBadgeBackgroundColor({ color: RECORDING_BADGE_COLOR });
+	} else {
+		updateBadge(activeConnection?.relay.getControlledIds().length ?? 0);
+	}
+}
+
 // The disabled state persists across service-worker restarts while the pending
 // flow does not — reset on startup so the drawer can't get stuck disabled.
 setDrawerEnabled(true);
+// Same story for the badge/title: they're native state, not tied to the
+// service worker's lifetime — reset so a worker evicted mid-recording can't
+// leave the red indicator stuck on forever.
+updateRecordingIndicator(false);
 
 chrome.action.onClicked.addListener(() => {
 	void focusPendingConnectPage();
@@ -344,6 +368,7 @@ async function startRecording(): Promise<{ success: boolean; error?: string }> {
 		pendingRecordingTabIds.add(pendingTabId);
 		recordingTabIds.add(pendingTabId);
 	}
+	updateRecordingIndicator(true);
 	await Promise.all(
 		controlledTabs.map(async ({ chromeTabId }) => await injectRecorder(chromeTabId)),
 	);
@@ -382,6 +407,7 @@ async function stopRecording(): Promise<void> {
 	lastRecordingActionByTab.clear();
 	if (!recording || recording.status !== 'recording') return;
 	recording.status = 'review';
+	updateRecordingIndicator(false);
 	broadcastRecordingChange();
 }
 

--- a/packages/@n8n/mcp-browser-extension/src/background.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.ts
@@ -69,7 +69,14 @@ const RECORDING_TITLE = 'n8n Browser Use — Recording…';
 const RECORDING_BADGE_TEXT = '•';
 const RECORDING_BADGE_COLOR = '#D32F2F';
 
+// Tab lifecycle events call updateBadge() with a fresh tab count throughout a
+// recording (new tab attached, agent tab created, etc.) — this flag makes
+// updateBadge() a no-op while recording so those calls can't stomp the red
+// indicator with the tab-count badge.
+let recordingIndicatorActive = false;
+
 export function updateRecordingIndicator(active: boolean): void {
+	recordingIndicatorActive = active;
 	void chrome.action.setTitle({ title: active ? RECORDING_TITLE : DEFAULT_TITLE });
 	if (active) {
 		void chrome.action.setBadgeText({ text: RECORDING_BADGE_TEXT });
@@ -1232,7 +1239,9 @@ function broadcastStatusChange(): void {
 // Badge
 // ---------------------------------------------------------------------------
 
-function updateBadge(tabCount: number): void {
+export function updateBadge(tabCount: number): void {
+	// The recording indicator takes precedence — don't let a tab-count refresh overwrite it.
+	if (recordingIndicatorActive) return;
 	// A prompt-free connect shows no UI at all, so mark the icon even before any tab attaches.
 	const text = tabCount > 0 ? String(tabCount) : activeConnection ? '•' : '';
 	void chrome.action.setBadgeText({ text });


### PR DESCRIPTION
## Summary

While a browser recording is active, the extension's toolbar icon now
shows a red badge dot and its tooltip changes to "Recording…". This
gives the user a signal that a recording is running even when the
extension popup is closed. Today the only feedback is inside the
popup itself, so the recording state is invisible once the popup is
closed.

The indicator reuses the extension's existing badge mechanism (already
used to show connection/tab-count state) and reverts automatically as
soon as the recording stops.

Researched whether the icon can also be forced out of the "puzzle
piece" overflow menu for an unpinned extension (like some other
extensions appear to do). There is no general-purpose Chrome API for
this. The one real mechanism (`chrome.permissions.addHostAccessRequest`)
is narrowly scoped to host-permission prompts and does not apply here,
and `chrome.action.openPopup()` requires a genuine user gesture that a
remotely-triggered recording start does not have. So the badge +
tooltip is the practical ceiling: it updates instantly whenever the
icon is visible, whether pinned or opened from the overflow menu.

## How to test

1. Load the unpacked extension (`pnpm build` in
   `packages/@n8n/mcp-browser-extension`, then load `dist/` in
   `chrome://extensions`).
2. Connect the extension to an n8n instance and start a browser
   recording.
3. Confirm the toolbar icon shows a red badge, and hovering it shows
   "n8n Browser Use — Recording…" as the tooltip.
4. Stop the recording and confirm the badge/tooltip revert to the
   normal connection state.

Unit tests: `cd packages/@n8n/mcp-browser-extension && pnpm test`.

## Related Linear tickets, Github issues, and Community forum posts

Hackweek project — no Linear ticket.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

