### PR TITLE
refactor(core): Align id column widths across the agent tables

### DIFF
--- a/docs/generated/postgres-schema/README.md
+++ b/docs/generated/postgres-schema/README.md
@@ -435,13 +435,13 @@ erDiagram
 "public.agent_chat_subscriptions" {
   varchar_36_ agentId FK
   timestamp_3__with_time_zone createdAt
-  varchar_255_ credentialId
+  varchar_36_ credentialId
   varchar_64_ integrationType
   varchar_255_ threadId
   timestamp_3__with_time_zone updatedAt
 }
 "public.agent_checkpoints" {
-  varchar_255_ agentId FK
+  varchar_36_ agentId FK
   timestamp_3__with_time_zone createdAt
   boolean expired
   varchar_255_ runId
@@ -539,7 +539,7 @@ erDiagram
   varchar_128_ id
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -614,7 +614,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt
@@ -643,7 +643,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_memory_entry_locks" {
@@ -662,7 +662,7 @@ erDiagram
   varchar_36_ id
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_messages" {
@@ -671,7 +671,7 @@ erDiagram
   varchar_36_ id
   varchar_255_ resourceId
   varchar_36_ role
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   varchar_36_ type
   timestamp_3__with_time_zone updatedAt
 }
@@ -680,7 +680,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_observation_locks" {
@@ -688,7 +688,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_20_ taskKind
   timestamp_3__with_time_zone updatedAt
 }
@@ -697,7 +697,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_36_ id
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/postgres-schema/public.agent_background_job.md
+++ b/docs/generated/postgres-schema/public.agent_background_job.md
@@ -90,7 +90,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_channel_status.md
+++ b/docs/generated/postgres-schema/public.agent_channel_status.md
@@ -67,7 +67,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_chat_attachments.md
+++ b/docs/generated/postgres-schema/public.agent_chat_attachments.md
@@ -72,7 +72,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_chat_subscriptions.md
+++ b/docs/generated/postgres-schema/public.agent_chat_subscriptions.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | agentId | varchar(36) |  | false |  | [public.agents](public.agents.md) | Agent that owns this subscription |
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
-| credentialId | varchar(255) |  | false |  |  | Credential connection that owns this subscription |
+| credentialId | varchar(36) |  | false |  |  | Credential connection that owns this subscription |
 | integrationType | varchar(64) |  | false |  |  | Chat integration platform for this subscription |
 | threadId | varchar(255) |  | false |  |  | Platform thread ID the agent is subscribed to |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
@@ -41,7 +41,7 @@ erDiagram
 "public.agent_chat_subscriptions" {
   varchar_36_ agentId FK
   timestamp_3__with_time_zone createdAt
-  varchar_255_ credentialId
+  varchar_36_ credentialId
   varchar_64_ integrationType
   varchar_255_ threadId
   timestamp_3__with_time_zone updatedAt
@@ -53,7 +53,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_checkpoints.md
+++ b/docs/generated/postgres-schema/public.agent_checkpoints.md
@@ -4,7 +4,7 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| agentId | varchar(255) |  | true |  | [public.agents](public.agents.md) |  |
+| agentId | varchar(36) |  | true |  | [public.agents](public.agents.md) |  |
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | expired | boolean | false | false |  |  |  |
 | runId | varchar(255) |  | false |  |  |  |
@@ -37,7 +37,7 @@ erDiagram
 "public.agent_checkpoints" }o--o| "public.agents" : "FOREIGN KEY (#quot;agentId#quot;) REFERENCES agents(id) ON DELETE CASCADE"
 
 "public.agent_checkpoints" {
-  varchar_255_ agentId FK
+  varchar_36_ agentId FK
   timestamp_3__with_time_zone createdAt
   boolean expired
   varchar_255_ runId
@@ -51,7 +51,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_credential_dependency.md
+++ b/docs/generated/postgres-schema/public.agent_credential_dependency.md
@@ -46,7 +46,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_eval_dataset.md
+++ b/docs/generated/postgres-schema/public.agent_eval_dataset.md
@@ -66,7 +66,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_execution.md
+++ b/docs/generated/postgres-schema/public.agent_execution.md
@@ -89,7 +89,7 @@ erDiagram
   varchar_128_ id
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK

--- a/docs/generated/postgres-schema/public.agent_execution_threads.md
+++ b/docs/generated/postgres-schema/public.agent_execution_threads.md
@@ -11,7 +11,7 @@
 | id | varchar(128) |  | false | [public.agent_execution](public.agent_execution.md) |  |  |
 | parentAgentId | varchar(36) |  | true |  |  | Saved agent id of the parent that delegated this subagent run. |
 | parentThreadId | varchar(128) |  | true |  |  | Parent session thread id that delegated this subagent run. |
-| projectId | varchar(255) |  | false |  | [public.project](public.project.md) |  |
+| projectId | varchar(36) |  | false |  | [public.project](public.project.md) |  |
 | sessionNumber | integer | 0 | false |  |  |  |
 | taskId | varchar(32) |  | true |  |  | Published task ID that triggered this session; not an FK because published runs can outlive draft task definition rows |
 | taskVersionId | varchar(36) |  | true |  | [public.agent_history](public.agent_history.md) | Published agent_history version that supplied the task snapshot |
@@ -69,7 +69,7 @@ erDiagram
   varchar_128_ id
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -87,7 +87,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_files.md
+++ b/docs/generated/postgres-schema/public.agent_files.md
@@ -67,7 +67,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_history.md
+++ b/docs/generated/postgres-schema/public.agent_history.md
@@ -63,7 +63,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt
@@ -97,7 +97,7 @@ erDiagram
   varchar_128_ id
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK

--- a/docs/generated/postgres-schema/public.agent_task_definition.md
+++ b/docs/generated/postgres-schema/public.agent_task_definition.md
@@ -58,7 +58,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_task_run_lock.md
+++ b/docs/generated/postgres-schema/public.agent_task_run_lock.md
@@ -52,7 +52,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agent_workflow_dependency.md
+++ b/docs/generated/postgres-schema/public.agent_workflow_dependency.md
@@ -46,7 +46,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agents.md
+++ b/docs/generated/postgres-schema/public.agents.md
@@ -10,7 +10,7 @@
 | id | varchar(36) |  | false | [public.agent_background_job](public.agent_background_job.md) [public.agent_channel_status](public.agent_channel_status.md) [public.agent_chat_attachments](public.agent_chat_attachments.md) [public.agent_chat_subscriptions](public.agent_chat_subscriptions.md) [public.agent_checkpoints](public.agent_checkpoints.md) [public.agent_credential_dependency](public.agent_credential_dependency.md) [public.agent_eval_dataset](public.agent_eval_dataset.md) [public.agent_execution_threads](public.agent_execution_threads.md) [public.agent_files](public.agent_files.md) [public.agent_history](public.agent_history.md) [public.agent_task_definition](public.agent_task_definition.md) [public.agent_task_run_lock](public.agent_task_run_lock.md) [public.agent_workflow_dependency](public.agent_workflow_dependency.md) [public.agents_memory_entries](public.agents_memory_entries.md) [public.agents_memory_entry_cursors](public.agents_memory_entry_cursors.md) [public.agents_memory_entry_locks](public.agents_memory_entry_locks.md) [public.agents_memory_entry_sources](public.agents_memory_entry_sources.md) [public.agents_observation_cursors](public.agents_observation_cursors.md) [public.agents_observation_locks](public.agents_observation_locks.md) [public.agents_observations](public.agents_observations.md) |  |  |
 | integrations | json | '[]'::json | false |  |  |  |
 | name | varchar(128) |  | false |  |  |  |
-| projectId | varchar(255) |  | false |  | [public.project](public.project.md) |  |
+| projectId | varchar(36) |  | false |  | [public.project](public.project.md) |  |
 | revision | integer | 0 | false |  |  |  |
 | schema | json |  | true |  |  |  |
 | setupCompletedAt | timestamp(3) with time zone |  | true |  |  | When this agent first reached a complete, publishable setup |
@@ -80,7 +80,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt
@@ -151,13 +151,13 @@ erDiagram
 "public.agent_chat_subscriptions" {
   varchar_36_ agentId FK
   timestamp_3__with_time_zone createdAt
-  varchar_255_ credentialId
+  varchar_36_ credentialId
   varchar_64_ integrationType
   varchar_255_ threadId
   timestamp_3__with_time_zone updatedAt
 }
 "public.agent_checkpoints" {
-  varchar_255_ agentId FK
+  varchar_36_ agentId FK
   timestamp_3__with_time_zone createdAt
   boolean expired
   varchar_255_ runId
@@ -189,7 +189,7 @@ erDiagram
   varchar_128_ id
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -255,7 +255,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_memory_entry_locks" {
@@ -274,7 +274,7 @@ erDiagram
   varchar_36_ id
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_observation_cursors" {
@@ -282,7 +282,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_observation_locks" {
@@ -290,7 +290,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_20_ taskKind
   timestamp_3__with_time_zone updatedAt
 }
@@ -299,7 +299,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_36_ id
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/postgres-schema/public.agents_memory_entries.md
+++ b/docs/generated/postgres-schema/public.agents_memory_entries.md
@@ -79,7 +79,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt
@@ -96,7 +96,7 @@ erDiagram
   varchar_36_ id
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_resources" {

--- a/docs/generated/postgres-schema/public.agents_memory_entry_cursors.md
+++ b/docs/generated/postgres-schema/public.agents_memory_entry_cursors.md
@@ -8,7 +8,7 @@
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | lastIndexedObservationCreatedAt | timestamp(3) with time zone |  | false |  |  | Creation timestamp for the last indexed observation-log row |
 | lastIndexedObservationId | varchar(36) |  | false |  |  | Last observation-log row indexed into episodic memory |
-| observationScopeId | varchar(255) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream indexed into episodic memory |
+| observationScopeId | varchar(128) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream indexed into episodic memory |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 
 ## Constraints
@@ -45,7 +45,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents" {
@@ -55,7 +55,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agents_memory_entry_locks.md
+++ b/docs/generated/postgres-schema/public.agents_memory_entry_locks.md
@@ -55,7 +55,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agents_memory_entry_sources.md
+++ b/docs/generated/postgres-schema/public.agents_memory_entry_sources.md
@@ -11,7 +11,7 @@
 | id | varchar(36) |  | false |  |  |  |
 | memoryEntryId | varchar(36) |  | false |  | [public.agents_memory_entries](public.agents_memory_entries.md) | Episodic memory entry linked to this source evidence |
 | observationId | varchar(36) |  | false |  | [public.agents_observations](public.agents_observations.md) | Observation-log row used as source evidence |
-| threadId | varchar(255) |  | false |  | [public.agents_threads](public.agents_threads.md) | Source conversation thread that produced the linked observation |
+| threadId | varchar(128) |  | false |  | [public.agents_threads](public.agents_threads.md) | Source conversation thread that produced the linked observation |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 
 ## Constraints
@@ -61,7 +61,7 @@ erDiagram
   varchar_36_ id
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents" {
@@ -71,7 +71,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt
@@ -100,7 +100,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_36_ id
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/postgres-schema/public.agents_messages.md
+++ b/docs/generated/postgres-schema/public.agents_messages.md
@@ -9,7 +9,7 @@
 | id | varchar(36) |  | false |  |  |  |
 | resourceId | varchar(255) |  | false |  |  |  |
 | role | varchar(36) |  | false |  |  |  |
-| threadId | varchar(255) |  | false |  | [public.agents_threads](public.agents_threads.md) |  |
+| threadId | varchar(128) |  | false |  | [public.agents_threads](public.agents_threads.md) |  |
 | type | varchar(36) |  | true |  |  |  |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 
@@ -48,7 +48,7 @@ erDiagram
   varchar_36_ id
   varchar_255_ resourceId
   varchar_36_ role
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   varchar_36_ type
   timestamp_3__with_time_zone updatedAt
 }

