### PR TITLE
fix(editor): Show loading skeletons in the AI Assistant artifacts sidebar

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiArtifactsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiArtifactsPanel.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { fireEvent, waitFor } from '@testing-library/vue';
 import { IconBodyLoaderKey } from '@n8n/design-system';
-import { reactive, ref } from 'vue';
+import { nextTick, reactive, ref } from 'vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import type { InstanceAiAgentNode, InstanceAiHandoffContext, TaskList } from '@n8n/api-types';
+import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ResourceEntry } from '../useResourceRegistry';
 import InstanceAiArtifactsPanel from '../components/InstanceAiArtifactsPanel.vue';
 
@@ -18,6 +20,7 @@ const storeState = reactive({
 		agentTree?: InstanceAiAgentNode;
 	}>,
 	projectId: undefined as string | undefined,
+	hydrationStatus: 'ready' as 'idle' | 'hydrating' | 'ready',
 });
 const metadataState = ref<Record<string, unknown> | undefined>(undefined);
 const updateThreadMetadataMock = vi.fn(
@@ -49,9 +52,43 @@ describe('InstanceAiArtifactsPanel', () => {
 		storeState.currentTasks = undefined;
 		storeState.producedArtifacts = new Map<string, ResourceEntry>();
 		storeState.projectId = 'proj-1';
+		storeState.hydrationStatus = 'ready';
 		storeState.messages = [];
 		metadataState.value = undefined;
 		updateThreadMetadataMock.mockClear();
+		useProjectsStore().myProjects = [];
+	});
+
+	it('shows the project name once the thread project is known', () => {
+		useProjectsStore().myProjects = [
+			{ id: 'proj-1', name: 'Marketing', type: 'team', icon: { type: 'icon', value: 'layers' } },
+		] as ProjectListItem[];
+
+		const { getByText, queryByText, queryByTestId } = renderComponent();
+
+		expect(getByText('Marketing')).toBeInTheDocument();
+		expect(queryByText('Unknown project')).not.toBeInTheDocument();
+		expect(queryByTestId('instance-ai-artifacts-project-loading')).not.toBeInTheDocument();
+	});
+
+	it('shows skeletons instead of "Unknown project" and "No artifacts yet" until hydration is ready', async () => {
+		storeState.projectId = undefined;
+		storeState.hydrationStatus = 'hydrating';
+
+		const { getByTestId, queryByTestId, queryByText, getByText } = renderComponent();
+
+		expect(getByTestId('instance-ai-artifacts-project-loading')).toBeInTheDocument();
+		expect(getByTestId('instance-ai-artifacts-list-loading')).toBeInTheDocument();
+		expect(queryByText('Unknown project')).not.toBeInTheDocument();
+		expect(queryByText('No artifacts yet')).not.toBeInTheDocument();
+
+		storeState.hydrationStatus = 'ready';
+		await nextTick();
+
+		expect(queryByTestId('instance-ai-artifacts-project-loading')).not.toBeInTheDocument();
+		expect(queryByTestId('instance-ai-artifacts-list-loading')).not.toBeInTheDocument();
+		expect(getByText('Unknown project')).toBeInTheDocument();
+		expect(getByText('No artifacts yet')).toBeInTheDocument();
 	});
 
 	it('keeps the empty artifacts section visible without an empty tasks section', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiArtifactsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiArtifactsPanel.vue
@@ -6,6 +6,7 @@ import {
 	N8nHeading,
 	N8nIcon,
 	N8nIconButton,
+	N8nLoading,
 	type IconName,
 } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
@@ -27,6 +28,9 @@ const store = useInstanceAiStore();
 const i18n = useI18n();
 const thread = useThread();
 const project = computed(() => {
+	// The project id arrives with thread hydration. Until then the lookup is
+	// pending, not unknown, so the template shows a skeleton instead.
+	if (!thread.projectId && thread.hydrationStatus !== 'ready') return undefined;
 	const match = projectsStore.myProjects.find((p) => p.id === thread.projectId);
 	if (!match)
 		return {
@@ -222,11 +226,23 @@ async function dismissContext(key: string) {
 				</div>
 
 				<div :class="$style.artifactList">
-					<div :class="[$style.artifactRow]">
+					<div v-if="project" :class="[$style.artifactRow]">
 						<span :class="$style.artifactIconWrap">
 							<ProjectIcon :icon="project.icon" size="small" border-less />
 						</span>
 						<span :class="$style.artifactName">{{ project.name }}</span>
+					</div>
+					<div
+						v-else
+						:class="$style.artifactRow"
+						data-test-id="instance-ai-artifacts-project-loading"
+					>
+						<span :class="[$style.artifactIconWrap, $style.iconSkeleton]">
+							<N8nLoading variant="custom" />
+						</span>
+						<span :class="$style.nameSkeleton">
+							<N8nLoading variant="custom" />
+						</span>
 					</div>
 				</div>
 			</div>
@@ -306,6 +322,21 @@ async function dismissContext(key: string) {
 							{{ i18n.baseText('instanceAi.artifactsPanel.archived') }}
 						</span>
 					</a>
+				</div>
+
+				<div
+					v-else-if="thread.hydrationStatus !== 'ready'"
+					:class="$style.artifactList"
+					data-test-id="instance-ai-artifacts-list-loading"
+				>
+					<div :class="[$style.artifactRow, $style.artifactRowSkeleton]">
+						<span :class="[$style.artifactIconWrap, $style.artifactIconSkeleton]">
+							<N8nLoading variant="custom" />
+						</span>
+						<span :class="$style.nameSkeleton">
+							<N8nLoading variant="custom" />
+						</span>
+					</div>
 				</div>
 
 				<div v-else :class="$style.emptyState">
@@ -497,6 +528,28 @@ async function dismissContext(key: string) {
 	white-space: nowrap;
 	flex: 1;
 	min-width: 0;
+}
+
+/* Same footprint as the resolved project row (small ProjectIcon + one text line) */
+.iconSkeleton {
+	width: var(--spacing--lg);
+	height: var(--spacing--lg);
+}
+
+.nameSkeleton {
+	flex: 1;
+	max-width: 50%;
+	height: var(--font-size--sm);
+}
+
+/* Artifact rows are shorter: one text line at its line height, plus the row padding (border-box) */
+.artifactRowSkeleton {
+	min-height: calc(var(--font-size--sm) * var(--line-height--lg) + 2 * var(--spacing--2xs));
+}
+
+.artifactIconSkeleton {
+	width: var(--spacing--sm);
+	height: var(--spacing--sm);
 }
 
 .artifactRowArchived {


### PR DESCRIPTION
## Summary

When you open a chat in the AI Assistant, the artifacts sidebar showed "Unknown project" and "No artifacts yet" for a moment. The real project name and the artifacts appeared only after the thread messages loaded.

The sidebar treated a pending lookup as "not found". It now shows a skeleton row in the Project section and in the Artifacts section until the thread hydration completes. The skeleton rows have the same size as the resolved rows, so the sidebar does not jump. The text fallbacks remain for a thread that finishes loading with no project or no artifacts.

## How to test

1. Open the AI Assistant and create two chats.
2. In the browser DevTools, set the network throttling to "Slow 3G".
3. Switch from one chat to the other.
4. Check the artifacts sidebar. The Project row and the Artifacts list show gray skeleton rows. The texts "Unknown project" and "No artifacts yet" do not appear.
5. Wait for the chat to load. The project name and the artifacts replace the skeletons.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1362

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

