### PR TITLE
fix: Handle missing SharePoint list labels and unopenable Excel workbooks

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/test/transport/index.test.ts
@@ -927,4 +927,56 @@ describe('Microsoft Excel Transport', () => {
 			expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe('FileOpenUserUnauthorized', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getCredentials.mockResolvedValue({});
+		});
+
+		const request = async () =>
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/drive/items/WB/workbook/worksheets',
+				{},
+				{},
+				undefined,
+				{},
+				0,
+			);
+
+		// Graph nests the parsed body differently depending on which request helper
+		// ran, so both shapes must reach the same steer.
+		it.each([
+			['a body nested under `error`', { error: { error: { code: 'FileOpenUserUnauthorized' } } }],
+			['a bare body', { error: { code: 'FileOpenUserUnauthorized' } }],
+		])('steers to the SharePoint node for %s', async (_name, failure) => {
+			mockRequestOAuth2.mockRejectedValue(failure);
+
+			let caught: unknown;
+			try {
+				await request();
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(NodeApiError);
+			expect((caught as NodeApiError).message).toBe('Microsoft could not open this workbook');
+			expect((caught as NodeApiError).description).toContain('Microsoft Excel (SharePoint)');
+		});
+
+		it('leaves an unrelated Graph error unchanged', async () => {
+			mockRequestOAuth2.mockRejectedValue({ error: { error: { code: 'itemNotFound' } } });
+
+			let caught: unknown;
+			try {
+				await request();
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(NodeApiError);
+			expect((caught as NodeApiError).message).not.toBe('Microsoft could not open this workbook');
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/transport/index.ts
@@ -107,6 +107,17 @@ export function resolveScopeRoot(
 	return getServicePrincipalResourceRoot(target, id, this.getNode());
 }
 
+function asObject(value: unknown): JsonObject {
+	return typeof value === 'object' && value !== null ? (value as JsonObject) : {};
+}
+
+/** Graph's error code, read from either the raw body or a body nested under `error`. */
+export function graphErrorCode(error: JsonObject): string {
+	const body = asObject(error.error);
+	const code = asObject(body.error).code ?? body.code ?? error.code;
+	return typeof code === 'string' ? code : '';
+}
+
 // `itemIndex` is REQUIRED so the compiler enforces the per-item contract: execute
 // call sites pass the loop index (batch ops pass a literal 0, matching their item-0
 // param reads); loadOptions/listSearch call sites pass a literal 0, where
@@ -166,8 +177,20 @@ export async function microsoftApiRequest(
 		}
 		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
+		const failure = error as JsonObject;
+		// Graph answers FileOpenUserUnauthorized when the Excel service refuses to open
+		// the workbook for this credential. The file's own permissions are a red herring:
+		// this node addresses workbooks under a user drive, so one that lives in a
+		// SharePoint document library stays out of reach whatever rights the account holds.
+		if (graphErrorCode(failure) === 'FileOpenUserUnauthorized') {
+			throw new NodeApiError(this.getNode(), failure, {
+				message: 'Microsoft could not open this workbook',
+				description:
+					'The Excel service refused to open the file for this credential. This node reaches workbooks in a user drive only. If the workbook is in a SharePoint document library, use the "Microsoft Excel (SharePoint)" node, which lets you choose the site and library. A file can open in Excel Online even when the credential cannot reach it.',
+			});
+		}
 		// The operation's catch stamps the failing item's index.
-		throw new NodeApiError(this.getNode(), error as JsonObject);
+		throw new NodeApiError(this.getNode(), failure);
 	}
 }
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/methods/listSearch.test.ts
@@ -532,5 +532,91 @@ describe('Microsoft SharePoint Node', () => {
 				],
 			});
 		});
+
+		// A single entry without a label used to throw
+		// "Cannot read properties of undefined (reading 'localeCompare')" from the
+		// sort comparator, which failed the whole dropdown instead of one row.
+		it('labels a site without a title by its ID instead of failing the list', async () => {
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [
+					{ id: 'mydomain.sharepoint.com,site-b,web-b', title: 'Site B' },
+					{ id: 'mydomain.sharepoint.com,site-a,web-a' },
+				],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getSites.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{
+					name: 'mydomain.sharepoint.com,site-a,web-a',
+					value: 'mydomain.sharepoint.com,site-a,web-a',
+				},
+				{ name: 'Site B', value: 'mydomain.sharepoint.com,site-b,web-b' },
+			]);
+		});
+
+		it.each([
+			['getSites', undefined],
+			['getLists', 'site'],
+			['getFolders', 'site'],
+		] as const)('returns no results when %s gets no collection back', async (method, siteParam) => {
+			if (siteParam) {
+				loadOptionsFunctions.getNodeParameter.mockReturnValueOnce(siteParam);
+			}
+			mockRequestWithAuthentication.mockReturnValue({
+				error: { code: 'invalidRequest', message: 'Bad request' },
+			});
+
+			const listSearchResult = await node.methods.listSearch[method].call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([]);
+		});
+
+		it('labels a list without a display name by its ID', async () => {
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('site');
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [{ id: 'zz-list', displayName: 'Alpha' }, { id: 'mm-list' }],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getLists.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{ name: 'Alpha', value: 'zz-list' },
+				{ name: 'mm-list', value: 'mm-list' },
+			]);
+		});
+
+		it('labels an item without a fields object by its ID', async () => {
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('site');
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('list');
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [{ id: '2', fields: { Title: 'Title 2' } }, { id: '1' }],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getItems.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{ name: '1', value: '1' },
+				{ name: 'Title 2', value: '2' },
+			]);
+		});
+
+		it('labels a file without a name by its ID', async () => {
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('site');
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('folder');
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [
+					{ id: 'file-b', name: 'file-b.txt', file: {} },
+					{ id: 'file-a', file: {} },
+				],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getFiles.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{ name: 'file-a', value: 'file-a' },
+				{ name: 'file-b.txt', value: 'file-b' },
+			]);
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v1/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v1/helpers/interfaces.ts
@@ -14,28 +14,30 @@ export interface IListColumnType {
 	};
 }
 
