### PR TITLE
feat(Azure Storage Node): Add Azure cloud selection and custom endpoints to the Shared Key credential

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/security.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/security.config.test.ts
@@ -14,6 +14,18 @@ describe('SecurityConfig', () => {
 		process.env = originalEnv;
 	});
 
+	describe('azureStorageCustomEndpoints', () => {
+		test('defaults to false', () => {
+			process.env = {};
+			expect(Container.get(SecurityConfig).azureStorageCustomEndpoints).toBe(false);
+		});
+
+		test('is enabled by N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED=true', () => {
+			process.env = { N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED: 'true' };
+			expect(Container.get(SecurityConfig).azureStorageCustomEndpoints).toBe(true);
+		});
+	});
+
 	describe('awsSystemCredentialsSdkSources', () => {
 		test('defaults to "all"', () => {
 			process.env = {};

--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -162,6 +162,14 @@ export class SecurityConfig {
 	awsSystemCredentialsSdkSources: string = 'all';
 
 	/**
+	 * Whether Azure Storage Shared Key credentials can target a custom endpoint, such as a private
+	 * endpoint or a custom domain. Off by default. The Azure sovereign clouds are always available
+	 * and do not need this setting.
+	 */
+	@Env('N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED')
+	azureStorageCustomEndpoints: boolean = false;
+
+	/**
 	 * Whether to enable hooks (like pre-commit hooks) for the Git node.
 	 */
 	@Env('N8N_GIT_NODE_ENABLE_HOOKS')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -538,6 +538,7 @@ describe('GlobalConfig', () => {
 			disableBareRepos: true,
 			awsSystemCredentialsAccess: false,
 			awsSystemCredentialsSdkSources: 'all',
+			azureStorageCustomEndpoints: false,
 			enableGitNodeHooks: false,
 			enableGitNodeAllConfigKeys: false,
 			postMessageAllowedOrigins: '',

--- a/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
@@ -48,8 +48,10 @@ function assertEndpointAllowed(credentials: ICredentialDataDecryptedObject): voi
 	try {
 		endpoint = new URL(String(credentials.customEndpoint));
 	} catch {}
-	if (!endpoint || !['http:', 'https:'].includes(endpoint.protocol)) {
-		throw new UserError('Endpoint must be a full URL that starts with https://');
+	if (!endpoint || endpoint.protocol !== 'https:' || endpoint.href !== `${endpoint.origin}/`) {
+		throw new UserError(
+			'Endpoint must be an https:// URL with only a hostname and an optional port, for example https://myaccount.privatelink.blob.core.windows.net',
+		);
 	}
 }
 
@@ -120,7 +122,7 @@ export class AzureStorageSharedKeyApi implements ICredentialType {
 				},
 			},
 			description:
-				'The full URL of the storage endpoint. The account name must be in the hostname. An administrator must set <code>N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED=true</code> on this n8n instance. Endpoints with the account name in the path, such as Azurite, do not work.',
+				'The https:// URL of the storage endpoint. The account name must be in the hostname. An administrator must set <code>N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED=true</code> on this n8n instance. Endpoints with the account name in the path, such as Azurite, do not work.',
 		},
 		{
 			displayName: 'Base URL',

--- a/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
@@ -42,8 +42,12 @@ export class AzureStorageSharedKeyApi implements ICredentialType {
 		{
 			displayName: 'Base URL',
 			name: 'baseUrl',
-			type: 'hidden',
+			type: 'string',
 			default: '=https://{{ $self["account"] }}.blob.core.windows.net',
+			placeholder: 'https://myaccount.blob.core.windows.net',
+			hint: 'Replace the whole value with your endpoint URL, for example https://myaccount.blob.core.chinacloudapi.cn',
+			description:
+				'Blob service endpoint. Keep the default for the public Azure cloud. For a sovereign cloud or a private endpoint, enter the full URL with the account name in the hostname, for example https://myaccount.blob.core.chinacloudapi.cn. Endpoints with the account name in the path, such as Azurite, do not work.',
 		},
 	];
 

--- a/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/AzureStorageSharedKeyApi.credentials.ts
@@ -1,3 +1,5 @@
+import { SecurityConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialTestRequest,
@@ -5,6 +7,7 @@ import type {
 	IHttpRequestOptions,
 	INodeProperties,
 } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 import { createHmac } from 'node:crypto';
 
 import {
@@ -13,6 +16,42 @@ import {
 	HeaderConstants,
 	XMsVersion,
 } from '../nodes/Microsoft/Storage/GenericFunctions';
+
+const AZURE_CLOUD_SUFFIXES = [
+	'blob.core.windows.net',
+	'blob.core.usgovcloudapi.net',
+	'blob.core.chinacloudapi.cn',
+];
+
+function assertEndpointAllowed(credentials: ICredentialDataDecryptedObject): void {
+	if (!/^[a-z0-9]+$/i.test(String(credentials.account ?? ''))) {
+		throw new UserError('The account name can contain only letters and numbers.');
+	}
+
+	const environment = credentials.environment ?? AZURE_CLOUD_SUFFIXES[0];
+	if (environment !== 'custom') {
+		if (!AZURE_CLOUD_SUFFIXES.includes(String(environment))) {
+			throw new UserError('Select an Azure cloud from the list.');
+		}
+		return;
+	}
+
+	if (!Container.get(SecurityConfig).azureStorageCustomEndpoints) {
+		throw new UserError(
+			'Custom Azure Storage endpoints are disabled on this instance, contact your administrator.',
+		);
+	}
+	if (!credentials.customEndpoint) {
+		throw new UserError('Endpoint is required when Azure Cloud is set to Custom.');
+	}
+	let endpoint: URL | undefined;
+	try {
+		endpoint = new URL(String(credentials.customEndpoint));
+	} catch {}
+	if (!endpoint || !['http:', 'https:'].includes(endpoint.protocol)) {
+		throw new UserError('Endpoint must be a full URL that starts with https://');
+	}
+}
 
 export class AzureStorageSharedKeyApi implements ICredentialType {
 	name = 'azureStorageSharedKeyApi';
@@ -40,14 +79,55 @@ export class AzureStorageSharedKeyApi implements ICredentialType {
 			default: '',
 		},
 		{
+			displayName: 'Azure Cloud',
+			name: 'environment',
+			type: 'options',
+			options: [
+				{
+					name: 'Azure Public Cloud',
+					value: 'blob.core.windows.net',
+					description: 'Uses <code>blob.core.windows.net</code>',
+				},
+				{
+					name: 'Azure US Government',
+					value: 'blob.core.usgovcloudapi.net',
+					description: 'Uses <code>blob.core.usgovcloudapi.net</code>',
+				},
+				{
+					name: 'Azure China',
+					value: 'blob.core.chinacloudapi.cn',
+					description: 'Uses <code>blob.core.chinacloudapi.cn</code>',
+				},
+				{
+					name: 'Custom',
+					value: 'custom',
+					description:
+						'A private endpoint or a custom domain. An administrator must enable custom endpoints on this n8n instance.',
+				},
+			],
+			default: 'blob.core.windows.net',
+		},
+		{
+			displayName: 'Endpoint',
+			name: 'customEndpoint',
+			type: 'string',
+			default: '',
+			required: true,
+			placeholder: 'https://myaccount.privatelink.blob.core.windows.net',
+			displayOptions: {
+				show: {
+					environment: ['custom'],
+				},
+			},
+			description:
+				'The full URL of the storage endpoint. The account name must be in the hostname. An administrator must set <code>N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED=true</code> on this n8n instance. Endpoints with the account name in the path, such as Azurite, do not work.',
+		},
+		{
 			displayName: 'Base URL',
 			name: 'baseUrl',
-			type: 'string',
-			default: '=https://{{ $self["account"] }}.blob.core.windows.net',
-			placeholder: 'https://myaccount.blob.core.windows.net',
-			hint: 'Replace the whole value with your endpoint URL, for example https://myaccount.blob.core.chinacloudapi.cn',
-			description:
-				'Blob service endpoint. Keep the default for the public Azure cloud. For a sovereign cloud or a private endpoint, enter the full URL with the account name in the hostname, for example https://myaccount.blob.core.chinacloudapi.cn. Endpoints with the account name in the path, such as Azurite, do not work.',
+			type: 'hidden',
+			default:
+				'={{ $self["environment"] === "custom" ? $self["customEndpoint"] : "https://" + $self["account"] + "." + $self["environment"] }}',
 		},
 	];
 
@@ -55,6 +135,8 @@ export class AzureStorageSharedKeyApi implements ICredentialType {
 		credentials: ICredentialDataDecryptedObject,
 		requestOptions: IHttpRequestOptions,
 	): Promise<IHttpRequestOptions> {
+		assertEndpointAllowed(credentials);
+
 		if (requestOptions.qs) {
 			for (const [key, value] of Object.entries(requestOptions.qs)) {
 				if (value === undefined) {

--- a/packages/nodes-base/credentials/test/AzureStorageSharedKeyApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/AzureStorageSharedKeyApi.credentials.test.ts
@@ -206,16 +206,19 @@ describe('AzureStorageSharedKeyApi Credential', () => {
 			);
 		});
 
-		it('should sign a custom endpoint request when the instance allows it', async () => {
-			securityConfig.azureStorageCustomEndpoints = true;
+		it.each([privateEndpoint, `${privateEndpoint}/`, 'https://myaccount.example.com:10000'])(
+			'should sign a request to the custom endpoint %j when the instance allows it',
+			async (customEndpoint) => {
+				securityConfig.azureStorageCustomEndpoints = true;
 
-			const result = await credential.authenticate(
-				custom(privateEndpoint),
-				listBlobsRequest(privateEndpoint),
-			);
+				const result = await credential.authenticate(
+					custom(customEndpoint),
+					listBlobsRequest(customEndpoint),
+				);
 
-			expect(result.headers?.[HeaderConstants.AUTHORIZATION]).toBe(publicCloudSignature);
-		});
+				expect(result.headers?.[HeaderConstants.AUTHORIZATION]).toBe(publicCloudSignature);
+			},
+		);
 
 		it('should require an endpoint for a custom cloud', async () => {
 			securityConfig.azureStorageCustomEndpoints = true;
@@ -231,21 +234,26 @@ describe('AzureStorageSharedKeyApi Credential', () => {
 			);
 		});
 
-		it.each(['myaccount.privatelink.blob.core.windows.net', 'ftp://myaccount.example.com'])(
-			'should reject the endpoint %j',
-			async (customEndpoint) => {
-				securityConfig.azureStorageCustomEndpoints = true;
+		it.each([
+			'myaccount.privatelink.blob.core.windows.net',
+			'ftp://myaccount.example.com',
+			'http://myaccount.example.com',
+			'https://user:pass@myaccount.example.com',
+			'https://myaccount.example.com/devstoreaccount1',
+			'https://myaccount.example.com/?x=1',
+			'https://myaccount.example.com/#fragment',
+		])('should reject the endpoint %j', async (customEndpoint) => {
+			securityConfig.azureStorageCustomEndpoints = true;
 
-				const request = credential.authenticate(
-					custom(customEndpoint),
-					listBlobsRequest('https://myaccount.blob.core.windows.net'),
-				);
+			const request = credential.authenticate(
+				custom(customEndpoint),
+				listBlobsRequest('https://myaccount.blob.core.windows.net'),
+			);
 
-				await expect(request).rejects.toThrow(UserError);
-				await expect(request).rejects.toThrow(
-					'Endpoint must be a full URL that starts with https://',
-				);
-			},
-		);
+			await expect(request).rejects.toThrow(UserError);
+			await expect(request).rejects.toThrow(
+				'Endpoint must be an https:// URL with only a hostname and an optional port',
+			);
+		});
 	});
 });

--- a/packages/nodes-base/credentials/test/AzureStorageSharedKeyApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/AzureStorageSharedKeyApi.credentials.test.ts
@@ -1,0 +1,49 @@
+import type { IHttpRequestOptions } from 'n8n-workflow';
+
+import { HeaderConstants } from '../../nodes/Microsoft/Storage/GenericFunctions';
+import { AzureStorageSharedKeyApi } from '../AzureStorageSharedKeyApi.credentials';
+
+describe('AzureStorageSharedKeyApi Credential', () => {
+	const credential = new AzureStorageSharedKeyApi();
+	const property = (name: string) => credential.properties.find((p) => p.name === name);
+	const credentials = {
+		account: 'myaccount',
+		key: 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==',
+	};
+	const listBlobsRequest = (baseURL: string): IHttpRequestOptions => ({
+		method: 'GET',
+		baseURL,
+		url: '/mycontainer',
+		qs: { restype: 'container', comp: 'list' },
+		headers: { 'x-ms-date': 'Wed, 01 Jan 2025 00:00:00 GMT', 'x-ms-version': '2021-12-02' },
+	});
+
+	it('should expose the base URL as an editable field that defaults to the public cloud endpoint', () => {
+		const baseUrl = property('baseUrl');
+
+		expect(baseUrl?.type).toBe('string');
+		expect(baseUrl?.default).toBe('=https://{{ $self["account"] }}.blob.core.windows.net');
+	});
+
+	it('should test the credential against the configured base URL', () => {
+		expect(credential.test.request.baseURL).toBe('={{$credentials.baseUrl}}');
+	});
+
+	it('should sign with the account name and path, independent of the host', async () => {
+		const publicCloud = await credential.authenticate(
+			credentials,
+			listBlobsRequest('https://myaccount.blob.core.windows.net'),
+		);
+		const sovereignCloud = await credential.authenticate(
+			credentials,
+			listBlobsRequest('https://myaccount.blob.core.chinacloudapi.cn'),
+		);
+
+		expect(publicCloud.headers?.[HeaderConstants.AUTHORIZATION]).toBe(
+			'SharedKey myaccount:LTfRKI8awvSOEoMJ6moAHQKF9Rt38hRdut6PsXHhnUI=',
+		);
+		expect(sovereignCloud.headers?.[HeaderConstants.AUTHORIZATION]).toBe(
+			publicCloud.headers?.[HeaderConstants.AUTHORIZATION],
+		);
+	});
+});

--- a/packages/nodes-base/credentials/test/AzureStorageSharedKeyApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/AzureStorageSharedKeyApi.credentials.test.ts
@@ -1,15 +1,35 @@
-import type { IHttpRequestOptions } from 'n8n-workflow';
+import type {
+	ICredentialDataDecryptedObject,
+	IHttpRequestOptions,
+	INodeParameters,
+	INodeType,
+	INodeTypes,
+} from 'n8n-workflow';
+import { NodeHelpers, UserError, Workflow } from 'n8n-workflow';
 
 import { HeaderConstants } from '../../nodes/Microsoft/Storage/GenericFunctions';
 import { AzureStorageSharedKeyApi } from '../AzureStorageSharedKeyApi.credentials';
 
+const { mockContainer, MockSecurityConfig } = vi.hoisted(() => {
+	class MockSecurityConfig {
+		azureStorageCustomEndpoints = false;
+	}
+	return { mockContainer: { get: vi.fn() }, MockSecurityConfig };
+});
+
+vi.mock('@n8n/di', () => ({ Container: mockContainer }));
+vi.mock('@n8n/config', () => ({ SecurityConfig: MockSecurityConfig }));
+
 describe('AzureStorageSharedKeyApi Credential', () => {
 	const credential = new AzureStorageSharedKeyApi();
 	const property = (name: string) => credential.properties.find((p) => p.name === name);
-	const credentials = {
+	const securityConfig = new MockSecurityConfig();
+	const credentials: ICredentialDataDecryptedObject = {
 		account: 'myaccount',
 		key: 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==',
 	};
+	const privateEndpoint = 'https://myaccount.privatelink.blob.core.windows.net';
+	const publicCloudSignature = 'SharedKey myaccount:LTfRKI8awvSOEoMJ6moAHQKF9Rt38hRdut6PsXHhnUI=';
 	const listBlobsRequest = (baseURL: string): IHttpRequestOptions => ({
 		method: 'GET',
 		baseURL,
@@ -18,32 +38,214 @@ describe('AzureStorageSharedKeyApi Credential', () => {
 		headers: { 'x-ms-date': 'Wed, 01 Jan 2025 00:00:00 GMT', 'x-ms-version': '2021-12-02' },
 	});
 
-	it('should expose the base URL as an editable field that defaults to the public cloud endpoint', () => {
-		const baseUrl = property('baseUrl');
+	const nodeTypes: INodeTypes = {
+		getByName: () => ({ description: { properties: [] } }) as unknown as INodeType,
+		getByNameAndVersion: () => ({ description: { properties: [] } }) as unknown as INodeType,
+		getKnownTypes: () => ({}),
+	};
+	const resolveDefault = (expression: unknown, selfData: ICredentialDataDecryptedObject) => {
+		const workflow = new Workflow({
+			id: '1',
+			nodes: [
+				{
+					name: 'Credential',
+					type: 'n8n-nodes-base.noOp',
+					typeVersion: 1,
+					id: 'credential-1',
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: {},
+			active: false,
+			nodeTypes,
+		});
+		return workflow.expression.getComplexParameterValue(
+			workflow.getNode('Credential')!,
+			expression as string,
+			'internal',
+			{},
+			undefined,
+			undefined,
+			selfData,
+		);
+	};
 
-		expect(baseUrl?.type).toBe('string');
-		expect(baseUrl?.default).toBe('=https://{{ $self["account"] }}.blob.core.windows.net');
+	beforeEach(() => {
+		securityConfig.azureStorageCustomEndpoints = false;
+		mockContainer.get.mockReset();
+		mockContainer.get.mockReturnValue(securityConfig);
 	});
 
-	it('should test the credential against the configured base URL', () => {
-		expect(credential.test.request.baseURL).toBe('={{$credentials.baseUrl}}');
+	describe('properties', () => {
+		it('should offer the Azure clouds and a custom endpoint, defaulting to the public cloud', () => {
+			const environment = property('environment');
+
+			expect(environment?.type).toBe('options');
+			expect(environment?.default).toBe('blob.core.windows.net');
+			expect(environment?.options?.map((option) => 'value' in option && option.value)).toEqual([
+				'blob.core.windows.net',
+				'blob.core.usgovcloudapi.net',
+				'blob.core.chinacloudapi.cn',
+				'custom',
+			]);
+		});
+
+		it('should ask for the endpoint only for a custom cloud', () => {
+			const endpoint = property('customEndpoint');
+
+			expect(endpoint?.type).toBe('string');
+			expect(endpoint?.required).toBe(true);
+			expect(endpoint?.displayOptions).toEqual({ show: { environment: ['custom'] } });
+		});
+
+		it.each([
+			['blob.core.windows.net', '', 'https://myaccount.blob.core.windows.net'],
+			['blob.core.usgovcloudapi.net', '', 'https://myaccount.blob.core.usgovcloudapi.net'],
+			['blob.core.chinacloudapi.cn', '', 'https://myaccount.blob.core.chinacloudapi.cn'],
+			['custom', privateEndpoint, privateEndpoint],
+		])('should build the hidden base URL for %s', (environment, customEndpoint, expected) => {
+			const baseUrl = property('baseUrl');
+
+			expect(baseUrl?.type).toBe('hidden');
+			expect(
+				resolveDefault(baseUrl?.default, { account: 'myaccount', environment, customEndpoint }),
+			).toBe(expected);
+		});
+
+		it('should resolve a credential saved before the cloud selection existed to the public cloud', () => {
+			const stored = { account: 'myaccount', key: 'secret' };
+			const withDefaults = NodeHelpers.getNodeParameters(
+				credential.properties,
+				stored as INodeParameters,
+				true,
+				false,
+				null,
+				null,
+			) as ICredentialDataDecryptedObject;
+
+			expect(withDefaults.environment).toBe('blob.core.windows.net');
+			expect(resolveDefault(withDefaults.baseUrl, withDefaults)).toBe(
+				'https://myaccount.blob.core.windows.net',
+			);
+		});
+
+		it('should test the credential against the configured base URL', () => {
+			expect(credential.test.request.baseURL).toBe('={{$credentials.baseUrl}}');
+		});
 	});
 
-	it('should sign with the account name and path, independent of the host', async () => {
-		const publicCloud = await credential.authenticate(
-			credentials,
-			listBlobsRequest('https://myaccount.blob.core.windows.net'),
-		);
-		const sovereignCloud = await credential.authenticate(
-			credentials,
-			listBlobsRequest('https://myaccount.blob.core.chinacloudapi.cn'),
+	describe('authenticate', () => {
+		const custom = (customEndpoint: string): ICredentialDataDecryptedObject => ({
+			...credentials,
+			environment: 'custom',
+			customEndpoint,
+		});
+
+		it('should sign with the account name and path, independent of the host', async () => {
+			const publicCloud = await credential.authenticate(
+				credentials,
+				listBlobsRequest('https://myaccount.blob.core.windows.net'),
+			);
+			const sovereignCloud = await credential.authenticate(
+				{ ...credentials, environment: 'blob.core.chinacloudapi.cn' },
+				listBlobsRequest('https://myaccount.blob.core.chinacloudapi.cn'),
+			);
+
+			expect(publicCloud.headers?.[HeaderConstants.AUTHORIZATION]).toBe(publicCloudSignature);
+			expect(sovereignCloud.headers?.[HeaderConstants.AUTHORIZATION]).toBe(publicCloudSignature);
+		});
+
+		it('should not consult the instance setting for an Azure cloud', async () => {
+			mockContainer.get.mockImplementation(() => {
+				throw new Error('instance setting read');
+			});
+
+			const result = await credential.authenticate(
+				{ ...credentials, environment: 'blob.core.usgovcloudapi.net' },
+				listBlobsRequest('https://myaccount.blob.core.usgovcloudapi.net'),
+			);
+
+			expect(result.headers?.[HeaderConstants.AUTHORIZATION]).toBe(publicCloudSignature);
+		});
+
+		it.each(['my-account', 'myaccount.example.com', 'myaccount/x', ''])(
+			'should reject the account name %j',
+			async (account) => {
+				const request = credential.authenticate(
+					{ ...credentials, account },
+					listBlobsRequest('https://myaccount.blob.core.windows.net'),
+				);
+
+				await expect(request).rejects.toThrow(UserError);
+				await expect(request).rejects.toThrow(
+					'The account name can contain only letters and numbers.',
+				);
+			},
 		);
 
-		expect(publicCloud.headers?.[HeaderConstants.AUTHORIZATION]).toBe(
-			'SharedKey myaccount:LTfRKI8awvSOEoMJ6moAHQKF9Rt38hRdut6PsXHhnUI=',
-		);
-		expect(sovereignCloud.headers?.[HeaderConstants.AUTHORIZATION]).toBe(
-			publicCloud.headers?.[HeaderConstants.AUTHORIZATION],
+		it('should reject a cloud that is not in the list', async () => {
+			const request = credential.authenticate(
+				{ ...credentials, environment: 'blob.example.com' },
+				listBlobsRequest('https://myaccount.blob.example.com'),
+			);
+
+			await expect(request).rejects.toThrow(UserError);
+			await expect(request).rejects.toThrow('Select an Azure cloud from the list.');
+		});
+
+		it('should refuse a custom endpoint when the instance does not allow it', async () => {
+			const request = credential.authenticate(
+				custom(privateEndpoint),
+				listBlobsRequest(privateEndpoint),
+			);
+
+			await expect(request).rejects.toThrow(UserError);
+			await expect(request).rejects.toThrow(
+				'Custom Azure Storage endpoints are disabled on this instance, contact your administrator.',
+			);
+		});
+
+		it('should sign a custom endpoint request when the instance allows it', async () => {
+			securityConfig.azureStorageCustomEndpoints = true;
+
+			const result = await credential.authenticate(
+				custom(privateEndpoint),
+				listBlobsRequest(privateEndpoint),
+			);
+
+			expect(result.headers?.[HeaderConstants.AUTHORIZATION]).toBe(publicCloudSignature);
+		});
+
+		it('should require an endpoint for a custom cloud', async () => {
+			securityConfig.azureStorageCustomEndpoints = true;
+
+			const request = credential.authenticate(
+				custom(''),
+				listBlobsRequest('https://myaccount.blob.core.windows.net'),
+			);
+
+			await expect(request).rejects.toThrow(UserError);
+			await expect(request).rejects.toThrow(
+				'Endpoint is required when Azure Cloud is set to Custom.',
+			);
+		});
+
+		it.each(['myaccount.privatelink.blob.core.windows.net', 'ftp://myaccount.example.com'])(
+			'should reject the endpoint %j',
+			async (customEndpoint) => {
+				securityConfig.azureStorageCustomEndpoints = true;
+
+				const request = credential.authenticate(
+					custom(customEndpoint),
+					listBlobsRequest('https://myaccount.blob.core.windows.net'),
+				);
+
+				await expect(request).rejects.toThrow(UserError);
+				await expect(request).rejects.toThrow(
+					'Endpoint must be a full URL that starts with https://',
+				);
+			},
 		);
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Storage/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Storage/GenericFunctions.ts
@@ -97,7 +97,7 @@ export async function azureStorageApiRequest(
 
 	const options: IHttpRequestOptions = {
 		method,
-		url: url ?? `${credentials.baseUrl}${endpoint}`,
+		url: url ?? `${credentials.baseUrl.replace(/\/+$/, '')}${endpoint}`,
 		headers,
 		body,
 		qs,

--- a/packages/nodes-base/nodes/Microsoft/Storage/test/listSearch/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Storage/test/listSearch/listSearch.test.ts
@@ -6,11 +6,11 @@ import { credentials } from '../credentials';
 
 describe('Azure Storage Node', () => {
 	const { baseUrl } = credentials.azureStorageOAuth2Api;
+	const blobListResponse = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><EnumerationResults ServiceEndpoint="${baseUrl}" ContainerName="item1"><Prefix/><Marker/><MaxResults>1</MaxResults><Blobs><Blob><Name>myblob1</Name><Properties><Creation-Time>Wed, 22 Jan 2025 18:53:15 GMT</Creation-Time><Last-Modified>Wed, 22 Jan 2025 18:53:15 GMT</Last-Modified><Etag>0x1F8268B228AA730</Etag><Content-Length>37</Content-Length><Content-Type>application/json</Content-Type><Content-MD5>aWQGHD8kGQd5ZtEN/S1/aw==</Content-MD5><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><AccessTierChangeTime>Wed, 22 Jan 2025 18:53:15 GMT</AccessTierChangeTime></Properties></Blob></Blobs><NextMarker>myblob2</NextMarker></EnumerationResults>`;
 
 	describe('List search', () => {
 		it('should list search blobs', async () => {
-			const mockResponse = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><EnumerationResults ServiceEndpoint="${baseUrl}" ContainerName="item1"><Prefix/><Marker/><MaxResults>1</MaxResults><Blobs><Blob><Name>myblob1</Name><Properties><Creation-Time>Wed, 22 Jan 2025 18:53:15 GMT</Creation-Time><Last-Modified>Wed, 22 Jan 2025 18:53:15 GMT</Last-Modified><Etag>0x1F8268B228AA730</Etag><Content-Length>37</Content-Length><Content-Type>application/json</Content-Type><Content-MD5>aWQGHD8kGQd5ZtEN/S1/aw==</Content-MD5><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><AccessTierChangeTime>Wed, 22 Jan 2025 18:53:15 GMT</AccessTierChangeTime></Properties></Blob></Blobs><NextMarker>myblob2</NextMarker></EnumerationResults>`;
-			const mockRequestWithAuthentication = vi.fn().mockReturnValue(mockResponse);
+			const mockRequestWithAuthentication = vi.fn().mockReturnValue(blobListResponse);
 			const mockGetNodeParameter = vi.fn((parameterName, _fallbackValue, _options) => {
 				if (parameterName === 'authentication') {
 					return 'sharedKey';
@@ -110,6 +110,31 @@ describe('Azure Storage Node', () => {
 				results: [{ name: 'mycontainer1', value: 'mycontainer1' }],
 				paginationToken: 'mycontainer2',
 			});
+		});
+		it('should build the request URL without a double slash when the base URL ends with one', async () => {
+			const mockRequestWithAuthentication = vi.fn().mockReturnValue(blobListResponse);
+			const mockContext = {
+				getCredentials: vi.fn(async () => ({
+					...credentials.azureStorageSharedKeyApi,
+					baseUrl: 'https://myaccount.blob.core.chinacloudapi.cn/',
+				})),
+				getNodeParameter: vi.fn((parameterName: string) =>
+					parameterName === 'authentication' ? 'sharedKey' : { value: 'mycontainer' },
+				),
+				helpers: {
+					requestWithAuthentication: mockRequestWithAuthentication,
+				},
+			} as unknown as ILoadOptionsFunctions;
+			const node = new AzureStorage();
+
+			await node.methods.listSearch.getBlobs.call(mockContext);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'azureStorageSharedKeyApi',
+				expect.objectContaining({
+					url: 'https://myaccount.blob.core.chinacloudapi.cn/mycontainer',
+				}),
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

The Shared Key credential computed its base URL from the account name and hid the field, so every credential pointed at the public Azure cloud. Customers on a sovereign cloud or behind a private endpoint had no way to set a different endpoint per credential. `CREDENTIALS_OVERWRITE_DATA` can override the field, but with one value for the whole instance.

The credential now has an **Azure Cloud** dropdown: Azure Public Cloud, Azure US Government, Azure China, and Custom. Custom reveals an **Endpoint** field for a private endpoint or a custom domain. The Base URL stays hidden and is built from the selection, so existing credentials resolve exactly as before and new credentials still target the public cloud unless the user changes the selection.

Custom endpoints are an instance decision. The new `N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED` setting (`SecurityConfig.azureStorageCustomEndpoints`, default `false`) allows them, in the same way `N8N_AWS_SYSTEM_CREDENTIALS_ACCESS_ENABLED` gates AWS system credentials. The credential enforces it in `authenticate`, so with the setting off a custom-endpoint credential fails its credential test and every node request with "Custom Azure Storage endpoints are disabled on this instance, contact your administrator." The sovereign clouds never need the setting. `authenticate` also checks that the cloud is one of the listed values, that the account name contains only letters and digits, and that a custom endpoint is an https URL with only a hostname and an optional port, so the hidden base URL can only take the shapes the form offers.

The Shared Key signature covers the account name, path, query and headers but not the host, so a host-style endpoint signs the same as the public one. The list-search helper now strips a trailing slash from the base URL, so a pasted `https://host/` does not produce a `//container` path.

Scope follows the ticket triage. Host-style endpoints only, with the account name in the hostname. Path-style endpoints, such as Azurite or a reverse proxy with the account as a path segment, need a signing change and are a follow-up. The OAuth2 credential is unchanged. It sends a reusable bearer token and needs its own decision.

## Notes for review

- The Custom option stays visible when the setting is off. n8n has no way to hide a credential dropdown option per instance setting: `showOnDeployment` and `envFeatureFlag` work at property level, and option-level filtering only runs with an active node. The AWS system-credentials gate takes the same approach, a visible option with a clear runtime error, and the option and field descriptions name the setting. Hiding the option would need Azure-specific code in the frontend service or a new generic marker. Happy to add either if preferred.
- Endpoint is `required`. Both the internal save validation and the public API schema apply `required` only when the field is displayed, so credentials for the three clouds are unaffected and API clients that send only Account and Key keep working.
- Domain restrictions. The declarative request path widens a credential's allowed-domains list with the node's `baseURL` in `routing-node.ts`. That host now comes from a credential selection, but nothing new is exposed. The base URL was already stored per credential, already settable through the credentials API, and already derived from the editor-controlled Account field. The same principal controls the endpoint and the allowed-domains list, and a workflow editor who can only use the credential cannot change either. Custom hosts additionally need the instance setting.
- What the setting does not gate. A credential created through the REST or public API with a literal hidden `baseUrl` keeps that value, as it always did, and the setting does not inspect it. Closing that means comparing the effective base URL with the one built from the selection, which would also break instances that point `baseUrl` at a private endpoint through `CREDENTIALS_OVERWRITE_DATA` today, so it is a breaking change for the 3.x branch rather than this PR.
- `CREDENTIALS_OVERWRITE_DATA` for `azureStorageSharedKeyApi.baseUrl` keeps working: the overwrite wins over the built value. Instances that want a different endpoint per credential should use the new setting instead.

## How to test

1. Create an Azure Storage Shared Key credential. Azure Cloud defaults to Azure Public Cloud. Test the credential. It passes against `https://<account>.blob.core.windows.net`.
2. Select Azure China or Azure US Government with an account in that cloud. Test the credential and list containers in the node. Requests go to that cloud's endpoint.
3. Select Custom and enter a host-style endpoint, for example `https://<account>.privatelink.blob.core.windows.net`. Without `N8N_AZURE_STORAGE_CUSTOM_ENDPOINTS_ENABLED=true` the test fails with the administrator message. Set the variable, restart n8n, and test again. It passes and the Container and Blob pickers load.
4. Enter the custom endpoint with a trailing slash. The pickers still load.
5. Open an existing Shared Key credential. It shows Azure Public Cloud and works without changes.

Unit tests:

```
cd packages/nodes-base && pnpm test credentials/test/AzureStorageSharedKeyApi.credentials.test.ts nodes/Microsoft/Storage
cd packages/@n8n/config && pnpm test src/configs/__tests__/security.config.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-405

Docs: the Azure Storage credentials page and the security environment variables table in n8n-docs need the two new fields and the new setting. The change is drafted and will be opened after release.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (Docs change drafted for n8n-docs, to open after release.)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
