### PR TITLE
fix(core): Reconnect the Email Trigger (IMAP) on every publish through the publication service

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
@@ -117,6 +117,20 @@ describe('computeTriggerDiff', () => {
 			expect(diff).toEqual({ toAdd: new Set(['legacy']), toRemove: new Set(['legacy']) });
 		});
 
+		test('re-registers an unchanged Email Trigger (IMAP) so a republish reconnects it', () => {
+			const imapTrigger = makeNode('imap', {
+				type: 'n8n-nodes-base.emailReadImap',
+				typeVersion: 2.1,
+				parameters: { mailbox: 'INBOX' },
+			});
+
+			const diff = computeTriggerDiff([imapTrigger], [{ ...imapTrigger }], {
+				versionChanged: true,
+			});
+
+			expect(diff).toEqual({ toAdd: new Set(['imap']), toRemove: new Set(['imap']) });
+		});
+
 		test('does not force other unchanged trigger types when the published version changed', () => {
 			const schedule = makeNode('a');
 

--- a/packages/cli/src/workflows/publication/trigger-diff.ts
+++ b/packages/cli/src/workflows/publication/trigger-diff.ts
@@ -19,6 +19,10 @@ function registrationEqual(base: INode | undefined, target: INode | undefined): 
 const ALWAYS_REREGISTER_TRIGGER_TYPES: ReadonlySet<string> = new Set([
 	'n8n-nodes-base.n8nTrigger',
 	'n8n-nodes-base.workflowTrigger',
+	// Workaround, not a contract: an IMAP connection can go silently half-open
+	// without a close or error event, so the node never asks to be reactivated.
+	// Republishing used to reconnect it. Remove once the node detects this itself.
+	'n8n-nodes-base.emailReadImap',
 ]);
 
 export interface TriggerDiffOptions {


### PR DESCRIPTION
## Summary

An IMAP connection can go silently half-open behind a NAT or proxy. No `close` or `error` event fires, so the Email Trigger (IMAP) never asks to be reactivated and stops delivering mail. The node's "Force Reconnect Every Minutes" option covers this, but it is unset on most existing workflows.

Before the workflow publication service, republishing the workflow tore every trigger down and reconnected it, so users used a republish as the manual heal. The publication service leaves unchanged triggers running (#38153 explains the diff), so that heal no longer has any effect on the IMAP trigger.

This PR adds `n8n-nodes-base.emailReadImap` to `ALWAYS_REREGISTER_TRIGGER_TYPES` in `trigger-diff.ts`, so the applier removes and re-adds the trigger on every publish that changes the version. This restores the legacy behaviour for this node only.

This is a workaround, not a contract. The comment on the entry says so, and the entry should go once the node detects a stalled connection itself. Duplicate mail is guarded by the node's `lastMessageUid` static data; the `activatedAt` cut-off only matters before the first mail is seen.

## How to test

Set `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

1. Publish a workflow with an Email Trigger (IMAP) connected to a No Op node. Watch the logs for the IMAP connection.
2. Add another No Op node (do not touch the trigger) and publish again.
3. The logs show the IMAP connection close and reconnect. Before this change, nothing happened to the trigger.
4. Publish a workflow with a Schedule Trigger and repeat step 2. The schedule trigger is not re-registered, so the change is scoped to the IMAP node.

Unit test added for the diff entry.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4221
Follow-up to #38153.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