+// The label fields are optional: the API omits them for some entries, and a
+// single missing label used to fail the whole dropdown instead of one row.
 export interface IDriveItem {
 	id: string;
-	name: string;
+	name?: string;
 	file?: IDataObject;
 	folder?: IDataObject;
 }
 
 export interface IListItem {
 	id: string;
-	fields: {
-		Title: string;
+	fields?: {
+		Title?: string;
 	};
 }
 
 export interface IList {
 	id: string;
-	displayName: string;
+	displayName?: string;
 }
 
 export interface ISite {
 	id: string;
-	title: string;
+	title?: string;
 }
 
 export interface IErrorResponse {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v1/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v1/methods/listSearch.ts
@@ -46,12 +46,12 @@ export async function getFiles(
 		);
 	}
 
-	const items: IDriveItem[] = response.value;
+	const items: IDriveItem[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = items
 		.filter((x) => x.file)
 		.map((g) => ({
-			name: g.name,
+			name: g.name ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -95,12 +95,12 @@ export async function getFolders(
 		);
 	}
 
-	const items: IDriveItem[] = response.value;
+	const items: IDriveItem[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = items
 		.filter((x) => x.folder && (!filter || x.name?.toLowerCase()?.includes?.(filter.toLowerCase())))
 		.map((g) => ({
-			name: g.name,
+			name: g.name ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -146,11 +146,11 @@ export async function getItems(
 		);
 	}
 
-	const items: IListItem[] = response.value;
+	const items: IListItem[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = items
 		.map((g) => ({
-			name: g.fields.Title ?? g.id,
+			name: g.fields?.Title ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -194,11 +194,11 @@ export async function getLists(
 		);
 	}
 
-	const lists: IList[] = response.value;
+	const lists: IList[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = lists
 		.map((g) => ({
-			name: g.displayName,
+			name: g.displayName ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -235,11 +235,11 @@ export async function getSites(
 		response = await microsoftSharePointApiRequest.call(this, 'GET', '/sites', {}, qs);
 	}
 
-	const sites: ISite[] = response.value;
+	const sites: ISite[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = sites
 		.map((g) => ({
-			name: g.title,
+			name: g.title ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>


### PR DESCRIPTION
## Summary

Two fixes for one support escalation (ENT-416). They sit in different nodes, so the title carries no scope.

### 1. Microsoft SharePoint — a missing label fails the whole dropdown

The v1 list-search methods label each row with a field the API can omit, then sort on that label. One entry without a label makes the sort comparator throw a `TypeError`, so the dropdown fails with **"Could not load list — Cannot read properties of undefined (reading 'localeCompare')"** instead of showing the other rows.

An Enterprise customer on 2.33.7 hits this on the **Site** field. Their tenant holds at least one site with no `title`; a tenant where every site has a title never sees it.

The fix mirrors v2:

- Fall back to the entry ID when the label is absent.
- Treat a response without a `value` collection as empty.

Both guards apply to all five methods (`getSites`, `getLists`, `getItems`, `getFiles`, `getFolders`) — every one shared the same unguarded sort.

`defaultVersion` moved to 2 in 2.37.0 (#36459), but `typeVersion` is pinned for each node, so existing v1 nodes never migrate on upgrade. v1 needs the fix on its own.

### 2. Microsoft Excel — `FileOpenUserUnauthorized` reached the user raw

This node reaches workbooks under a user drive (`/me/drive` for delegated credentials, `/users/{id}/drive` or `/drives/{id}` for app-only). A workbook in a SharePoint document library stays out of reach, and Graph answers `FileOpenUserUnauthorized`.

The raw code reads as a permission problem on the file, so people check sharing, sensitivity labels, and re-upload the workbook — none of which can help. The same customer spent a support cycle doing exactly that.

The code now maps to a message that names the cause and points at the **Microsoft Excel (SharePoint)** node, which selects the site and library:

> **Microsoft could not open this workbook**
>
> The Excel service refused to open the file for this credential. This node reaches workbooks in a user drive only. If the workbook is in a SharePoint document library, use the "Microsoft Excel (SharePoint)" node, which lets you choose the site and library. A file can open in Excel Online even when the credential cannot reach it.

No behaviour change beyond the error text — every other failure passes through as before.

## How to test

```
cd packages/nodes-base && pnpm test nodes/Microsoft/SharePoint nodes/Microsoft/Excel
```

**SharePoint:** the live path needs a tenant with a title-less site, so the regression tests are the reliable check. Note that `Array.prototype.sort` skips the comparator for a single-element array — one nameless entry on its own produced a blank label rather than a crash.

**Excel:** put an `.xlsx` in a SharePoint document library, copy its driveItem ID (the Microsoft Excel (SharePoint) node's Workbook picker resolves one), paste it into the **Microsoft Excel** node's Workbook field in "By ID" mode, then open the **Sheet** dropdown. Before this change the error was the raw `FileOpenUserUnauthorized`.

The added unit tests cover both shapes Graph uses for the parsed body (nested under `error`, and bare), plus an unrelated error code passing through untouched.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-416

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)