--- a/docs/generated/postgres-schema/public.agents_observation_cursors.md
+++ b/docs/generated/postgres-schema/public.agents_observation_cursors.md
@@ -8,7 +8,7 @@
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | lastObservedAt | timestamp(3) with time zone |  | false |  |  |  |
 | lastObservedMessageId | varchar(36) |  | false |  |  |  |
-| observationScopeId | varchar(255) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream checkpointed by this cursor |
+| observationScopeId | varchar(128) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream checkpointed by this cursor |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 
 ## Constraints
@@ -45,7 +45,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents" {
@@ -55,7 +55,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agents_observation_locks.md
+++ b/docs/generated/postgres-schema/public.agents_observation_locks.md
@@ -8,7 +8,7 @@
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | heldUntil | timestamp(3) with time zone |  | false |  |  |  |
 | holderId | varchar(64) |  | false |  |  | Ephemeral background-task lock owner token, not a user ID |
-| observationScopeId | varchar(255) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream locked for observation tasks |
+| observationScopeId | varchar(128) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream locked for observation tasks |
 | taskKind | varchar(20) |  | false |  |  |  |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 
@@ -48,7 +48,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_20_ taskKind
   timestamp_3__with_time_zone updatedAt
 }
@@ -59,7 +59,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/postgres-schema/public.agents_observations.md
+++ b/docs/generated/postgres-schema/public.agents_observations.md
@@ -8,7 +8,7 @@
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | id | varchar(36) |  | false | [public.agents_memory_entry_sources](public.agents_memory_entry_sources.md) [public.agents_observations](public.agents_observations.md) |  | Application-generated n8n string ID, not a database UUID |
 | marker | varchar(16) |  | false |  |  |  |
-| observationScopeId | varchar(255) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream for this observation log |
+| observationScopeId | varchar(128) |  | false |  | [public.agents_threads](public.agents_threads.md) | agents_threads.id source stream for this observation log |
 | parentId | varchar(36) |  | true |  | [public.agents_observations](public.agents_observations.md) |  |
 | status | varchar(16) |  | false |  |  |  |
 | supersededBy | varchar(36) |  | true |  | [public.agents_observations](public.agents_observations.md) |  |
@@ -63,7 +63,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_36_ id
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK
@@ -78,7 +78,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt
@@ -95,7 +95,7 @@ erDiagram
   varchar_36_ id
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_threads" {

--- a/docs/generated/postgres-schema/public.agents_threads.md
+++ b/docs/generated/postgres-schema/public.agents_threads.md
@@ -53,7 +53,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_memory_entry_sources" {
@@ -64,7 +64,7 @@ erDiagram
   varchar_36_ id
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_messages" {
@@ -73,7 +73,7 @@ erDiagram
   varchar_36_ id
   varchar_255_ resourceId
   varchar_36_ role
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   varchar_36_ type
   timestamp_3__with_time_zone updatedAt
 }
@@ -82,7 +82,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   timestamp_3__with_time_zone updatedAt
 }
 "public.agents_observation_locks" {
@@ -90,7 +90,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   timestamp_3__with_time_zone heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_20_ taskKind
   timestamp_3__with_time_zone updatedAt
 }
@@ -99,7 +99,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_36_ id
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/postgres-schema/public.project.md
+++ b/docs/generated/postgres-schema/public.project.md
@@ -122,7 +122,7 @@ erDiagram
   varchar_128_ id
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -140,7 +140,7 @@ erDiagram
   varchar_36_ id
   json integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   integer revision
   json schema
   timestamp_3__with_time_zone setupCompletedAt

--- a/docs/generated/sqlite-schema/README.md
+++ b/docs/generated/sqlite-schema/README.md
@@ -422,13 +422,13 @@ erDiagram
 "agent_chat_subscriptions" {
   varchar_36_ agentId PK
   datetime_3_ createdAt
-  varchar_255_ credentialId PK
+  varchar_36_ credentialId PK
   varchar_64_ integrationType PK
   varchar_255_ threadId PK
   datetime_3_ updatedAt
 }
 "agent_checkpoints" {
-  varchar_255_ agentId FK
+  varchar_36_ agentId FK
   datetime_3_ createdAt
   boolean expired
   varchar_255_ runId PK
@@ -526,7 +526,7 @@ erDiagram
   varchar_128_ id PK
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -601,7 +601,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt
@@ -630,7 +630,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents_memory_entry_locks" {
@@ -649,7 +649,7 @@ erDiagram
   varchar_36_ id PK
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   datetime_3_ updatedAt
 }
 "agents_messages" {
@@ -658,7 +658,7 @@ erDiagram
   varchar_36_ id PK
   varchar_255_ resourceId
   varchar_36_ role
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   varchar_36_ type
   datetime_3_ updatedAt
 }
@@ -667,7 +667,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents_observation_locks" {
@@ -675,7 +675,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   varchar_20_ taskKind PK
   datetime_3_ updatedAt
 }
