### PR TITLE
fix(ai-builder): Give agent narration a larger judge budget than tool payloads (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/conversation-text.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/conversation-text.test.ts
@@ -299,4 +299,31 @@ describe('lastAgentText', () => {
 		];
 		expect(lastAgentText(transcript)).toBe('latest');
 	});
+
+	// An analysis case lost a legitimate green here: the agent's closing
+	// "which should I build?" sat past a 2000-char cut while the stored
+	// transcript held it in full, so the judge graded an answer that had no
+	// ask in it. Narration is what process expectations read; tool payloads
+	// are what cost tokens.
+	it('keeps a long assistant answer whole while still capping tool payloads', () => {
+		const answer = `${'a'.repeat(2400)} SO WHICH ONE SHOULD I BUILD?`;
+		const text = transcriptAsText([
+			{
+				userMessage: 'analyse this',
+				steps: [
+					{ kind: 'agent-text', text: answer },
+					{
+						kind: 'tool-call',
+						toolName: 'workflow-connections',
+						args: {},
+						result: { blob: 'z'.repeat(9000) },
+					},
+				],
+			},
+		] as never);
+
+		expect(text).toContain('SO WHICH ONE SHOULD I BUILD?');
+		expect(text).toContain('more chars');
+		expect(text.length).toBeLessThan(answer.length + 6000);
+	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/conversation-text.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/conversation-text.test.ts
@@ -307,7 +307,7 @@ describe('lastAgentText', () => {
 	// are what cost tokens.
 	it('keeps a long assistant answer whole while still capping tool payloads', () => {
 		const answer = `${'a'.repeat(2400)} SO WHICH ONE SHOULD I BUILD?`;
-		const text = transcriptAsText([
+		const transcript: TranscriptTurn[] = [
 			{
 				userMessage: 'analyse this',
 				steps: [
@@ -320,7 +320,8 @@ describe('lastAgentText', () => {
 					},
 				],
 			},
-		] as never);
+		];
+		const text = transcriptAsText(transcript);
 
 		expect(text).toContain('SO WHICH ONE SHOULD I BUILD?');
 		expect(text).toContain('more chars');

--- a/packages/@n8n/instance-ai/evaluations/utils/conversation-text.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/conversation-text.ts
@@ -189,9 +189,20 @@ export function failedBuildsPerTurn(transcript: TranscriptTurn[]): number[] {
 // Cap each serialized field to bound judge token cost (matches the report's cap).
 const MAX_STEP_CHARS = 2000;
 
-function cap(text: string): string {
-	return text.length > MAX_STEP_CHARS
-		? `${text.slice(0, MAX_STEP_CHARS)}… (${String(text.length - MAX_STEP_CHARS)} more chars)`
+/**
+ * The agent's own words get a larger budget than tool payloads. Process and
+ * behaviour expectations are graded from what the agent said, and a
+ * report-shaped answer puts its conclusion last — an analysis case lost a
+ * legitimate green because the closing "which should I build?" fell past the
+ * 2000-char cut while the stored transcript held it in full. Tool args and
+ * results keep the tighter cap: they are unbounded and are what actually
+ * drives judge token cost.
+ */
+const MAX_NARRATION_CHARS = 8000;
+
+function cap(text: string, limit: number = MAX_STEP_CHARS): string {
+	return text.length > limit
+		? `${text.slice(0, limit)}… (${String(text.length - limit)} more chars)`
 		: text;
 }
 
@@ -207,7 +218,7 @@ function capJson(value: unknown): string {
 
 function describeStep(step: TranscriptStep): string | null {
 	if (step.kind === 'agent-text') {
-		return step.text ? `Assistant: ${cap(step.text)}` : null;
+		return step.text ? `Assistant: ${cap(step.text, MAX_NARRATION_CHARS)}` : null;
 	}
 	return describeInteraction(step);
 }


### PR DESCRIPTION
## Summary

The expectations judge reads the build transcript. Every field in that
transcript was cut to 2000 characters first. This is fine for a build case. The
agent narrates briefly there, and the workflow is the artifact under test.

It breaks a case whose answer *is* the artifact. An analysis case asks the agent
to report findings. The agent puts its conclusion at the end. That conclusion
fell past the cut.

A real case failed this way. The agent asked the user which finding to act on.
The judge answered "no such prompt is visible in the response text". The stored
transcript held the full sentence. Only the judge's copy lost it.

This change gives narration 8000 characters. Tool arguments and results keep
2000.

## Why not raise the cap for everything

Tool payloads are the cost. One tool result in the case above was 25k
characters. Narration is small and bounded, and process expectations are graded
from it. So the two get different budgets.

## Review notes

- `cap()` now takes a limit. The default is unchanged, so every other call site
  keeps the old behaviour.
- One call site changes: the assistant narration line.
- The new test asserts both halves. A long answer stays whole. A long tool
  result is still cut.

## Related

Found while building an analysis-shaped eval case for a cross-workflow feature.
The case scored 6/7 with a correct agent run. It scores 7/8 now, and the one
remaining failure is a real capability gap.

#### How to test

```bash
cd packages/@n8n/instance-ai
pnpm test evaluations/__tests__/conversation-text.test.ts
```

Any analysis or behaviour case whose expectations read the end of a long
assistant answer now grades correctly.

## Review / Merge checklist

- [x] PR title and description are relevant to the change
- [x] Tests included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

