### PR TITLE
fix(editor): Align AI Assistant permission dropdowns with the group control

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
@@ -899,7 +899,7 @@ function openAiUsageSettings() {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--3xs);
-	padding: 0 0 var(--spacing--2xs) var(--spacing--sm);
+	padding: 0 var(--spacing--sm) var(--spacing--2xs);
 }
 
 .permissionRow {


### PR DESCRIPTION
## Summary

| Before | After |
| --- | --- |
| <img width="2880" height="1432" alt="ins1286-before" src="https://github.com/user-attachments/assets/f1c7fae2-4350-49e5-9e16-a3cdf48f4df7" /> | <img width="2880" height="1432" alt="ins1286-after" src="https://github.com/user-attachments/assets/55c57177-8064-4e4a-bba7-fe4b1c5ca30d" /> |


In Instance settings > AI Assistant > Permissions, the dropdowns inside an expanded permission group ended at the card edge. The top-level "Default" control ended 16px before that edge, so the right side of the card looked uneven.

Cause: the expanded region of `N8nSettingsRow` is flush with the card edges, and the permission list only had left and bottom padding.

Fix: give the permission list the same `--spacing--sm` padding on the right as on the left. The dropdown right edges and chevrons now match the "Default" control. `N8nSettingsRow` is unchanged.

Measured in a local instance (right edge, in px):

| Viewport | "Default" control | Dropdowns before | Dropdowns after |
| --- | --- | --- | --- |
| 1440 wide | 1163 | 1179 | 1163 |
| 1100 wide | 993 | | 993 |

## How to test

1. Open Settings > AI Assistant (`/settings/assistant`).
2. Scroll to the Permissions section.
3. Expand the Workflows group.
4. Check that the right edge and the chevron of each dropdown line up with the "Default" control.
5. Resize the browser window. The alignment must not change.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1286

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. CSS-only change; layout is not testable in unit tests. The existing view tests still pass.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

