### PR TITLE
test: Use the hosted sandbox service when it is configured (backport to release-candidate/2.38.x)

### DIFF
--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -172,6 +172,11 @@ jobs:
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
+          # Hosted sandbox service for the instance-ai specs. When both are set the
+          # `sandbox` test service skips its local dind stack and points n8n here.
+          # Unset (fork PRs get no secrets) falls back to the local containers.
+          N8N_SANDBOX_SERVICE_URL: ${{ secrets.N8N_SANDBOX_SERVICE_URL }}
+          N8N_SANDBOX_SERVICE_API_KEY: ${{ secrets.N8N_SANDBOX_SERVICE_API_KEY }}
           N8N_TEST_ENV: ${{ inputs.n8n-env }}
 
       - name: Upload Shard Artifacts

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -224,9 +224,29 @@ jobs:
           done' > /dev/null 2>&1 &
           echo $! > eval-diag/sampler.pid
 
+      # Only needed when there's no usable hosted deployment to point at. The guard
+      # lives in the script because the `secrets` context isn't available to
+      # `step.if`. `SANDBOX_HOSTED_OK` carries the decision to the next step, so a
+      # deployment that fails the preflight is never handed to n8n.
       - name: Start sandbox service
         if: ${{ inputs.sandbox-provider == 'n8n-sandbox' }}
-        run: pnpm --filter n8n-containers services --services sandbox --network n8n-eval-net --name n8n-svc-sandbox
+        env:
+          HOSTED_SANDBOX_URL: ${{ secrets.N8N_SANDBOX_SERVICE_URL }}
+          HOSTED_SANDBOX_API_KEY: ${{ secrets.N8N_SANDBOX_SERVICE_API_KEY }}
+        run: |
+          if [ -n "$HOSTED_SANDBOX_URL" ]; then
+            # Authenticated so a revoked key fails here rather than mid-eval;
+            # /healthz is unauthenticated and would pass with a bad key.
+            if curl -fsS -m 10 -o /dev/null \
+              -H "X-Api-Key: $HOSTED_SANDBOX_API_KEY" \
+              "${HOSTED_SANDBOX_URL%/}/sandboxes"; then
+              echo "Hosted sandbox service healthy — skipping the local stack."
+              echo "SANDBOX_HOSTED_OK=true" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "::warning::Hosted sandbox service is not usable — falling back to the local sandbox stack."
+          fi
+          pnpm --filter n8n-containers services --services sandbox --network n8n-eval-net --name n8n-svc-sandbox
 
       - name: Start n8n containers
         env:
@@ -249,6 +269,8 @@ jobs:
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          HOSTED_SANDBOX_URL: ${{ secrets.N8N_SANDBOX_SERVICE_URL }}
+          HOSTED_SANDBOX_API_KEY: ${{ secrets.N8N_SANDBOX_SERVICE_API_KEY }}
           # LangSmith creds for backend thread traces, routed to the same
           # dedicated project as the eval CLI to keep the 'instance-ai' corpus clean.
           LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
@@ -264,6 +286,7 @@ jobs:
         run: |
           # Build provider-specific env args
           SANDBOX_ARGS=()
+          USE_LOCAL_SANDBOX=false
           if [ "$SANDBOX_PROVIDER" = "daytona" ]; then
             SANDBOX_ARGS+=(
               -e N8N_INSTANCE_AI_SANDBOX_PROVIDER=daytona
@@ -271,7 +294,14 @@ jobs:
               -e DAYTONA_API_URL=https://app.daytona.io/api
               -e DAYTONA_API_KEY="$DAYTONA_API_KEY"
             )
+          elif [ "$SANDBOX_HOSTED_OK" = "true" ]; then
+            SANDBOX_ARGS+=(
+              -e N8N_INSTANCE_AI_SANDBOX_PROVIDER=n8n-sandbox
+              -e N8N_SANDBOX_SERVICE_URL="$HOSTED_SANDBOX_URL"
+              -e N8N_SANDBOX_SERVICE_API_KEY="$HOSTED_SANDBOX_API_KEY"
+            )
           else
+            USE_LOCAL_SANDBOX=true
             SANDBOX_ARGS+=(
               -e N8N_INSTANCE_AI_SANDBOX_PROVIDER=n8n-sandbox
               -e N8N_SANDBOX_SERVICE_URL=http://sandbox-api:8080
@@ -279,9 +309,11 @@ jobs:
             )
           fi
 