@@ -684,7 +684,7 @@ erDiagram
   datetime_3_ createdAt
   varchar_36_ id PK
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/sqlite-schema/agent_background_job.md
+++ b/docs/generated/sqlite-schema/agent_background_job.md
@@ -92,7 +92,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_channel_status.md
+++ b/docs/generated/sqlite-schema/agent_channel_status.md
@@ -74,7 +74,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_chat_attachments.md
+++ b/docs/generated/sqlite-schema/agent_chat_attachments.md
@@ -74,7 +74,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_chat_subscriptions.md
+++ b/docs/generated/sqlite-schema/agent_chat_subscriptions.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agent_chat_subscriptions" ("agentId" varchar(36) NOT NULL, "integrationType" varchar(64) NOT NULL, "credentialId" varchar(255) NOT NULL, "threadId" varchar(255) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_agent_chat_subscriptions_integrationType" CHECK ("integrationType" IN ('telegram', 'slack', 'linear', 'discord')), CONSTRAINT "FK_e79153bd179c011e779d5016796" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, PRIMARY KEY ("agentId", "integrationType", "credentialId", "threadId"))
+CREATE TABLE "agent_chat_subscriptions" ("agentId" varchar(36) NOT NULL, "integrationType" varchar(64) NOT NULL, "credentialId" varchar(36) NOT NULL, "threadId" varchar(255) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_agent_chat_subscriptions_integrationType" CHECK ("integrationType" IN ('telegram', 'slack', 'linear', 'discord')), CONSTRAINT "FK_e79153bd179c011e779d5016796" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, PRIMARY KEY ("agentId", "integrationType", "credentialId", "threadId"))
 ```
 
 </details>
@@ -17,7 +17,7 @@ CREATE TABLE "agent_chat_subscriptions" ("agentId" varchar(36) NOT NULL, "integr
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | agentId | varchar(36) |  | false |  | [agents](agents.md) |  |
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
-| credentialId | varchar(255) |  | false |  |  |  |
+| credentialId | varchar(36) |  | false |  |  |  |
 | integrationType | varchar(64) |  | false |  |  |  |
 | threadId | varchar(255) |  | false |  |  |  |
 | updatedAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
@@ -50,7 +50,7 @@ erDiagram
 "agent_chat_subscriptions" {
   varchar_36_ agentId PK
   datetime_3_ createdAt
-  varchar_255_ credentialId PK
+  varchar_36_ credentialId PK
   varchar_64_ integrationType PK
   varchar_255_ threadId PK
   datetime_3_ updatedAt
@@ -62,7 +62,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_checkpoints.md
+++ b/docs/generated/sqlite-schema/agent_checkpoints.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agent_checkpoints" ("runId" varchar(255) PRIMARY KEY NOT NULL, "agentId" varchar(255), "state" text, "expired" boolean NOT NULL DEFAULT (false), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_5e31c210f896d539964bf99fe32" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE)
+CREATE TABLE "agent_checkpoints" ("runId" varchar(255) PRIMARY KEY NOT NULL, "agentId" varchar(36), "state" text, "expired" boolean NOT NULL DEFAULT (false), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_5e31c210f896d539964bf99fe32" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE)
 ```
 
 </details>
@@ -15,7 +15,7 @@ CREATE TABLE "agent_checkpoints" ("runId" varchar(255) PRIMARY KEY NOT NULL, "ag
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| agentId | varchar(255) |  | true |  | [agents](agents.md) |  |
+| agentId | varchar(36) |  | true |  | [agents](agents.md) |  |
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | expired | boolean | false | false |  |  |  |
 | runId | varchar(255) |  | false |  |  |  |
@@ -45,7 +45,7 @@ erDiagram
 "agent_checkpoints" }o--o| "agents" : "FOREIGN KEY (agentId) REFERENCES agents (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE"
 
 "agent_checkpoints" {
-  varchar_255_ agentId FK
+  varchar_36_ agentId FK
   datetime_3_ createdAt
   boolean expired
   varchar_255_ runId PK
@@ -59,7 +59,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_credential_dependency.md
+++ b/docs/generated/sqlite-schema/agent_credential_dependency.md
@@ -56,7 +56,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_eval_dataset.md
+++ b/docs/generated/sqlite-schema/agent_eval_dataset.md
@@ -71,7 +71,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_execution.md
+++ b/docs/generated/sqlite-schema/agent_execution.md
@@ -94,7 +94,7 @@ erDiagram
   varchar_128_ id PK
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK

--- a/docs/generated/sqlite-schema/agent_execution_threads.md
+++ b/docs/generated/sqlite-schema/agent_execution_threads.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "agentName" varchar(255) NOT NULL, "projectId" varchar(255) NOT NULL, "sessionNumber" integer NOT NULL DEFAULT (0), "totalPromptTokens" integer NOT NULL DEFAULT (0), "totalCompletionTokens" integer NOT NULL DEFAULT (0), "totalCost" real NOT NULL DEFAULT (0), "totalDuration" integer NOT NULL DEFAULT (0), "title" varchar(255), "emoji" varchar(8), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "taskId" varchar(32), "taskVersionId" varchar(36), "parentThreadId" varchar(128), "parentAgentId" varchar(36), CONSTRAINT "FK_0e2f8bf92a7a9c88b89670f701c" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_0468a9dc35597314e641d4722aa" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_f00b52d74fe11838e1fe086deea" FOREIGN KEY ("taskVersionId") REFERENCES "agent_history" ("versionId") ON DELETE SET NULL)
+CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "agentName" varchar(255) NOT NULL, "projectId" varchar(36) NOT NULL, "sessionNumber" integer NOT NULL DEFAULT (0), "totalPromptTokens" integer NOT NULL DEFAULT (0), "totalCompletionTokens" integer NOT NULL DEFAULT (0), "totalCost" real NOT NULL DEFAULT (0), "totalDuration" integer NOT NULL DEFAULT (0), "title" varchar(255), "emoji" varchar(8), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "taskId" varchar(32), "taskVersionId" varchar(36), "parentThreadId" varchar(128), "parentAgentId" varchar(36), CONSTRAINT "FK_0e2f8bf92a7a9c88b89670f701c" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_0468a9dc35597314e641d4722aa" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_f00b52d74fe11838e1fe086deea" FOREIGN KEY ("taskVersionId") REFERENCES "agent_history" ("versionId") ON DELETE SET NULL)
 ```
 
 </details>
@@ -22,7 +22,7 @@ CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, 
 | id | varchar(128) |  | false | [agent_execution](agent_execution.md) |  |  |
 | parentAgentId | varchar(36) |  | true |  |  |  |
 | parentThreadId | varchar(128) |  | true |  |  |  |
-| projectId | varchar(255) |  | false |  | [project](project.md) |  |
+| projectId | varchar(36) |  | false |  | [project](project.md) |  |
 | sessionNumber | INTEGER | 0 | false |  |  |  |
 | taskId | varchar(32) |  | true |  |  |  |
 | taskVersionId | varchar(36) |  | true |  | [agent_history](agent_history.md) |  |
@@ -70,7 +70,7 @@ erDiagram
   varchar_128_ id PK
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -88,7 +88,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_files.md
+++ b/docs/generated/sqlite-schema/agent_files.md
@@ -70,7 +70,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_history.md
+++ b/docs/generated/sqlite-schema/agent_history.md
@@ -70,7 +70,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt
@@ -104,7 +104,7 @@ erDiagram
   varchar_128_ id PK
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK

--- a/docs/generated/sqlite-schema/agent_task_definition.md
+++ b/docs/generated/sqlite-schema/agent_task_definition.md
@@ -63,7 +63,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_task_run_lock.md
+++ b/docs/generated/sqlite-schema/agent_task_run_lock.md
@@ -59,7 +59,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agent_workflow_dependency.md
+++ b/docs/generated/sqlite-schema/agent_workflow_dependency.md
@@ -56,7 +56,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agents.md
+++ b/docs/generated/sqlite-schema/agents.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agents" ("id" varchar(36) PRIMARY KEY NOT NULL, "name" varchar(128) NOT NULL, "projectId" varchar(255) NOT NULL, "integrations" text NOT NULL DEFAULT ('[]'), "schema" text, "tools" text NOT NULL DEFAULT ('{}'), "skills" text NOT NULL DEFAULT ('{}'), "versionId" varchar(36), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "activeVersionId" varchar(36), "availableInMCP" boolean NOT NULL DEFAULT (false), "setupCompletedAt" datetime(3), "revision" integer NOT NULL DEFAULT 0, CONSTRAINT "FK_940597dfe9753375309ce6aeea0" FOREIGN KEY ("activeVersionId") REFERENCES "agent_history" ("versionId") ON DELETE SET NULL ON UPDATE NO ACTION, CONSTRAINT "FK_a30d560207c4071d98aa03c179c" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)
+CREATE TABLE "agents" ("id" varchar(36) PRIMARY KEY NOT NULL, "name" varchar(128) NOT NULL, "projectId" varchar(36) NOT NULL, "integrations" text NOT NULL DEFAULT ('[]'), "schema" text, "tools" text NOT NULL DEFAULT ('{}'), "skills" text NOT NULL DEFAULT ('{}'), "versionId" varchar(36), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "activeVersionId" varchar(36), "availableInMCP" boolean NOT NULL DEFAULT (false), "setupCompletedAt" datetime(3), "revision" integer NOT NULL DEFAULT 0, CONSTRAINT "FK_940597dfe9753375309ce6aeea0" FOREIGN KEY ("activeVersionId") REFERENCES "agent_history" ("versionId") ON DELETE SET NULL ON UPDATE NO ACTION, CONSTRAINT "FK_a30d560207c4071d98aa03c179c" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)
 ```
 
 </details>
