### PR TITLE
fix(Microsoft Excel Node): Explain why Microsoft refuses to open a workbook

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/test/transport/index.test.ts
@@ -927,4 +927,56 @@ describe('Microsoft Excel Transport', () => {
 			expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe('FileOpenUserUnauthorized', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getCredentials.mockResolvedValue({});
+		});
+
+		const request = async () =>
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/drive/items/WB/workbook/worksheets',
+				{},
+				{},
+				undefined,
+				{},
+				0,
+			);
+
+		// Graph nests the parsed body differently depending on which request helper
+		// ran, so both shapes must reach the same steer.
+		it.each([
+			['a body nested under `error`', { error: { error: { code: 'FileOpenUserUnauthorized' } } }],
+			['a bare body', { error: { code: 'FileOpenUserUnauthorized' } }],
+		])('steers to the SharePoint node for %s', async (_name, failure) => {
+			mockRequestOAuth2.mockRejectedValue(failure);
+
+			let caught: unknown;
+			try {
+				await request();
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(NodeApiError);
+			expect((caught as NodeApiError).message).toBe('Microsoft could not open this workbook');
+			expect((caught as NodeApiError).description).toContain('Microsoft Excel (SharePoint)');
+		});
+
+		it('leaves an unrelated Graph error unchanged', async () => {
+			mockRequestOAuth2.mockRejectedValue({ error: { error: { code: 'itemNotFound' } } });
+
+			let caught: unknown;
+			try {
+				await request();
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(NodeApiError);
+			expect((caught as NodeApiError).message).not.toBe('Microsoft could not open this workbook');
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/transport/index.ts
@@ -107,6 +107,17 @@ export function resolveScopeRoot(
 	return getServicePrincipalResourceRoot(target, id, this.getNode());
 }
 
+function asObject(value: unknown): JsonObject {
+	return typeof value === 'object' && value !== null ? (value as JsonObject) : {};
+}
+
+/** Graph's error code, read from either the raw body or a body nested under `error`. */
+export function graphErrorCode(error: JsonObject): string {
+	const body = asObject(error.error);
+	const code = asObject(body.error).code ?? body.code ?? error.code;
+	return typeof code === 'string' ? code : '';
+}
+
 // `itemIndex` is REQUIRED so the compiler enforces the per-item contract: execute
 // call sites pass the loop index (batch ops pass a literal 0, matching their item-0
 // param reads); loadOptions/listSearch call sites pass a literal 0, where
@@ -166,8 +177,20 @@ export async function microsoftApiRequest(
 		}
 		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
+		const failure = error as JsonObject;
+		// Graph answers FileOpenUserUnauthorized when the Excel service refuses to open
+		// the workbook for this credential. The file's own permissions are a red herring:
+		// this node addresses workbooks under a user drive, so one that lives in a
+		// SharePoint document library stays out of reach whatever rights the account holds.
+		if (graphErrorCode(failure) === 'FileOpenUserUnauthorized') {
+			throw new NodeApiError(this.getNode(), failure, {
+				message: 'Microsoft could not open this workbook',
+				description:
+					'The Excel service refused to open the file for this credential. This node reaches workbooks in a user drive only. If the workbook is in a SharePoint document library, use the "Microsoft Excel (SharePoint)" node, which lets you choose the site and library. A file can open in Excel Online even when the credential cannot reach it.',
+			});
+		}
 		// The operation's catch stamps the failing item's index.
-		throw new NodeApiError(this.getNode(), error as JsonObject);
+		throw new NodeApiError(this.getNode(), failure);
 	}
 }
 


### PR DESCRIPTION
## Summary

This node reaches workbooks under a user drive (`/me/drive` for delegated credentials, `/users/{id}/drive` or `/drives/{id}` for app-only). A workbook that lives in a SharePoint document library stays out of reach, and Graph answers `FileOpenUserUnauthorized`.

That raw code reached the user unchanged. It reads as a permission problem on the file, so people go and check sharing, sensitivity labels, and re-upload the workbook — none of which can help. An Enterprise customer spent a support cycle doing exactly that.

Map the code to a message that names the cause and points to the **Microsoft Excel (SharePoint)** node, which selects the site and library:

> **Microsoft could not open this workbook**
>
> The Excel service refused to open the file for this credential. This node reaches workbooks in a user drive only. If the workbook is in a SharePoint document library, use the "Microsoft Excel (SharePoint)" node, which lets you choose the site and library. A file can open in Excel Online even when the credential cannot reach it.

No behaviour change beyond the error text — every other failure passes through as before.

## How to test

```
cd packages/nodes-base && pnpm test nodes/Microsoft/Excel
```

The added tests cover both shapes Graph uses for the parsed body (nested under `error`, and bare), plus an unrelated error code passing through untouched.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-416

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