-          # Use the eval network when sandbox service is running
+          # Only the local sandbox stack needs the shared network — a hosted
+          # deployment is reached over the default bridge, and the network is
+          # never created when the start step short-circuits.
           NETWORK_ARGS=()
-          if [ "$SANDBOX_PROVIDER" == "n8n-sandbox" ]; then
+          if [ "$USE_LOCAL_SANDBOX" = true ]; then
             NETWORK_ARGS+=(--network n8n-eval-net)
           fi
 

--- a/packages/testing/containers/service-stack.ts
+++ b/packages/testing/containers/service-stack.ts
@@ -47,9 +47,15 @@ export function collectExternalEnv(
 ): Record<string, string> {
 	const env: Record<string, string> = {};
 	for (const name of services) {
-		const result = stack.serviceResults[name];
-		if (!result) continue;
 		const service = SERVICE_REGISTRY[name];
+		const result = stack.serviceResults[name];
+		if (!result) {
+			// Nothing started because a hosted deployment stands in for it. Reuse what
+			// the stack already resolved instead of re-probing, so the .env cannot
+			// disagree with the decision the stack actually made.
+			Object.assign(env, stack.hostedServiceEnv[name] ?? {});
+			continue;
+		}
 		Object.assign(env, service.env?.(result, true) ?? {}, service.extraEnv?.(result, true) ?? {});
 	}
 	return env;

--- a/packages/testing/containers/services/sandbox.ts
+++ b/packages/testing/containers/services/sandbox.ts
@@ -19,6 +19,8 @@ const API_KEY = 'n8n-sandbox-ci-key';
 const RUNNER_API_KEY = 'ci-runner-key';
 const REGISTRATION_TOKEN = 'ci-reg-token';
 const SANDBOX_READY_TIMEOUT_MS = 120_000;
+/** Preflight only — a slow answer means fall back, not wait it out. */
+const HOSTED_HEALTH_TIMEOUT_MS = 10_000;
 const SANDBOX_READY_POLL_INTERVAL_MS = 1_000;
 const DOCKER_COMMAND_MAX_BUFFER = 10 * 1024 * 1024;
 
@@ -135,8 +137,70 @@ async function generateMtlsCerts(network: StartedNetwork, projectName: string): 
 	return tlsDir;
 }
 