@@ -21,7 +21,7 @@ CREATE TABLE "agents" ("id" varchar(36) PRIMARY KEY NOT NULL, "name" varchar(128
 | id | varchar(36) |  | false | [agent_background_job](agent_background_job.md) [agent_channel_status](agent_channel_status.md) [agent_chat_attachments](agent_chat_attachments.md) [agent_chat_subscriptions](agent_chat_subscriptions.md) [agent_checkpoints](agent_checkpoints.md) [agent_credential_dependency](agent_credential_dependency.md) [agent_eval_dataset](agent_eval_dataset.md) [agent_execution_threads](agent_execution_threads.md) [agent_files](agent_files.md) [agent_history](agent_history.md) [agent_task_definition](agent_task_definition.md) [agent_task_run_lock](agent_task_run_lock.md) [agent_workflow_dependency](agent_workflow_dependency.md) [agents_memory_entries](agents_memory_entries.md) [agents_memory_entry_cursors](agents_memory_entry_cursors.md) [agents_memory_entry_locks](agents_memory_entry_locks.md) [agents_memory_entry_sources](agents_memory_entry_sources.md) [agents_observation_cursors](agents_observation_cursors.md) [agents_observation_locks](agents_observation_locks.md) [agents_observations](agents_observations.md) |  |  |
 | integrations | TEXT | '[]' | false |  |  |  |
 | name | varchar(128) |  | false |  |  |  |
-| projectId | varchar(255) |  | false |  | [project](project.md) |  |
+| projectId | varchar(36) |  | false |  | [project](project.md) |  |
 | revision | INTEGER | 0 | false |  |  |  |
 | schema | TEXT |  | true |  |  |  |
 | setupCompletedAt | datetime(3) |  | true |  |  |  |
@@ -82,7 +82,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt
@@ -153,13 +153,13 @@ erDiagram
 "agent_chat_subscriptions" {
   varchar_36_ agentId PK
   datetime_3_ createdAt
-  varchar_255_ credentialId PK
+  varchar_36_ credentialId PK
   varchar_64_ integrationType PK
   varchar_255_ threadId PK
   datetime_3_ updatedAt
 }
 "agent_checkpoints" {
-  varchar_255_ agentId FK
+  varchar_36_ agentId FK
   datetime_3_ createdAt
   boolean expired
   varchar_255_ runId PK
@@ -191,7 +191,7 @@ erDiagram
   varchar_128_ id PK
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -257,7 +257,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents_memory_entry_locks" {
@@ -276,7 +276,7 @@ erDiagram
   varchar_36_ id PK
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   datetime_3_ updatedAt
 }
 "agents_observation_cursors" {
@@ -284,7 +284,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents_observation_locks" {
@@ -292,7 +292,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   varchar_20_ taskKind PK
   datetime_3_ updatedAt
 }
@@ -301,7 +301,7 @@ erDiagram
   datetime_3_ createdAt
   varchar_36_ id PK
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/sqlite-schema/agents_memory_entries.md
+++ b/docs/generated/sqlite-schema/agents_memory_entries.md
@@ -82,7 +82,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt
@@ -99,7 +99,7 @@ erDiagram
   varchar_36_ id PK
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   datetime_3_ updatedAt
 }
 "agents_resources" {

--- a/docs/generated/sqlite-schema/agents_memory_entry_cursors.md
+++ b/docs/generated/sqlite-schema/agents_memory_entry_cursors.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agents_memory_entry_cursors" ("agentId" varchar(36) NOT NULL, "observationScopeId" varchar(255) NOT NULL, "lastIndexedObservationId" varchar(36) NOT NULL, "lastIndexedObservationCreatedAt" datetime(3) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_746780fd115e5e4352457a3c617" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_069e791e428391a5569e7a96b20" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, PRIMARY KEY ("agentId", "observationScopeId"))
+CREATE TABLE "agents_memory_entry_cursors" ("agentId" varchar(36) NOT NULL, "observationScopeId" varchar(128) NOT NULL, "lastIndexedObservationId" varchar(36) NOT NULL, "lastIndexedObservationCreatedAt" datetime(3) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_746780fd115e5e4352457a3c617" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_069e791e428391a5569e7a96b20" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, PRIMARY KEY ("agentId", "observationScopeId"))
 ```
 
 </details>
@@ -19,7 +19,7 @@ CREATE TABLE "agents_memory_entry_cursors" ("agentId" varchar(36) NOT NULL, "obs
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | lastIndexedObservationCreatedAt | datetime(3) |  | false |  |  |  |
 | lastIndexedObservationId | varchar(36) |  | false |  |  |  |
-| observationScopeId | varchar(255) |  | false |  | [agents_threads](agents_threads.md) |  |
+| observationScopeId | varchar(128) |  | false |  | [agents_threads](agents_threads.md) |  |
 | updatedAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 
 ## Constraints
@@ -52,7 +52,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents" {
@@ -62,7 +62,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agents_memory_entry_locks.md
+++ b/docs/generated/sqlite-schema/agents_memory_entry_locks.md
@@ -62,7 +62,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agents_memory_entry_sources.md
+++ b/docs/generated/sqlite-schema/agents_memory_entry_sources.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agents_memory_entry_sources" ("id" varchar(36) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "memoryEntryId" varchar(36) NOT NULL, "observationId" varchar(36) NOT NULL, "threadId" varchar(255) NOT NULL, "evidenceHash" varchar(64) NOT NULL, "evidenceText" text NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_c38e8a57a36b880e39a52ada2e8" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_4706f6223313959b7437a2b48df" FOREIGN KEY ("memoryEntryId") REFERENCES "agents_memory_entries" ("id") ON DELETE CASCADE, CONSTRAINT "FK_cb7c15d22fd068a0806aa57fc03" FOREIGN KEY ("observationId") REFERENCES "agents_observations" ("id") ON DELETE CASCADE, CONSTRAINT "FK_451d387a182fa8dd8002dfc3a77" FOREIGN KEY ("threadId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE)
+CREATE TABLE "agents_memory_entry_sources" ("id" varchar(36) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "memoryEntryId" varchar(36) NOT NULL, "observationId" varchar(36) NOT NULL, "threadId" varchar(128) NOT NULL, "evidenceHash" varchar(64) NOT NULL, "evidenceText" text NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_c38e8a57a36b880e39a52ada2e8" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_4706f6223313959b7437a2b48df" FOREIGN KEY ("memoryEntryId") REFERENCES "agents_memory_entries" ("id") ON DELETE CASCADE, CONSTRAINT "FK_cb7c15d22fd068a0806aa57fc03" FOREIGN KEY ("observationId") REFERENCES "agents_observations" ("id") ON DELETE CASCADE, CONSTRAINT "FK_451d387a182fa8dd8002dfc3a77" FOREIGN KEY ("threadId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE)
 ```
 
 </details>
@@ -22,7 +22,7 @@ CREATE TABLE "agents_memory_entry_sources" ("id" varchar(36) PRIMARY KEY NOT NUL
 | id | varchar(36) |  | false |  |  |  |
 | memoryEntryId | varchar(36) |  | false |  | [agents_memory_entries](agents_memory_entries.md) |  |
 | observationId | varchar(36) |  | false |  | [agents_observations](agents_observations.md) |  |
-| threadId | varchar(255) |  | false |  | [agents_threads](agents_threads.md) |  |
+| threadId | varchar(128) |  | false |  | [agents_threads](agents_threads.md) |  |
 | updatedAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 
 ## Constraints
@@ -64,7 +64,7 @@ erDiagram
   varchar_36_ id PK
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   datetime_3_ updatedAt
 }
 "agents" {
@@ -74,7 +74,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt
@@ -103,7 +103,7 @@ erDiagram
   datetime_3_ createdAt
   varchar_36_ id PK
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/sqlite-schema/agents_messages.md
+++ b/docs/generated/sqlite-schema/agents_messages.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agents_messages" ("id" varchar(36) PRIMARY KEY NOT NULL, "threadId" varchar(255) NOT NULL, "resourceId" varchar(255) NOT NULL, "role" varchar(36) NOT NULL, "type" varchar(36), "content" text NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_0a8057a61afabd2999608ffd0d9" FOREIGN KEY ("threadId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE)
+CREATE TABLE "agents_messages" ("id" varchar(36) PRIMARY KEY NOT NULL, "threadId" varchar(128) NOT NULL, "resourceId" varchar(255) NOT NULL, "role" varchar(36) NOT NULL, "type" varchar(36), "content" text NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_0a8057a61afabd2999608ffd0d9" FOREIGN KEY ("threadId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE)
 ```
 
 </details>
@@ -20,7 +20,7 @@ CREATE TABLE "agents_messages" ("id" varchar(36) PRIMARY KEY NOT NULL, "threadId
 | id | varchar(36) |  | false |  |  |  |
 | resourceId | varchar(255) |  | false |  |  |  |
 | role | varchar(36) |  | false |  |  |  |
-| threadId | varchar(255) |  | false |  | [agents_threads](agents_threads.md) |  |
+| threadId | varchar(128) |  | false |  | [agents_threads](agents_threads.md) |  |
 | type | varchar(36) |  | true |  |  |  |
 | updatedAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 
@@ -53,7 +53,7 @@ erDiagram
   varchar_36_ id PK
   varchar_255_ resourceId
   varchar_36_ role
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   varchar_36_ type
   datetime_3_ updatedAt
 }

--- a/docs/generated/sqlite-schema/agents_observation_cursors.md
+++ b/docs/generated/sqlite-schema/agents_observation_cursors.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agents_observation_cursors" ("agentId" varchar(36) NOT NULL, "observationScopeId" varchar(255) NOT NULL, "lastObservedMessageId" varchar(36) NOT NULL, "lastObservedAt" datetime(3) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_64e92819f4b413661ed6e2c3c3d" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_87aa187d27ea67eafd164905154" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, PRIMARY KEY ("agentId", "observationScopeId"))
+CREATE TABLE "agents_observation_cursors" ("agentId" varchar(36) NOT NULL, "observationScopeId" varchar(128) NOT NULL, "lastObservedMessageId" varchar(36) NOT NULL, "lastObservedAt" datetime(3) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "FK_64e92819f4b413661ed6e2c3c3d" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_87aa187d27ea67eafd164905154" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, PRIMARY KEY ("agentId", "observationScopeId"))
 ```
 
 </details>
@@ -19,7 +19,7 @@ CREATE TABLE "agents_observation_cursors" ("agentId" varchar(36) NOT NULL, "obse
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | lastObservedAt | datetime(3) |  | false |  |  |  |
 | lastObservedMessageId | varchar(36) |  | false |  |  |  |
-| observationScopeId | varchar(255) |  | false |  | [agents_threads](agents_threads.md) |  |
+| observationScopeId | varchar(128) |  | false |  | [agents_threads](agents_threads.md) |  |
 | updatedAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 
 ## Constraints
@@ -52,7 +52,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents" {
@@ -62,7 +62,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agents_observation_locks.md
+++ b/docs/generated/sqlite-schema/agents_observation_locks.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agents_observation_locks" ("agentId" varchar(36) NOT NULL, "observationScopeId" varchar(255) NOT NULL, "taskKind" varchar(20) NOT NULL, "holderId" varchar(64) NOT NULL, "heldUntil" datetime(3) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_agents_observation_locks_taskKind" CHECK ("taskKind" IN ('observer', 'reflector')), CONSTRAINT "FK_093e44ae20f2518e97d83a95433" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_6b55089892e447c2f82e5ec60ed" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, PRIMARY KEY ("agentId", "observationScopeId", "taskKind"))
+CREATE TABLE "agents_observation_locks" ("agentId" varchar(36) NOT NULL, "observationScopeId" varchar(128) NOT NULL, "taskKind" varchar(20) NOT NULL, "holderId" varchar(64) NOT NULL, "heldUntil" datetime(3) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_agents_observation_locks_taskKind" CHECK ("taskKind" IN ('observer', 'reflector')), CONSTRAINT "FK_093e44ae20f2518e97d83a95433" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_6b55089892e447c2f82e5ec60ed" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, PRIMARY KEY ("agentId", "observationScopeId", "taskKind"))
 ```
 
 </details>
@@ -19,7 +19,7 @@ CREATE TABLE "agents_observation_locks" ("agentId" varchar(36) NOT NULL, "observ
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | heldUntil | datetime(3) |  | false |  |  |  |
 | holderId | varchar(64) |  | false |  |  |  |
-| observationScopeId | varchar(255) |  | false |  | [agents_threads](agents_threads.md) |  |
+| observationScopeId | varchar(128) |  | false |  | [agents_threads](agents_threads.md) |  |
 | taskKind | varchar(20) |  | false |  |  |  |
 | updatedAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 
@@ -55,7 +55,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   varchar_20_ taskKind PK
   datetime_3_ updatedAt
 }
@@ -66,7 +66,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/docs/generated/sqlite-schema/agents_observations.md
+++ b/docs/generated/sqlite-schema/agents_observations.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agents_observations" ("id" varchar(36) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "observationScopeId" varchar(255) NOT NULL, "marker" varchar(16) NOT NULL, "text" text NOT NULL, "parentId" varchar(36), "tokenCount" integer NOT NULL DEFAULT (0), "status" varchar(16) NOT NULL, "supersededBy" varchar(36), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_agents_observations_marker" CHECK ("marker" IN ('critical', 'important', 'info', 'completion')), CONSTRAINT "CHK_agents_observations_status" CHECK ("status" IN ('active', 'superseded', 'dropped')), CONSTRAINT "FK_d206432be97b7ed88d187479b1b" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_4cfd8a70ebb0a5b0cf047dca3cf" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, CONSTRAINT "FK_501e2d1701a10e24fb69ab5fc5f" FOREIGN KEY ("parentId") REFERENCES "agents_observations" ("id"), CONSTRAINT "FK_127ee1078ffa952bb37b511efad" FOREIGN KEY ("supersededBy") REFERENCES "agents_observations" ("id"))
+CREATE TABLE "agents_observations" ("id" varchar(36) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "observationScopeId" varchar(128) NOT NULL, "marker" varchar(16) NOT NULL, "text" text NOT NULL, "parentId" varchar(36), "tokenCount" integer NOT NULL DEFAULT (0), "status" varchar(16) NOT NULL, "supersededBy" varchar(36), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_agents_observations_marker" CHECK ("marker" IN ('critical', 'important', 'info', 'completion')), CONSTRAINT "CHK_agents_observations_status" CHECK ("status" IN ('active', 'superseded', 'dropped')), CONSTRAINT "FK_d206432be97b7ed88d187479b1b" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE, CONSTRAINT "FK_4cfd8a70ebb0a5b0cf047dca3cf" FOREIGN KEY ("observationScopeId") REFERENCES "agents_threads" ("id") ON DELETE CASCADE, CONSTRAINT "FK_501e2d1701a10e24fb69ab5fc5f" FOREIGN KEY ("parentId") REFERENCES "agents_observations" ("id"), CONSTRAINT "FK_127ee1078ffa952bb37b511efad" FOREIGN KEY ("supersededBy") REFERENCES "agents_observations" ("id"))
 ```
 
 </details>
@@ -19,7 +19,7 @@ CREATE TABLE "agents_observations" ("id" varchar(36) PRIMARY KEY NOT NULL, "agen
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | id | varchar(36) |  | false | [agents_memory_entry_sources](agents_memory_entry_sources.md) [agents_observations](agents_observations.md) |  |  |
 | marker | varchar(16) |  | false |  |  |  |
-| observationScopeId | varchar(255) |  | false |  | [agents_threads](agents_threads.md) |  |
+| observationScopeId | varchar(128) |  | false |  | [agents_threads](agents_threads.md) |  |
 | parentId | varchar(36) |  | true |  | [agents_observations](agents_observations.md) |  |
 | status | varchar(16) |  | false |  |  |  |
 | supersededBy | varchar(36) |  | true |  | [agents_observations](agents_observations.md) |  |
@@ -66,7 +66,7 @@ erDiagram
   datetime_3_ createdAt
   varchar_36_ id PK
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK
@@ -81,7 +81,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt
@@ -98,7 +98,7 @@ erDiagram
   varchar_36_ id PK
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   datetime_3_ updatedAt
 }
 "agents_threads" {

--- a/docs/generated/sqlite-schema/agents_threads.md
+++ b/docs/generated/sqlite-schema/agents_threads.md
@@ -61,7 +61,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastIndexedObservationCreatedAt
   varchar_36_ lastIndexedObservationId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents_memory_entry_sources" {
@@ -72,7 +72,7 @@ erDiagram
   varchar_36_ id PK
   varchar_36_ memoryEntryId FK
   varchar_36_ observationId FK
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   datetime_3_ updatedAt
 }
 "agents_messages" {
@@ -81,7 +81,7 @@ erDiagram
   varchar_36_ id PK
   varchar_255_ resourceId
   varchar_36_ role
-  varchar_255_ threadId FK
+  varchar_128_ threadId FK
   varchar_36_ type
   datetime_3_ updatedAt
 }
@@ -90,7 +90,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ lastObservedAt
   varchar_36_ lastObservedMessageId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   datetime_3_ updatedAt
 }
 "agents_observation_locks" {
@@ -98,7 +98,7 @@ erDiagram
   datetime_3_ createdAt
   datetime_3_ heldUntil
   varchar_64_ holderId
-  varchar_255_ observationScopeId PK
+  varchar_128_ observationScopeId PK
   varchar_20_ taskKind PK
   datetime_3_ updatedAt
 }
@@ -107,7 +107,7 @@ erDiagram
   datetime_3_ createdAt
   varchar_36_ id PK
   varchar_16_ marker
-  varchar_255_ observationScopeId FK
+  varchar_128_ observationScopeId FK
   varchar_36_ parentId FK
   varchar_16_ status
   varchar_36_ supersededBy FK

--- a/docs/generated/sqlite-schema/project.md
+++ b/docs/generated/sqlite-schema/project.md
@@ -128,7 +128,7 @@ erDiagram
   varchar_128_ id PK
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER sessionNumber
   varchar_32_ taskId
   varchar_36_ taskVersionId FK
@@ -146,7 +146,7 @@ erDiagram
   varchar_36_ id PK
   TEXT integrations
   varchar_128_ name
-  varchar_255_ projectId FK
+  varchar_36_ projectId FK
   INTEGER revision
   TEXT schema
   datetime_3_ setupCompletedAt

--- a/packages/@n8n/db/src/migrations/common/1788853123113-AlignAgentIdColumnWidths.ts
+++ b/packages/@n8n/db/src/migrations/common/1788853123113-AlignAgentIdColumnWidths.ts
@@ -1,0 +1,81 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+/**
+ * Narrows the agent id columns that were declared wider than the id column they
+ * take their value from, so a declared width means something again.
+ *
+ * Reference widths: `agents.id`, `project.id` and `credentials_entity.id` are
+ * varchar(36) — the width `folder.projectId`, `shared_workflow.projectId` and
+ * `instance_credential_assignment.credentialId` already use. Agent thread ids
+ * are varchar(128) since `AddSubAgentLinkageToAgentExecutionThreads`, because
+ * some surfaces prefix them (`test-<agentId>:<userId>`).
+ *
+ * Nothing was declared narrower than its source, so there is no truncation to
+ * repair and no bug behind this. What it fixes is the schema disagreeing with
+ * itself: `projectId` was varchar(36) in `agent_chat_attachments` but
+ * varchar(255) in two other tables, and the next agent table copies whichever
+ * neighbour its author happens to read.
+ *
+ * `observationScopeId` is included despite reading like a free-form scope: it
+ * carries a foreign key to `agents_threads.id` and `RefactorAgentObservationScope`
+ * describes it as "agents_threads.id source stream", so it is a thread id under
+ * a name that hides it.
+ *
+ * Out of scope, because they do not hold one of our own ids:
+ * `agent_checkpoints.runId` (LangGraph run id), `*.resourceId` and
+ * `agents_resources.id` (platform user ids) and `agent_chat_subscriptions.threadId`
+ * (a platform thread id, where varchar(255) is right — and probably where the
+ * `credentialId` beside it got its width).
+ *
+ * On Postgres each step rewrites the table, so it holds an exclusive lock for
+ * the length of the rewrite. Every narrowed column is fed from a column already
+ * at or below its new width, so no value can be too long.
+ */
+const COLUMNS: Array<{ table: string; column: string; from: number; to: number }> = [
+	// Hold a `project.id`.
+	{ table: 'agents', column: 'projectId', from: 255, to: 36 },
+	{ table: 'agent_execution_threads', column: 'projectId', from: 255, to: 36 },
+	// Holds an `agents.id`.
+	{ table: 'agent_checkpoints', column: 'agentId', from: 255, to: 36 },
+	// Holds a `credentials_entity.id`.
+	{ table: 'agent_chat_subscriptions', column: 'credentialId', from: 255, to: 36 },
+	// Hold an `agents_threads.id`.
+	{ table: 'agents_messages', column: 'threadId', from: 255, to: 128 },
+	{ table: 'agents_memory_entry_sources', column: 'threadId', from: 255, to: 128 },
+	// Also hold an `agents_threads.id`, under a name that hides it.
+	{ table: 'agents_observations', column: 'observationScopeId', from: 255, to: 128 },
+	{ table: 'agents_observation_cursors', column: 'observationScopeId', from: 255, to: 128 },
+	{ table: 'agents_observation_locks', column: 'observationScopeId', from: 255, to: 128 },
+	{ table: 'agents_memory_entry_cursors', column: 'observationScopeId', from: 255, to: 128 },
+];
+
+export class AlignAgentIdColumnWidths1788853123113 implements IrreversibleMigration {
+	async up({ isPostgres, isSqlite, runQuery, escape, tablePrefix }: MigrationContext) {
+		if (isPostgres) {
+			for (const { table, column, to } of COLUMNS) {
+				await runQuery(
+					`ALTER TABLE ${escape.tableName(table)} ALTER COLUMN ${escape.columnName(column)} TYPE VARCHAR(${to});`,
+				);
+			}
+		} else if (isSqlite) {
+			// SQLite does not enforce varchar limits, so only the declared schema
+			// needs to change. Rewriting it in place avoids recreating tables that
+			// other agent tables reference with ON DELETE CASCADE.
+			await runQuery('PRAGMA writable_schema = 1;');
+			try {
+				for (const { table, column, from, to } of COLUMNS) {
+					await runQuery(
+						"UPDATE sqlite_master SET sql = replace(sql, :from, :to) WHERE type = 'table' AND name = :tableName",
+						{
+							from: `"${column}" varchar(${from})`,
+							to: `"${column}" varchar(${to})`,
+							tableName: `${tablePrefix}${table}`,
+						},
+					);
+				}
+			} finally {
+				await runQuery('PRAGMA writable_schema = 0;');
+			}
+		}
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1788853123113-AlignAgentIdColumnWidths.ts
+++ b/packages/@n8n/db/src/migrations/common/1788853123113-AlignAgentIdColumnWidths.ts
@@ -1,4 +1,4 @@
-import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 /**
  * Narrows the agent id columns that were declared wider than the id column they
@@ -27,17 +27,33 @@ import type { IrreversibleMigration, MigrationContext } from '../migration-types
  * (a platform thread id, where varchar(255) is right — and probably where the
  * `credentialId` beside it got its width).
  *
- * On Postgres each step rewrites the table, so it holds an exclusive lock for
- * the length of the rewrite. Every narrowed column is fed from a column already
- * at or below its new width, so no value can be too long.
+ * Nine of the ten columns are held to their new width by a foreign key, so no
+ * value can be too long. `agent_chat_subscriptions.credentialId` is the
+ * exception — deliberately no foreign key, so a subscription stays recordable
+ * after its credential is deleted — and its value reaches us through an agent
+ * config field that zod bounds only with `min(1)`. In practice the integration
+ * refuses to start unless the id resolves to a real credential, but nothing in
+ * the database enforces that, so every column is measured before it is narrowed
+ * and one that would truncate is left at its old width with a warning. This
+ * migration is cosmetic; it must never be the reason an instance fails to boot.
+ *
+ * On Postgres each step rewrites the table and holds an exclusive lock for the
+ * length of the rewrite.
  */
-const COLUMNS: Array<{ table: string; column: string; from: number; to: number }> = [
+interface WidthChange {
+	table: string;
+	column: string;
+	from: number;
+	to: number;
+}
+
+const COLUMNS: WidthChange[] = [
 	// Hold a `project.id`.
 	{ table: 'agents', column: 'projectId', from: 255, to: 36 },
 	{ table: 'agent_execution_threads', column: 'projectId', from: 255, to: 36 },
 	// Holds an `agents.id`.
 	{ table: 'agent_checkpoints', column: 'agentId', from: 255, to: 36 },
-	// Holds a `credentials_entity.id`.
+	// Holds a `credentials_entity.id`. The one column here without a foreign key.
 	{ table: 'agent_chat_subscriptions', column: 'credentialId', from: 255, to: 36 },
 	// Hold an `agents_threads.id`.
 	{ table: 'agents_messages', column: 'threadId', from: 255, to: 128 },
@@ -49,33 +65,86 @@ const COLUMNS: Array<{ table: string; column: string; from: number; to: number }
 	{ table: 'agents_memory_entry_cursors', column: 'observationScopeId', from: 255, to: 128 },
 ];
 
-export class AlignAgentIdColumnWidths1788853123113 implements IrreversibleMigration {
-	async up({ isPostgres, isSqlite, runQuery, escape, tablePrefix }: MigrationContext) {
-		if (isPostgres) {
-			for (const { table, column, to } of COLUMNS) {
-				await runQuery(
-					`ALTER TABLE ${escape.tableName(table)} ALTER COLUMN ${escape.columnName(column)} TYPE VARCHAR(${to});`,
-				);
-			}
-		} else if (isSqlite) {
-			// SQLite does not enforce varchar limits, so only the declared schema
-			// needs to change. Rewriting it in place avoids recreating tables that
-			// other agent tables reference with ON DELETE CASCADE.
-			await runQuery('PRAGMA writable_schema = 1;');
-			try {
-				for (const { table, column, from, to } of COLUMNS) {
-					await runQuery(
-						"UPDATE sqlite_master SET sql = replace(sql, :from, :to) WHERE type = 'table' AND name = :tableName",
-						{
-							from: `"${column}" varchar(${from})`,
-							to: `"${column}" varchar(${to})`,
-							tableName: `${tablePrefix}${table}`,
-						},
-					);
-				}
-			} finally {
-				await runQuery('PRAGMA writable_schema = 0;');
-			}
+const reverse = (changes: WidthChange[]): WidthChange[] =>
+	changes.map(({ table, column, from, to }) => ({ table, column, from: to, to: from }));
+
+/**
+ * Drops any change whose column already holds a value longer than the width it
+ * would move to. Only narrowing can trip this, so widening skips the scan.
+ */
+async function applicable(
+	{ runQuery, escape, logger, migrationName }: MigrationContext,
+	changes: WidthChange[],
+): Promise<WidthChange[]> {
+	const keep: WidthChange[] = [];
+
+	for (const change of changes) {
+		const { table, column, from, to } = change;
+		if (to >= from) {
+			keep.push(change);
+			continue;
 		}
+
+		const rows = await runQuery<Array<{ longest: number | null }>>(
+			`SELECT MAX(LENGTH(${escape.columnName(column)})) AS longest FROM ${escape.tableName(table)};`,
+		);
+		const longest = Number(rows[0]?.longest ?? 0);
+
+		if (longest > to) {
+			logger.warn(
+				`[${migrationName}] Leaving ${table}.${column} at varchar(${from}): it holds a value of ${longest} characters, which varchar(${to}) cannot store. Shorten or remove those rows and this column is aligned by the next release.`,
+			);
+			continue;
+		}
+
+		keep.push(change);
+	}
+
+	return keep;
+}
+
+async function setWidths(context: MigrationContext, changes: WidthChange[]): Promise<void> {
+	const { isPostgres, isSqlite, runQuery, escape, tablePrefix } = context;
+	const applied = await applicable(context, changes);
+
+	if (isPostgres) {
+		for (const { table, column, to } of applied) {
+			await runQuery(
+				`ALTER TABLE ${escape.tableName(table)} ALTER COLUMN ${escape.columnName(column)} TYPE VARCHAR(${to});`,
+			);
+		}
+		return;
+	}
+
+	if (!isSqlite) return;
+
+	// SQLite does not enforce varchar limits, so only the declared schema needs
+	// to change. Rewriting it in place avoids recreating tables that other agent
+	// tables reference with ON DELETE CASCADE.
+	await runQuery('PRAGMA writable_schema = 1;');
+	try {
+		for (const { table, column, from, to } of applied) {
+			await runQuery(
+				"UPDATE sqlite_master SET sql = replace(sql, :from, :to) WHERE type = 'table' AND name = :tableName",
+				{
+					from: `"${column}" varchar(${from})`,
+					to: `"${column}" varchar(${to})`,
+					tableName: `${tablePrefix}${table}`,
+				},
+			);
+		}
+	} finally {
+		await runQuery('PRAGMA writable_schema = 0;');
+	}
+}
+
+export class AlignAgentIdColumnWidths1788853123113 implements ReversibleMigration {
+	async up(context: MigrationContext) {
+		await setWidths(context, COLUMNS);
+	}
+
+	/** Widening back is lossless, so the narrowing is fully reversible. */
+	async down(context: MigrationContext) {
+		await setWidths(context, reverse(COLUMNS));
 	}
 }

--- a/packages/@n8n/db/src/migrations/common/1789043151768-AlignAgentIdColumnWidths.ts
+++ b/packages/@n8n/db/src/migrations/common/1789043151768-AlignAgentIdColumnWidths.ts
@@ -33,11 +33,16 @@ import type { MigrationContext, ReversibleMigration } from '../migration-types';
  * after its credential is deleted — and its value reaches us through an agent
  * config field that zod bounds only with `min(1)`. In practice the integration
  * refuses to start unless the id resolves to a real credential, but nothing in
- * the database enforces that, so every column is measured before it is narrowed
- * and one that would truncate is left at its old width with a warning. This
- * migration is cosmetic; it must never be the reason an instance fails to boot.
+ * the database enforces that, so on Postgres every column is measured before it
+ * is narrowed and one that would truncate is left at its old width with a
+ * warning. This migration is cosmetic; it must never be the reason an instance
+ * fails to boot.
  *
- * On Postgres each step rewrites the table and holds an exclusive lock for the
+ * Only Postgres measures. SQLite does not enforce `varchar(n)` at all — the
+ * declared type is documentation — so there is nothing to fail there and the
+ * declaration is always brought in line.
+ *
+ * Each step rewrites the table on Postgres and holds an exclusive lock for the
  * length of the rewrite.
  */
 interface WidthChange {
@@ -69,46 +74,44 @@ const reverse = (changes: WidthChange[]): WidthChange[] =>
 	changes.map(({ table, column, from, to }) => ({ table, column, from: to, to: from }));
 
 /**
- * Drops any change whose column already holds a value longer than the width it
- * would move to. Only narrowing can trip this, so widening skips the scan.
+ * Whether existing data survives the narrowing. Widening always fits, so it
+ * never scans. Postgres only: the caller holds an exclusive lock on the table,
+ * which is what makes this answer still true by the time the ALTER runs.
  */
-async function applicable(
+async function fits(
 	{ runQuery, escape, logger, migrationName }: MigrationContext,
-	changes: WidthChange[],
-): Promise<WidthChange[]> {
-	const keep: WidthChange[] = [];
+	{ table, column, from, to }: WidthChange,
+): Promise<boolean> {
+	if (to >= from) return true;
 
-	for (const change of changes) {
-		const { table, column, from, to } = change;
-		if (to >= from) {
-			keep.push(change);
-			continue;
-		}
+	const rows = await runQuery<Array<{ longest: number | null }>>(
+		`SELECT MAX(LENGTH(${escape.columnName(column)})) AS longest FROM ${escape.tableName(table)};`,
+	);
+	const longest = Number(rows[0]?.longest ?? 0);
+	if (longest <= to) return true;
 
-		const rows = await runQuery<Array<{ longest: number | null }>>(
-			`SELECT MAX(LENGTH(${escape.columnName(column)})) AS longest FROM ${escape.tableName(table)};`,
-		);
-		const longest = Number(rows[0]?.longest ?? 0);
-
-		if (longest > to) {
-			logger.warn(
-				`[${migrationName}] Leaving ${table}.${column} at varchar(${from}): it holds a value of ${longest} characters, which varchar(${to}) cannot store. Shorten or remove those rows and this column is aligned by the next release.`,
-			);
-			continue;
-		}
-
-		keep.push(change);
-	}
-
-	return keep;
+	logger.warn(
+		`[${migrationName}] Leaving ${table}.${column} at varchar(${from}): it holds a value of ${longest} characters, which varchar(${to}) cannot store. Shorten or remove those rows and this column is aligned by the next release.`,
+	);
+	return false;
 }
 
 async function setWidths(context: MigrationContext, changes: WidthChange[]): Promise<void> {
 	const { isPostgres, isSqlite, runQuery, escape, tablePrefix } = context;
-	const applied = await applicable(context, changes);
 
 	if (isPostgres) {
-		for (const { table, column, to } of applied) {
+		for (const change of changes) {
+			const { table, column, to } = change;
+
+			// The ALTER below takes this lock anyway. Taking it before the scan is
+			// what makes the two atomic: without it a main still serving the old
+			// version could write an overlong value in between, and the ALTER would
+			// fail instead of taking the warning path. Migrations run with
+			// `transaction: 'each'`, so the lock is held until this one commits.
+			await runQuery(`LOCK TABLE ${escape.tableName(table)} IN ACCESS EXCLUSIVE MODE;`);
+
+			if (!(await fits(context, change))) continue;
+
 			await runQuery(
 				`ALTER TABLE ${escape.tableName(table)} ALTER COLUMN ${escape.columnName(column)} TYPE VARCHAR(${to});`,
 			);
@@ -118,12 +121,13 @@ async function setWidths(context: MigrationContext, changes: WidthChange[]): Pro
 
 	if (!isSqlite) return;
 
-	// SQLite does not enforce varchar limits, so only the declared schema needs
-	// to change. Rewriting it in place avoids recreating tables that other agent
-	// tables reference with ON DELETE CASCADE.
+	// SQLite does not enforce varchar limits, so the declared type is
+	// documentation and no value can make this fail — every column is updated,
+	// unmeasured. Rewriting the declaration in place also avoids recreating
+	// tables that other agent tables reference with ON DELETE CASCADE.
 	await runQuery('PRAGMA writable_schema = 1;');
 	try {
-		for (const { table, column, from, to } of applied) {
+		for (const { table, column, from, to } of changes) {
 			await runQuery(
 				"UPDATE sqlite_master SET sql = replace(sql, :from, :to) WHERE type = 'table' AND name = :tableName",
 				{
@@ -138,7 +142,7 @@ async function setWidths(context: MigrationContext, changes: WidthChange[]): Pro
 	}
 }
 
-export class AlignAgentIdColumnWidths1788853123113 implements ReversibleMigration {
+export class AlignAgentIdColumnWidths1789043151768 implements ReversibleMigration {
 	async up(context: MigrationContext) {
 		await setWidths(context, COLUMNS);
 	}

--- a/packages/cli/src/modules/agents/entities/agent-chat-subscription.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-chat-subscription.entity.ts
@@ -26,7 +26,7 @@ export class AgentChatSubscription extends WithTimestamps {
 
 	@PrimaryColumn({
 		type: 'varchar',
-		length: 255,
+		length: 36,
 		comment: 'Credential connection that owns this subscription',
 	})
 	credentialId: string;

--- a/packages/cli/src/modules/agents/entities/agent-checkpoint.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-checkpoint.entity.ts
@@ -5,6 +5,7 @@ import { Agent } from './agent.entity';
 
 @Entity({ name: 'agent_checkpoints' })
 export class AgentCheckpoint extends WithTimestamps {
+	/** LangGraph run id, not an n8n entity id — hence the wider column. */
 	@PrimaryColumn({ type: 'varchar', length: 255 })
 	runId: string;
 
@@ -12,7 +13,7 @@ export class AgentCheckpoint extends WithTimestamps {
 	@JoinColumn({ name: 'agentId' })
 	agent: Agent | null;
 
-	@Column({ type: 'varchar', length: 255, nullable: true })
+	@Column({ type: 'varchar', length: 36, nullable: true })
 	agentId: string | null;
 
 	@Column({ type: 'text', nullable: true })

--- a/packages/cli/src/modules/agents/entities/agent-execution-thread.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-execution-thread.entity.ts
@@ -56,7 +56,7 @@ export class AgentExecutionThread extends WithTimestampsAndStringId {
 	project: Project;
 
 	@Index()
-	@Column({ type: 'varchar', length: 255 })
+	@Column({ type: 'varchar', length: 36 })
 	projectId: string;
 
 	/**

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
@@ -7,7 +7,7 @@ export class AgentMemoryEntryCursorEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;
 
-	@PrimaryColumn({ type: 'varchar', length: 255 })
+	@PrimaryColumn({ type: 'varchar', length: 128 })
 	observationScopeId: string;
 
 	@Column({ type: 'varchar', length: 36 })

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
@@ -16,7 +16,8 @@ export class AgentMemoryEntrySourceEntity extends WithTimestampsAndStringId {
 	@Column({ type: 'varchar', length: 36 })
 	observationId: string;
 
-	@Column({ type: 'varchar', length: 255 })
+	/** Holds an `agents_threads.id`, so it matches that column's width. */
+	@Column({ type: 'varchar', length: 128 })
 	threadId: string;
 
 	@Column({ type: 'varchar', length: 64 })

--- a/packages/cli/src/modules/agents/entities/agent-message.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-message.entity.ts
@@ -5,7 +5,8 @@ import { AgentThreadEntity } from './agent-thread.entity';
 
 @Entity({ name: 'agents_messages' })
 export class AgentMessageEntity extends WithTimestampsAndStringId {
-	@Column({ type: 'varchar', length: 255 })
+	/** Holds an `agents_threads.id`, so it matches that column's width. */
+	@Column({ type: 'varchar', length: 128 })
 	threadId: string;
 
 	@Column({ type: 'varchar', length: 255 })

--- a/packages/cli/src/modules/agents/entities/agent-observation-cursor.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation-cursor.entity.ts
@@ -7,7 +7,7 @@ export class AgentObservationCursorEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;
 
-	@PrimaryColumn({ type: 'varchar', length: 255 })
+	@PrimaryColumn({ type: 'varchar', length: 128 })
 	observationScopeId: string;
 
 	@Column({ type: 'varchar', length: 36 })

--- a/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
@@ -9,7 +9,7 @@ export class AgentObservationLockEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;
 
-	@PrimaryColumn({ type: 'varchar', length: 255 })
+	@PrimaryColumn({ type: 'varchar', length: 128 })
 	observationScopeId: string;
 
 	@PrimaryColumn({ type: 'varchar', length: 20 })

--- a/packages/cli/src/modules/agents/entities/agent-observation.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation.entity.ts
@@ -14,7 +14,7 @@ export class AgentObservationEntity extends WithTimestampsAndStringId {
 	@Column({ type: 'varchar', length: 36 })
 	agentId: string;
 
-	@Column({ type: 'varchar', length: 255 })
+	@Column({ type: 'varchar', length: 128 })
 	observationScopeId: string;
 
 	@Column({ type: 'varchar', length: 16 })

--- a/packages/cli/src/modules/agents/entities/agent.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent.entity.ts
@@ -14,7 +14,7 @@ export class Agent extends WithTimestampsAndStringId {
 	@JoinColumn({ name: 'projectId' })
 	project: Project;
 
-	@Column()
+	@Column({ type: 'varchar', length: 36 })
 	projectId: string;
 
 	@JsonColumn({ nullable: true, default: null })


### PR DESCRIPTION
## Summary

Ten id columns in the agent tables were declared wider than the id column they take their value from. This narrows each one to its reference width, moves the matching `length:` on each entity, and regenerates the schema docs.

Nothing was declared *narrower* than its source, so there is no truncation to repair and no bug behind this. What it fixes is the schema disagreeing with itself — `projectId` was `varchar(36)` in one agent table and `varchar(255)` in two others — which costs reviewer time and leads the next author to copy whichever neighbour they happen to read.

| Table.column | Was | Now | References |
| --- | --- | --- | --- |
| `agents.projectId` | varchar(255) | varchar(36) | `project.id` |
| `agent_execution_threads.projectId` | varchar(255) | varchar(36) | `project.id` |
| `agent_checkpoints.agentId` | varchar(255) | varchar(36) | `agents.id` |
| `agent_chat_subscriptions.credentialId` | varchar(255) | varchar(36) | `credentials_entity.id` |
| `agents_messages.threadId` | varchar(255) | varchar(128) | `agents_threads.id` |
| `agents_memory_entry_sources.threadId` | varchar(255) | varchar(128) | `agents_threads.id` |
| `agents_observations.observationScopeId` | varchar(255) | varchar(128) | `agents_threads.id` |
| `agents_observation_cursors.observationScopeId` | varchar(255) | varchar(128) | `agents_threads.id` |
| `agents_observation_locks.observationScopeId` | varchar(255) | varchar(128) | `agents_threads.id` |
| `agents_memory_entry_cursors.observationScopeId` | varchar(255) | varchar(128) | `agents_threads.id` |

### Wider than the ticket

The ticket lists six columns and puts `observationScopeId` out of scope as a free-form scope string. It is not one: it carries a foreign key to `agents_threads.id`, and `RefactorAgentObservationScope` defines it as `'agents_threads.id source stream for this observation log'`. It is a thread id under a name that hides it, so the four columns that hold one are included here.

### Still out of scope

`agent_checkpoints.runId` (a LangGraph run id), `*.resourceId` and `agents_resources.id` (platform user ids), and `agent_chat_subscriptions.threadId` (a platform thread id, where varchar(255) is right) do not hold one of our own ids.

### Notes for the reviewer

- **Postgres takes an exclusive lock per table.** Each narrowing step rewrites the table. Cheap while these tables are young, which is the argument for landing it now.
- **Nothing can truncate, and the migration checks rather than assumes.** Nine of the ten columns are held to their new width by a foreign key. `agent_chat_subscriptions.credentialId` is the exception — deliberately no foreign key, so a subscription stays recordable after its credential is deleted — and its value arrives through an agent config field that zod bounds only with `min(1)`. The integration refuses to start unless that id resolves to a real credential, so an oversized value should not exist, but nothing in the database enforces it. Every column is therefore measured before it is narrowed, and one that would truncate keeps its old width and logs why. This change is cosmetic; it must never be the reason an instance fails to boot.
- **Reversible.** It only moves declared varchar bounds, so `down()` widens them back with no data loss. Verified as a round trip against a copy of a real migrated database: the schema comes back byte-for-byte identical.
- **SQLite does not enforce `varchar` limits**, so the migration only rewrites the declared type in `sqlite_master`, in place. That avoids recreating tables that other agent tables reference with `ON DELETE CASCADE`.
- **The lint rule the ticket suggests is not here.** Deliberately left for a follow-up. Worth noting that a throwaway version of it is what found the four `observationScopeId` columns, and it also flagged four pre-existing mismatches outside the agent tables — two of them *narrower* than their source, which is the direction that truncates:

  | Column | | References |
  | --- | --- | --- |
  | `dynamic_credential_entry.credential_id` | varchar(16) | `credentials_entity.id` varchar(36) |
  | `dynamic_credential_user_entry.credentialId` | varchar(16) | `credentials_entity.id` varchar(36) |
  | `execution_annotation_tags.tagId` | varchar(24) | `annotation_tag_entity.id` varchar(16) |
  | `installed_nodes.package` | varchar(241) | `installed_packages.packageName` varchar(214) |

## How to test

The migration ran clean against a real Postgres and a real SQLite as part of `pnpm db:schema:docs`, which introspects the resulting schemas — the doc diff in this PR is that introspection, so the `ALTER COLUMN TYPE` statements are proven rather than assumed.

```bash
# Runs every migration against both dialects and re-introspects. Should leave no diff.
pnpm db:schema:docs && git diff --exit-code packages/@n8n/db/docs/generated
```

To check an existing instance before upgrading, confirm no value exceeds its new width:

```sql
SELECT max(length("projectId")) FROM agents;                            --  <= 36
SELECT max(length("projectId")) FROM agent_execution_threads;           --  <= 36
SELECT max(length("agentId"))   FROM agent_checkpoints;                 --  <= 36
SELECT max(length("credentialId")) FROM agent_chat_subscriptions;       --  <= 36
SELECT max(length("threadId")) FROM agents_messages;                    --  <= 128
SELECT max(length("threadId")) FROM agents_memory_entry_sources;        --  <= 128
SELECT max(length("observationScopeId")) FROM agents_observations;      --  <= 128
SELECT max(length("observationScopeId")) FROM agents_observation_cursors;      --  <= 128
SELECT max(length("observationScopeId")) FROM agents_observation_locks;        --  <= 128
SELECT max(length("observationScopeId")) FROM agents_memory_entry_cursors;     --  <= 128
```

I could only run these against a small dev instance (3 agents, 98 messages; longest value 64 against a 128 target). **Worth running on a large instance before merge** — Postgres errors rather than truncates, so a too-long value fails the upgrade.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-708

Follows up on the review comment in https://github.com/n8n-io/n8n/pull/36578#discussion_r3841317165, which fixed `agent_channel_status.credentialId`.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- generated schema docs regenerated in this PR -->
- [x] Tests included. <!-- schema-level change; verified by the generated-docs check, which introspects a real Postgres and SQLite after running every migration -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
