### PR TITLE
fix(editor): Rename the first agent builder tab to Build

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -8004,7 +8004,7 @@
 	"agents.builder.tree.customBadge": "Custom",
 	"agents.builder.tree.foldersEmpty": "No items yet",
 	"agents.builder.header.executions": "Executions",
-	"agents.builder.header.tab.agent": "Agent",
+	"agents.builder.header.tab.agent": "Build",
 	"agents.builder.header.tab.knowledge": "Knowledge",
 	"agents.builder.header.tab.executions": "Sessions",
 	"agents.builder.header.tab.settings": "Settings",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilder.readonly.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilder.readonly.test.ts
@@ -28,7 +28,7 @@ describe('AgentBuilderEditorColumn — childrenDisabled composes streaming and c
 			props: {
 				activeMainTab: 'agent',
 				mainTabOptions: [
-					{ label: 'Agent', value: 'agent' },
+					{ label: 'Build', value: 'agent' },
 					{ label: 'Sessions', value: 'sessions' },
 					{ label: 'Settings', value: 'settings' },
 				],
@@ -126,7 +126,7 @@ describe('AgentBuilderEditorColumn — childrenDisabled composes streaming and c
 			props: {
 				activeMainTab: 'settings',
 				mainTabOptions: [
-					{ label: 'Agent', value: 'agent' },
+					{ label: 'Build', value: 'agent' },
 					{ label: 'Sessions', value: 'sessions' },
 					{ label: 'Settings', value: 'settings' },
 				],

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
@@ -158,7 +158,7 @@ async function mountColumn(
 		props: {
 			activeMainTab: overrides.activeMainTab ?? 'agent',
 			mainTabOptions: overrides.mainTabOptions ?? [
-				{ label: 'Agent', value: 'agent' },
+				{ label: 'Build', value: 'agent' },
 				{ label: 'Knowledge', value: 'knowledge' },
 				{ label: 'Sessions', value: 'sessions' },
 				{ label: 'Settings', value: 'settings' },
@@ -210,11 +210,11 @@ describe('AgentBuilderEditorColumn', () => {
 		vi.clearAllMocks();
 	});
 
-	it('renders Agent, Knowledge, Sessions, and Settings tabs without Raw', async () => {
+	it('renders Build, Knowledge, Sessions, and Settings tabs without Raw', async () => {
 		const wrapper = await mountColumn();
 
 		const tabs = wrapper.find('[data-testid="agent-header-tabs"]');
-		expect(tabs.text()).toContain('Agent');
+		expect(tabs.text()).toContain('Build');
 		expect(tabs.text()).toContain('Knowledge');
 		expect(tabs.text()).toContain('Sessions');
 		expect(tabs.text()).toContain('Settings');


### PR DESCRIPTION
## Summary

Rename the first tab in the agent builder from **Agent** to **Build**. The new label describes what users do on this tab.

- Update the i18n label.
- Update the existing tab-label test and three fixtures.
- Keep the internal tab ID and navigation unchanged.

No screenshot was captured for this label-only change.

## How to test

1. Start an instance with `agents` included in `N8N_ENABLED_MODULES`.
2. Open an agent in the agent builder.
3. Check that the first tab shows **Build**, followed by **Knowledge**, **Sessions**, and **Settings**.
4. Select another tab.
5. Select **Build** and check that the agent editor opens.

`git diff --check` passed. Tests, lint, typecheck, and commit hooks were not run, as requested. The manual steps above were not run.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-759

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

