### PR TITLE
fix: Scope the legacy setup credential picker to the target workflow and report unusable credentials on apply

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -2553,6 +2553,28 @@ describe('workflows tool', () => {
 			);
 		});
 
+		it('returns a failed result when the save fails so nothing counts as applied', async () => {
+			// The save is where a credential the workflow's project cannot use is
+			// rejected. Reporting it as a partial success would hide the reason.
+			(applyNodeChanges as Mock).mockResolvedValue({
+				applied: [],
+				failed: [{ nodeName: 'HTTP Request', error: 'Failed to save workflow: no access' }],
+				saveError: 'Failed to save workflow: no access',
+			});
+
+			const tool = createWorkflowsTool(createMockContext());
+			const result = await executeTool(tool, { action: 'setup', workflowId: 'wf1' }, {
+				resumeData: {
+					approved: true,
+					action: 'apply',
+					credentials: { 'HTTP Request': { httpHeaderAuth: 'cred-1' } },
+				},
+			} as never);
+
+			expect(result).toEqual({ success: false, error: 'Failed to save workflow: no access' });
+			expect(analyzeWorkflow).not.toHaveBeenCalled();
+		});
+
 		it('reports a just-applied credential whose test failed as a failed node', async () => {
 			// A bound credential is settled (needsAction=false) even when its test
 			// fails, so the apply path must re-analyze with includeSettled to keep

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -1236,6 +1236,14 @@ async function handleSetupApply(
 			resumeData.nodeParameters,
 		);
 
+		// Nothing was saved, so there is nothing to re-analyze. A failed result keeps
+		// the setup panel open with the user's input; a "partial" success would
+		// replace the panel and hide the reason (e.g. a credential the workflow's
+		// project cannot use).
+		if (applyResult.saveError) {
+			return { success: false, error: applyResult.saveError };
+		}
+
 		const failedNodes = applyResult.failed.length > 0 ? applyResult.failed : undefined;
 
 		// Fetch updated workflow to include in response so the frontend can refresh the canvas

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -1236,10 +1236,9 @@ async function handleSetupApply(
 			resumeData.nodeParameters,
 		);
 
-		// Nothing was saved, so there is nothing to re-analyze. A failed result keeps
-		// the setup panel open with the user's input; a "partial" success would
-		// replace the panel and hide the reason (e.g. a credential the workflow's
-		// project cannot use).
+		// Nothing was saved, so there is nothing to re-analyze. A failed result shows
+		// the reason to the user and the agent; a "partial" success would hide it
+		// (e.g. a credential the workflow's project cannot use).
 		if (applyResult.saveError) {
 			return { success: false, error: applyResult.saveError };
 		}

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -1740,6 +1740,7 @@ describe('applyNodeChanges', () => {
 		expect(result.applied).toHaveLength(0);
 		expect(result.failed).toHaveLength(1);
 		expect(result.failed[0].error).toContain('Failed to save workflow');
+		expect(result.saveError).toContain('Failed to save workflow');
 	});
 
 	it('strips credentials not valid for the current parameters', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -1041,6 +1041,8 @@ export function sortByExecutionOrder(
 export interface ApplyResult {
 	applied: string[];
 	failed: Array<{ nodeName: string; error: string }>;
+	/** Set when the single save failed: nothing was persisted. */
+	saveError?: string;
 }
 
 function addUnknownNodeFailures(
@@ -1330,6 +1332,7 @@ export async function applyNodeChanges(
 			result.failed.push({ nodeName, error: saveError });
 		}
 		result.applied = [];
+		result.saveError = saveError;
 	}
 
 	return result;

--- a/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
@@ -375,30 +375,41 @@ describe('EnterpriseWorkflowService', () => {
 			expect(result.nodes[0].parameters).toEqual({ url: '' });
 		});
 
-		it('rejects an unresolved credential that replaces a different one on an existing node', () => {
-			const previousVersion = {
-				nodes: [httpNode({ httpHeaderAuth: { id: null, name: 'Old' } })],
+		it('restores a read-only node whose credential is swapped for another the user cannot use', () => {
+			const previous = httpNode({ httpHeaderAuth: { id: 'foreign-cred', name: 'Theirs' } });
+			const previousVersion = { nodes: [previous] } as unknown as IWorkflowBase;
+			const newVersion = {
+				nodes: [
+					httpNode(
+						{ httpHeaderAuth: { id: 'other-foreign-cred', name: 'Fake' } },
+						{ url: 'https://changed.test' },
+					),
+				],
 			} as unknown as IWorkflowBase;
+
+			const result = service.validateWorkflowCredentialUsage(
+				newVersion,
+				previousVersion,
+				accessible,
+			);
+
+			expect(result.nodes[0]).toEqual(previous);
+		});
+
+		it('restores a read-only node whose unresolved credential is replaced', () => {
+			const previous = httpNode({ httpHeaderAuth: { id: null, name: 'Old' } });
+			const previousVersion = { nodes: [previous] } as unknown as IWorkflowBase;
 			const newVersion = {
 				nodes: [httpNode({ httpHeaderAuth: { id: null, name: 'New' } }, { url: 'https://x.test' })],
 			} as unknown as IWorkflowBase;
 
-			expect(() =>
-				service.validateWorkflowCredentialUsage(newVersion, previousVersion, accessible),
-			).toThrow(/credentials in the 'Call' node/);
-		});
+			const result = service.validateWorkflowCredentialUsage(
+				newVersion,
+				previousVersion,
+				accessible,
+			);
 
-		it('compares unresolved credentials by type and name, not by a joined string', () => {
-			const previousVersion = {
-				nodes: [httpNode({ a: { id: null, name: 'b:c' } })],
-			} as unknown as IWorkflowBase;
-			const newVersion = {
-				nodes: [httpNode({ 'a:b': { id: null, name: 'c' } })],
-			} as unknown as IWorkflowBase;
-
-			expect(() =>
-				service.validateWorkflowCredentialUsage(newVersion, previousVersion, accessible),
-			).toThrow(/credentials in the 'Call' node/);
+			expect(result.nodes[0]).toEqual(previous);
 		});
 	});
 

--- a/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
@@ -310,6 +310,72 @@ describe('EnterpriseWorkflowService', () => {
 		});
 	});
 
+	describe('validateWorkflowCredentialUsage() - credential added to an existing node', () => {
+		const httpNode = (
+			credentials?: INode['credentials'],
+			parameters: Record<string, unknown> = { url: '' },
+		) =>
+			({
+				id: 'existing-1',
+				name: 'Call',
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 4.2,
+				position: [0, 0],
+				parameters,
+				...(credentials ? { credentials } : {}),
+			}) as unknown as INode;
+		const accessible = [{ id: 'team-cred' }];
+
+		it('rejects a credential the user cannot use when the node did not have it before', () => {
+			const previousVersion = { nodes: [httpNode()] } as unknown as IWorkflowBase;
+			const newVersion = {
+				nodes: [
+					httpNode(
+						{ httpHeaderAuth: { id: 'personal-cred', name: 'Mine' } },
+						{ url: 'https://x.test' },
+					),
+				],
+			} as unknown as IWorkflowBase;
+
+			expect(() =>
+				service.validateWorkflowCredentialUsage(newVersion, previousVersion, accessible),
+			).toThrow(/credentials in the 'Call' node/);
+		});
+
+		it('saves a credential the user can use together with the other edits', () => {
+			const previousVersion = { nodes: [httpNode()] } as unknown as IWorkflowBase;
+			const edited = httpNode(
+				{ httpHeaderAuth: { id: 'team-cred', name: 'Team' } },
+				{ url: 'https://x.test', query: { key: 'value' } },
+			);
+			const newVersion = { nodes: [edited] } as unknown as IWorkflowBase;
+
+			const result = service.validateWorkflowCredentialUsage(
+				newVersion,
+				previousVersion,
+				accessible,
+			);
+
+			expect(result.nodes[0]).toEqual(edited);
+		});
+
+		it('still restores a node whose credential the user could not use before', () => {
+			const previous = httpNode({ httpHeaderAuth: { id: 'foreign-cred', name: 'Theirs' } });
+			const previousVersion = { nodes: [previous] } as unknown as IWorkflowBase;
+			const newVersion = {
+				nodes: [{ ...previous, parameters: { url: 'https://changed.test' } }],
+			} as unknown as IWorkflowBase;
+
+			const result = service.validateWorkflowCredentialUsage(
+				newVersion,
+				previousVersion,
+				accessible,
+			);
+
+			expect(result.nodes[0].parameters).toEqual({ url: '' });
+		});
+	});
+
 	describe('attemptWorkflowReactivation', () => {
 		// Workflow and folder transfers deactivate, transfer, then re-add. A failed
 		// re-add may have partially registered triggers, in memory and as durable

--- a/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
@@ -387,6 +387,19 @@ describe('EnterpriseWorkflowService', () => {
 				service.validateWorkflowCredentialUsage(newVersion, previousVersion, accessible),
 			).toThrow(/credentials in the 'Call' node/);
 		});
+
+		it('compares unresolved credentials by type and name, not by a joined string', () => {
+			const previousVersion = {
+				nodes: [httpNode({ a: { id: null, name: 'b:c' } })],
+			} as unknown as IWorkflowBase;
+			const newVersion = {
+				nodes: [httpNode({ 'a:b': { id: null, name: 'c' } })],
+			} as unknown as IWorkflowBase;
+
+			expect(() =>
+				service.validateWorkflowCredentialUsage(newVersion, previousVersion, accessible),
+			).toThrow(/credentials in the 'Call' node/);
+		});
 	});
 
 	describe('attemptWorkflowReactivation', () => {

--- a/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
@@ -374,6 +374,19 @@ describe('EnterpriseWorkflowService', () => {
 
 			expect(result.nodes[0].parameters).toEqual({ url: '' });
 		});
+
+		it('rejects an unresolved credential that replaces a different one on an existing node', () => {
+			const previousVersion = {
+				nodes: [httpNode({ httpHeaderAuth: { id: null, name: 'Old' } })],
+			} as unknown as IWorkflowBase;
+			const newVersion = {
+				nodes: [httpNode({ httpHeaderAuth: { id: null, name: 'New' } }, { url: 'https://x.test' })],
+			} as unknown as IWorkflowBase;
+
+			expect(() =>
+				service.validateWorkflowCredentialUsage(newVersion, previousVersion, accessible),
+			).toThrow(/credentials in the 'Call' node/);
+		});
 	});
 
 	describe('attemptWorkflowReactivation', () => {

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -200,7 +200,7 @@ export class EnterpriseWorkflowService {
 		 * We only need to check nodes that use credentials the current user cannot access,
 		 * since these can be 2 possibilities:
 		 * - Same ID already exist: it's a read only node and therefore cannot be changed
-		 * - It's a new node, or an existing node that newly references such a credential,
+		 * - It's a new node, or an editable node that newly references such a credential,
 		 *   which indicates tampering and therefore must fail saving
 		 */
 
@@ -216,23 +216,20 @@ export class EnterpriseWorkflowService {
 			return newWorkflowVersion;
 		}
 
-		// Restoring the previous version of a node keeps a credential that version
-		// did not have, so a credential that is new on the node fails the save the
-		// same way a new node does.
-		const introducesInaccessibleCredential = (node: INode, previousNodeVersion: INode) => {
-			const previous = this.getNodeCredentialRefs(previousNodeVersion);
-			const current = this.getNodeCredentialRefs(node);
-			return (
-				current.unresolved.some((ref) => !previous.unresolved.includes(ref)) ||
-				current.ids.some((id) => !allowedCredentialIds.includes(id) && !previous.ids.includes(id))
-			);
-		};
+		// A node the user could not use before stays read only and is restored. A node
+		// the user could edit that now carries a credential they cannot use fails the
+		// save like a new node does; restoring it would drop the other edits silently.
+		const readOnlyNodeIds = new Set(
+			this.getNodesWithInaccessibleCreds(previousWorkflowVersion, allowedCredentialIds).map(
+				(node) => node.id,
+			),
+		);
 
 		nodesWithCredentialsUserDoesNotHaveAccessTo.forEach((node) => {
 			const previousNodeVersion = previousWorkflowVersion.nodes.find(
 				(previousNode) => previousNode.id === node.id,
 			);
-			if (!previousNodeVersion || introducesInaccessibleCredential(node, previousNodeVersion)) {
+			if (!previousNodeVersion || !readOnlyNodeIds.has(node.id)) {
 				this.logger.warn('Blocked workflow update due to tampering attempt', {
 					nodeType: node.type,
 					nodeName: node.name,
@@ -277,8 +274,8 @@ export class EnterpriseWorkflowService {
 		}
 		const allowedCredentialIds = userCredIds instanceof Set ? userCredIds : new Set(userCredIds);
 		return workflow.nodes.filter((node) => {
-			const { ids, unresolved } = this.getNodeCredentialRefs(node);
-			return unresolved.length > 0 || ids.some((credId) => !allowedCredentialIds.has(credId));
+			const { ids, hasUnresolved } = this.getNodeCredentialRefs(node);
+			return hasUnresolved || ids.some((credId) => !allowedCredentialIds.has(credId));
 		});
 	}
 
@@ -292,7 +289,7 @@ export class EnterpriseWorkflowService {
 		for (const node of workflow.nodes ?? []) {
 			const references = this.getNodeCredentialRefs(node);
 			for (const id of references.ids) ids.add(id);
-			hasUnresolved ||= references.unresolved.length > 0;
+			hasUnresolved ||= references.hasUnresolved;
 		}
 
 		return { ids, hasUnresolved };
@@ -305,9 +302,8 @@ export class EnterpriseWorkflowService {
 	 * including its nodes' credentials — inside its `workflowJson` string
 	 * parameter, so those references are walked as well.
 	 *
-	 * Returns `ids` (resolvable credential ids) and `unresolved` (one JSON
-	 * `[type, name]` key per non-managed credential carrying no id; a joined string
-	 * could collide when a type or name contains the separator). A name-only reference can be
+	 * Returns `ids` (resolvable credential ids) and `hasUnresolved` (a non-managed
+	 * credential carrying no id, i.e. only a name). A name-only reference can be
 	 * resolved by name to a credential the user cannot access, so callers gating a
 	 * save must reject it rather than treat the node as credential-free.
 	 * `__aiGatewayManaged` credentials with a null id are resolved at execution and
@@ -320,23 +316,23 @@ export class EnterpriseWorkflowService {
 	 * the request size (each level embeds its child as literal escaped JSON) and
 	 * cannot cycle, so the stack cannot grow unbounded.
 	 */
-	private getNodeCredentialRefs(node: INode): { ids: string[]; unresolved: string[] } {
+	private getNodeCredentialRefs(node: INode): { ids: string[]; hasUnresolved: boolean } {
 		const ids: string[] = [];
-		const unresolved: string[] = [];
+		let hasUnresolved = false;
 		const stack: INode[] = [node];
 
 		while (stack.length > 0) {
 			const current = stack.pop()!;
 
 			if (current.credentials) {
-				for (const [type, nodeCred] of Object.entries(current.credentials)) {
+				for (const nodeCred of Object.values(current.credentials)) {
 					const id = nodeCred.id?.toString();
 					if (id) {
 						ids.push(id);
 					} else if (nodeCred.__aiGatewayManaged && nodeCred.id === null) {
 						// Managed credential, resolved at execution — exempt.
 					} else if (nodeCred.id === null || nodeCred.id === '') {
-						unresolved.push(JSON.stringify([type, nodeCred.name]));
+						hasUnresolved = true;
 					}
 				}
 			}
@@ -346,7 +342,7 @@ export class EnterpriseWorkflowService {
 			}
 		}
 
-		return { ids, unresolved };
+		return { ids, hasUnresolved };
 	}
 
 	/**

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -305,8 +305,9 @@ export class EnterpriseWorkflowService {
 	 * including its nodes' credentials — inside its `workflowJson` string
 	 * parameter, so those references are walked as well.
 	 *
-	 * Returns `ids` (resolvable credential ids) and `unresolved` (one `type:name`
-	 * key per non-managed credential carrying no id). A name-only reference can be
+	 * Returns `ids` (resolvable credential ids) and `unresolved` (one JSON
+	 * `[type, name]` key per non-managed credential carrying no id; a joined string
+	 * could collide when a type or name contains the separator). A name-only reference can be
 	 * resolved by name to a credential the user cannot access, so callers gating a
 	 * save must reject it rather than treat the node as credential-free.
 	 * `__aiGatewayManaged` credentials with a null id are resolved at execution and
@@ -335,7 +336,7 @@ export class EnterpriseWorkflowService {
 					} else if (nodeCred.__aiGatewayManaged && nodeCred.id === null) {
 						// Managed credential, resolved at execution — exempt.
 					} else if (nodeCred.id === null || nodeCred.id === '') {
-						unresolved.push(`${type}:${nodeCred.name}`);
+						unresolved.push(JSON.stringify([type, nodeCred.name]));
 					}
 				}
 			}

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -200,7 +200,8 @@ export class EnterpriseWorkflowService {
 		 * We only need to check nodes that use credentials the current user cannot access,
 		 * since these can be 2 possibilities:
 		 * - Same ID already exist: it's a read only node and therefore cannot be changed
-		 * - It's a new node which indicates tampering and therefore must fail saving
+		 * - It's a new node, or an existing node that newly references such a credential,
+		 *   which indicates tampering and therefore must fail saving
 		 */
 
 		const allowedCredentialIds = credentialsUserHasAccessTo.map((cred) => cred.id);
@@ -215,22 +216,29 @@ export class EnterpriseWorkflowService {
 			return newWorkflowVersion;
 		}
 
-		const previouslyExistingNodeIds = previousWorkflowVersion.nodes.map((node) => node.id);
-
-		// If it's a new node we can't allow it to be saved
-		// since it uses creds the node doesn't have access
-		const isTamperingAttempt = (inaccessibleCredNodeId: string) =>
-			!previouslyExistingNodeIds.includes(inaccessibleCredNodeId);
+		// Restoring the previous version of a node keeps a credential that version
+		// did not have, so a credential that is new on the node fails the save the
+		// same way a new node does.
+		const introducesInaccessibleCredential = (node: INode, previousNodeVersion: INode) => {
+			const previous = this.getNodeCredentialRefs(previousNodeVersion);
+			const current = this.getNodeCredentialRefs(node);
+			return (
+				(current.hasUnresolved && !previous.hasUnresolved) ||
+				current.ids.some((id) => !allowedCredentialIds.includes(id) && !previous.ids.includes(id))
+			);
+		};
 
 		nodesWithCredentialsUserDoesNotHaveAccessTo.forEach((node) => {
-			if (isTamperingAttempt(node.id)) {
+			const previousNodeVersion = previousWorkflowVersion.nodes.find(
+				(previousNode) => previousNode.id === node.id,
+			);
+			if (!previousNodeVersion || introducesInaccessibleCredential(node, previousNodeVersion)) {
 				this.logger.warn('Blocked workflow update due to tampering attempt', {
 					nodeType: node.type,
 					nodeName: node.name,
 					nodeId: node.id,
 					nodeCredentials: node.credentials,
 				});
-				// Node is new, so this is probably a tampering attempt. Throw an error
 				throw new NodeOperationError(
 					node,
 					`You don't have access to the credentials in the '${node.name}' node. Ask the owner to share them with you.`,
@@ -247,9 +255,6 @@ export class EnterpriseWorkflowService {
 				nodeName: node.name,
 				nodeId: node.id,
 			});
-			const previousNodeVersion = previousWorkflowVersion.nodes.find(
-				(previousNode) => previousNode.id === node.id,
-			);
 			// Allow changing only name, position and disabled status for read-only nodes
 			Object.assign(
 				newWorkflowVersion.nodes[nodeIdx],

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -223,7 +223,7 @@ export class EnterpriseWorkflowService {
 			const previous = this.getNodeCredentialRefs(previousNodeVersion);
 			const current = this.getNodeCredentialRefs(node);
 			return (
-				(current.hasUnresolved && !previous.hasUnresolved) ||
+				current.unresolved.some((ref) => !previous.unresolved.includes(ref)) ||
 				current.ids.some((id) => !allowedCredentialIds.includes(id) && !previous.ids.includes(id))
 			);
 		};
@@ -277,8 +277,8 @@ export class EnterpriseWorkflowService {
 		}
 		const allowedCredentialIds = userCredIds instanceof Set ? userCredIds : new Set(userCredIds);
 		return workflow.nodes.filter((node) => {
-			const { ids, hasUnresolved } = this.getNodeCredentialRefs(node);
-			return hasUnresolved || ids.some((credId) => !allowedCredentialIds.has(credId));
+			const { ids, unresolved } = this.getNodeCredentialRefs(node);
+			return unresolved.length > 0 || ids.some((credId) => !allowedCredentialIds.has(credId));
 		});
 	}
 
@@ -292,7 +292,7 @@ export class EnterpriseWorkflowService {
 		for (const node of workflow.nodes ?? []) {
 			const references = this.getNodeCredentialRefs(node);
 			for (const id of references.ids) ids.add(id);
-			hasUnresolved ||= references.hasUnresolved;
+			hasUnresolved ||= references.unresolved.length > 0;
 		}
 
 		return { ids, hasUnresolved };
@@ -305,8 +305,8 @@ export class EnterpriseWorkflowService {
 	 * including its nodes' credentials — inside its `workflowJson` string
 	 * parameter, so those references are walked as well.
 	 *
-	 * Returns `ids` (resolvable credential ids) and `hasUnresolved` (a non-managed
-	 * credential carrying no id, i.e. only a name). A name-only reference can be
+	 * Returns `ids` (resolvable credential ids) and `unresolved` (one `type:name`
+	 * key per non-managed credential carrying no id). A name-only reference can be
 	 * resolved by name to a credential the user cannot access, so callers gating a
 	 * save must reject it rather than treat the node as credential-free.
 	 * `__aiGatewayManaged` credentials with a null id are resolved at execution and
@@ -319,23 +319,23 @@ export class EnterpriseWorkflowService {
 	 * the request size (each level embeds its child as literal escaped JSON) and
 	 * cannot cycle, so the stack cannot grow unbounded.
 	 */
-	private getNodeCredentialRefs(node: INode): { ids: string[]; hasUnresolved: boolean } {
+	private getNodeCredentialRefs(node: INode): { ids: string[]; unresolved: string[] } {
 		const ids: string[] = [];
-		let hasUnresolved = false;
+		const unresolved: string[] = [];
 		const stack: INode[] = [node];
 
 		while (stack.length > 0) {
 			const current = stack.pop()!;
 
 			if (current.credentials) {
-				for (const nodeCred of Object.values(current.credentials)) {
+				for (const [type, nodeCred] of Object.entries(current.credentials)) {
 					const id = nodeCred.id?.toString();
 					if (id) {
 						ids.push(id);
 					} else if (nodeCred.__aiGatewayManaged && nodeCred.id === null) {
 						// Managed credential, resolved at execution — exempt.
 					} else if (nodeCred.id === null || nodeCred.id === '') {
-						hasUnresolved = true;
+						unresolved.push(`${type}:${nodeCred.name}`);
 					}
 				}
 			}
@@ -345,7 +345,7 @@ export class EnterpriseWorkflowService {
 			}
 		}
 
-		return { ids, hasUnresolved };
+		return { ids, unresolved };
 	}
 
 	/**

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -405,6 +405,33 @@ describe('NodeCredentials', () => {
 		});
 	});
 
+	it('should fetch credentials scoped to the workflow passed by a standalone host', () => {
+		// Legacy setup wizard: the conversation lives in the personal project while
+		// the workflow lives in a team project. The picker has to follow the workflow.
+		workflowDocumentStoreRef.value = null;
+		credentialsStore.state.credentials = {};
+
+		renderComponent(
+			{
+				props: {
+					node: httpNode,
+					overrideCredType: 'openAiApi',
+					standalone: true,
+					workflowId: 'wf-team',
+					projectId: 'personal-project',
+				},
+			},
+			{ merge: true },
+		);
+
+		expect(credentialsStore.fetchUsableCredentials).toHaveBeenCalledWith({
+			workflowId: 'wf-team',
+		});
+		expect(credentialsStore.fetchUsableCredentials).not.toHaveBeenCalledWith({
+			projectId: 'personal-project',
+		});
+	});
+
 	it('should ignore managed credentials in the dropdown if active node is the HTTP node', async () => {
 		ndvStore.activeNode = httpNode;
 		credentialsStore.state.credentials = {

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -100,9 +100,10 @@ type Props = {
 	 *  instead of reading as a list to choose from. Existing credentials stay
 	 *  selectable — the user may change their mind once they see them. */
 	preferNewCredential?: boolean;
-	/** Workflow this credential slot belongs to, for telemetry attribution. Standalone
-	 *  hosts (Instance AI setup card) must pass it — they render without a provided
-	 *  workflow document; other hosts fall back to the injected document. */
+	/** Workflow this credential slot belongs to. Scopes the usable-credentials fetch
+	 *  and telemetry attribution. Standalone hosts (Instance AI setup card) must pass
+	 *  it — they render without a provided workflow document; other hosts fall back
+	 *  to the injected document. */
 	workflowId?: string;
 	/** When true, skip all global store writes (workflowsStore, nodeHelpers).
 	 *  Used by Instance AI to render credential selection without polluting the active workflow. */
@@ -458,6 +459,12 @@ watch(
 );
 
 function getCredentialFetchScope(): CredentialFetchScope | undefined {
+	// A host-supplied workflow wins over the project fallback: the workflow may
+	// live in another project than the conversation that renders the picker.
+	if (props.workflowId) {
+		return { workflowId: props.workflowId };
+	}
+
 	const workflowId = workflowDocumentStore?.value.workflowId;
 	if (workflowId && !workflowsStore.isNewWorkflow) {
 		return { workflowId };


### PR DESCRIPTION
## Summary

With the legacy setup wizard (`N8N_INSTANCE_AI_SETUP_PANEL_ENABLED=false`), a conversation in the personal project can set up a workflow that lives in a team project. The credential picker fetched credentials for the conversation's project, so it offered personal credentials the team workflow cannot use. Apply then saved the credential and silently dropped the URL and query values the user typed.

Changes:
- `NodeCredentials` uses the `workflowId` prop for the usable-credentials fetch when a host passes it. The legacy wizard passes the target workflow, so the picker only offers credentials that workflow can use.
- The workflow save guard rejects a credential that is new on an existing node when the user cannot use it in that workflow. Before, it restored the old parameters but kept the new credential.
- Setup apply returns a failed result when the save fails. A "Setup failed" toast shows the reason, the workflow stays unchanged, and the assistant offers to reopen the setup.

## How to test

1. Start with `N8N_INSTANCE_AI_SETUP_PANEL_ENABLED=false` and a license that includes projects.
2. Create a team project with a shared Header Auth credential and a workflow with an HTTP Request node (generic Header Auth, empty URL, one query parameter).
3. Create a Header Auth credential in your personal project. Do not share it.
4. Open the AI Assistant in your personal project, attach the team workflow and ask to set it up.
5. The picker lists only the team credential. Select it, fill the URL and the query value, click Apply.
6. Reload the workflow. The credential, the URL and the query value are saved.
7. Optional: send the setup apply with the id of the personal credential. The "Setup failed" toast names the node, the workflow is unchanged, and the assistant offers to reopen the setup.

Unit tests cover the different-project picker scope, the guard for a credential that is new on an existing node, a successful save with a usable credential, and the failed apply result.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1390

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, if the fix is meant to be applied on the Beta release.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