+/**
+ * A deployed sandbox service, as configured in the host environment — CI passes
+ * both vars as secrets, and a local run gets the same path by exporting them.
+ * Config alone is not enough to use it: `hostedEnv` still has to reach it. With
+ * a var missing (fork PRs have no secrets) the local containers start instead.
+ */
+function hostedSandboxConfig(): SandboxMeta | undefined {
+	// Trailing slash stripped once, here: everything downstream appends `/sandboxes`
+	// and would otherwise build `//sandboxes`.
+	const apiUrl = process.env.N8N_SANDBOX_SERVICE_URL?.trim().replace(/\/+$/, '');
+	const apiKey = process.env.N8N_SANDBOX_SERVICE_API_KEY?.trim();
+	if (!apiUrl || !apiKey) return undefined;
+	return { apiUrl, apiKey };
+}
+
+/**
+ * `GET /sandboxes` is the cheapest call that proves the whole chain the tests
+ * depend on: the deployment answers from this machine, and the key resolves to
+ * a tenant. `/healthz` would be wrong here — it is unauthenticated and returns
+ * a static 200, so it passes with a revoked or misspelled key.
+ *
+ * Returns `true` when healthy, otherwise the reason to report.
+ */
+async function checkHostedSandbox(meta: SandboxMeta): Promise<true | string> {
+	try {
+		const response = await fetch(`${meta.apiUrl}/sandboxes`, {
+			headers: { 'X-Api-Key': meta.apiKey },
+			signal: AbortSignal.timeout(HOSTED_HEALTH_TIMEOUT_MS),
+		});
+		if (response.ok) return true;
+		return `HTTP ${response.status} ${(await response.text().catch(() => '')).slice(0, 200)}`.trim();
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+}
+
 export const sandbox: Service<SandboxResult> = {
 	description: 'Sandbox service (API + runner)',
+
+	async hostedEnv(): Promise<Record<string, string> | undefined> {
+		const hosted = hostedSandboxConfig();
+		if (!hosted) return undefined;
+
+		const health = await checkHostedSandbox(hosted);
+		if (health !== true) {
+			// An outage in the deployment must not turn every instance-ai spec red, so
+			// hand the run back to the local stack. Warn rather than log: the run stays
+			// green but slower, and someone still has to go look at the deployment.
+			const message = `Hosted sandbox service is not usable (${health}) — falling back to the local sandbox stack`;
+			// GitHub surfaces `::warning::` in the run summary, so the downgrade doesn't
+			// hide behind thousands of lines of test output.
+			console.warn(
+				process.env.GITHUB_ACTIONS === 'true' ? `::warning::${message}` : `⚠ ${message}`,
+			);
+			return undefined;
+		}
+
+		// One URL for both n8n-in-network and host callers — it isn't stack-local.
+		return {
+			N8N_INSTANCE_AI_SANDBOX_PROVIDER: 'n8n-sandbox',
+			N8N_SANDBOX_SERVICE_URL: hosted.apiUrl,
+			N8N_SANDBOX_SERVICE_API_KEY: hosted.apiKey,
+		};
+	},
 
 	async start(network: StartedNetwork, projectName: string): Promise<SandboxResult> {
 		const tlsDir = await generateMtlsCerts(network, projectName);

--- a/packages/testing/containers/services/types.ts
+++ b/packages/testing/containers/services/types.ts
@@ -109,6 +109,19 @@ export interface Service<TResult extends ServiceResult = ServiceResult> {
 	shouldStart?(ctx: StartContext): boolean;
 	/** @example (ctx) => ({ taskBrokerUri: `http://${ctx.projectName}-n8n:5679` }) */
 	getOptions?(ctx: StartContext): unknown;
+	/**
+	 * Env for an already-deployed instance of this service, read from the host
+	 * environment. Returning a value means the deployment stands in for the
+	 * local containers: `start()` is skipped and this env is handed to n8n
+	 * instead. Return `undefined` to fall back to the local stack.
+	 *
+	 * Implementations may probe the deployment before claiming it. They must
+	 * resolve, never reject: an unreachable deployment is `undefined` (use the
+	 * local stack), not an error that takes the whole stack down with it.
+	 *
+	 * @example async () => (await reachable()) ? { FOO_URL: process.env.FOO_URL } : undefined
+	 */
+	hostedEnv?(ctx?: StartContext): Promise<Record<string, string> | undefined>;
 	/** Starts container, returns connection details for env() */
 	start(
 		network: StartedNetwork,

--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -37,6 +37,11 @@ export interface N8NStack {
 	stop: () => Promise<void>;
 	containers: StartedTestContainer[];
 	serviceResults: Partial<Record<ServiceName, ServiceResult>>;
+	/**
+	 * Env of the services a hosted deployment stood in for, so they started no
+	 * containers and have no `serviceResults` entry. Keyed by service name.
+	 */
+	hostedServiceEnv: Partial<Record<ServiceName, Record<string, string>>>;
 	services: ServiceHelpers;
 	logs: ServiceHelpers['observability']['logs'];
 	metrics: ServiceHelpers['observability']['metrics'];
@@ -121,6 +126,7 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 
 	const containers: StartedTestContainer[] = [];
 	const serviceResults: Record<string, ServiceResult> = {};
+	const hostedServiceEnv: Partial<Record<ServiceName, Record<string, string>>> = {};
 	let environment: Record<string, string> = {};
 
 	log(`Starting: ${uniqueProjectName}`);
@@ -164,9 +170,26 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 		// Local benchmarks showed individual containers booting 2-4× faster sequentially under
 		// contention, with only modest wall-clock cost on uncontended hardware.
 		const allServiceNames = Object.keys(SERVICE_REGISTRY) as ServiceName[];
-		const servicesToStart = allServiceNames.filter((name) =>
+		const requestedServices = allServiceNames.filter((name) =>
 			shouldServiceStart(name, SERVICE_REGISTRY[name], ctx),
 		);
+
+		// A requested service that reports a healthy hosted deployment contributes its
+		// env and starts nothing. A service that declines (no config, or the
+		// deployment did not answer) falls through to its local containers below.
+		for (const name of requestedServices) {
+			const hostedEnv = await SERVICE_REGISTRY[name].hostedEnv?.(ctx);
+			if (!hostedEnv) continue;
+			environment = { ...environment, ...hostedEnv };
+			hostedServiceEnv[name] = hostedEnv;
+		}
+		const hostedServices = Object.keys(hostedServiceEnv) as ServiceName[];
+		if (hostedServices.length > 0) {
+			ctx.environment = environment;
+			log(`Using hosted: ${hostedServices.map((n) => SERVICE_REGISTRY[n].description).join(', ')}`);
+		}
+
+		const servicesToStart = requestedServices.filter((name) => !(name in hostedServiceEnv));
 		const dependencyLevels = groupByDependencyLevel(servicesToStart);
 
 		const startService = async (name: ServiceName) => {
@@ -359,6 +382,7 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 			stop: async () => await stopN8NStack(containers, network, uniqueProjectName, coverageHostDir),
 			containers,
 			serviceResults,
+			hostedServiceEnv,
 			services: servicesProxy,
 			get logs() {
 				return servicesProxy.observability.logs;

--- a/packages/testing/playwright/tests/e2e/instance-ai/README.md
+++ b/packages/testing/playwright/tests/e2e/instance-ai/README.md
@@ -4,14 +4,41 @@ These tests cover the `/instance-ai` UI and exercise the end-to-end agent flow
 (chat, tool calls, workflow preview). They're tagged
 `@capability:proxy` because the standard CI run uses a MockServer proxy to
 record/replay LLM traffic instead of hitting the real Anthropic API. The shared
-fixture also starts the sandbox service that the workflow builder requires.
+fixture also brings in the sandbox service that the workflow builder requires.
+
+### Sandbox service: hosted or local
+
+Set `N8N_SANDBOX_SERVICE_URL` and `N8N_SANDBOX_SERVICE_API_KEY` and the stack
+points n8n at that deployment and starts no sandbox containers. CI supplies both
+as repository secrets, so internal runs use the hosted service.
+
+The stack falls back to booting the local stack (cert bootstrap + API +
+privileged dind runner + image load, a couple of minutes) when either:
+
+- a var is missing — fork PRs get no secrets; or
+- the deployment fails a preflight check. Before claiming the deployment, the
+  `sandbox` service calls `GET /sandboxes` on it with a 10s timeout. Anything
+  other than a 2xx — service down, DNS failure, no egress, revoked key — means
+  the run uses local containers instead of going red. `/healthz` is deliberately
+  *not* used: it is unauthenticated and returns a static 200, so it would pass
+  with a wrong key.
+
+Nothing else changes between the two paths: the provider is `n8n-sandbox`
+either way. The stack logs which one it picked (`Using hosted: Sandbox service
+(API + runner)`), and a failed preflight prints a warning — a GitHub Actions
+`::warning::` annotation in CI, so a silent downgrade to the slow path is
+visible in the run summary.
+
+The preflight only covers stack startup. A deployment that dies mid-run still
+fails the tests it was serving; the check narrows the window, it does not close
+it.
 
 ## Two run modes
 
 ### CI / container mode (default)
 
-Spins up an n8n container plus the MockServer proxy and sandbox service. The
-proxy either:
+Spins up an n8n container plus the MockServer proxy, and wires in the sandbox
+service (hosted or local, see above). The proxy either:
 
 - **Replays** previously-recorded responses from `expectations/instance-ai/<test-slug>/`
   when no real Anthropic key is present (the default in CI).


### PR DESCRIPTION
# Description
Backport of #37297 to `release-candidate/2.38.x`. Byte-identical cherry-pick. Test infrastructure and CI workflow only, no product code.

## Why
`tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts` fails deterministically on this branch on every PR that triggers the full E2E run (four attempts on #37975, all the same). Master switched the E2E harness to the hosted sandbox service in #37297 on Sept 1. This branch was cut before that and still boots the local sandbox containers, a path master's CI no longer exercises. On the local stack the build step never produces a workflow, the replay runs out of recordings, and the spec hits its 9-minute timeout. Each failing attempt costs 9 minutes, so the shard containing the spec exceeds the 30-minute job limit and Required Checks reports `e2e: cancelled`.

Recordings, proxy service, fixtures and the spec itself are identical to master. Quarantining the test in Currents does not help: a quarantined test still runs and still costs the 9 minutes.

## What changes
With the two hosted-sandbox secrets present, the harness points n8n at the hosted sandbox service instead of starting local containers. Without them (fork PRs) it falls back to the local stack exactly as before.

## Evidence
This PR runs the full E2E suite via the `force-e2e` label. The spec passes in 37s here, same as master's nightly, with all 16 shards green and Required Checks passing. The only red job is the non-required E2E Performance shard, which only runs because this PR touches an E2E workflow file.

Related: INS-1043.