### PR TITLE
ci: Point the workflow-scripts lockfile dir at .github/scripts (no-changelog)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Compute backport targets

--- a/.github/workflows/ci-detect-new-packages.yml
+++ b/.github/workflows/ci-detect-new-packages.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Check for new unpublished packages

--- a/.github/workflows/ci-owners-assign-reviewers.yml
+++ b/.github/workflows/ci-owners-assign-reviewers.yml
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Assign reviewer teams

--- a/.github/workflows/ci-owners-review-recommendations.yml
+++ b/.github/workflows/ci-owners-review-recommendations.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Post review recommendations

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Re-request PR Size Limit check
@@ -72,7 +72,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Check PR size

--- a/.github/workflows/clean-stale-branches.yml
+++ b/.github/workflows/clean-stale-branches.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Clean stale branches

--- a/.github/workflows/release-create-github-releases.yml
+++ b/.github/workflows/release-create-github-releases.yml
@@ -71,7 +71,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Create GitHub releases

--- a/.github/workflows/release-create-patch-pr.yml
+++ b/.github/workflows/release-create-patch-pr.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Determine release candidate branch from track

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Bump package versions

--- a/.github/workflows/release-populate-cloud-with-releases.yml
+++ b/.github/workflows/release-populate-cloud-with-releases.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Extract changes

--- a/.github/workflows/release-promote-backport-labels.yml
+++ b/.github/workflows/release-promote-backport-labels.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Reconcile backport labels

--- a/.github/workflows/release-promote-github-release.yml
+++ b/.github/workflows/release-promote-github-release.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Promote GitHub releases

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Determine track from package version number
@@ -61,7 +61,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Install script dependencies
-        run: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+        run: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
 
       - name: Check for new unpublished packages
         run: node .github/scripts/detect-new-packages.mjs

--- a/.github/workflows/release-recreate-failed-release.yml
+++ b/.github/workflows/release-recreate-failed-release.yml
@@ -88,7 +88,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Bump the root and cli versions

--- a/.github/workflows/release-set-stable-npm-packages-to-latest.yml
+++ b/.github/workflows/release-set-stable-npm-packages-to-latest.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Set npm packages to latest

--- a/.github/workflows/release-update-pointer-tag.yml
+++ b/.github/workflows/release-update-pointer-tag.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Configure git author

--- a/.github/workflows/release-version-release-notification.yml
+++ b/.github/workflows/release-version-release-notification.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Send release notification

--- a/.github/workflows/test-workflow-scripts-reusable.yml
+++ b/.github/workflows/test-workflow-scripts-reusable.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Run tests

--- a/.github/workflows/util-cleanup-abandoned-release-branches.yml
+++ b/.github/workflows/util-cleanup-abandoned-release-branches.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Cleanup release branch if PR qualifies

--- a/.github/workflows/util-codespace-preview.yml
+++ b/.github/workflows/util-codespace-preview.yml
@@ -68,7 +68,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Run the preview operation

--- a/.github/workflows/util-determine-current-version.yml
+++ b/.github/workflows/util-determine-current-version.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Extract release versions

--- a/.github/workflows/util-ensure-release-candidate-branches.yml
+++ b/.github/workflows/util-ensure-release-candidate-branches.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Ensure release-candidate branches

--- a/.github/workflows/util-refresh-cubic-schema.yml
+++ b/.github/workflows/util-refresh-cubic-schema.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       # Refreshes only. Validation runs on the PR this opens, so a schema change

--- a/.github/workflows/util-sync-master-to-3x.yml
+++ b/.github/workflows/util-sync-master-to-3x.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
         with:
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir . --ignore-workspace
+          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
           cache-dependency-path: .github/scripts/pnpm-lock.yaml
           build-command: ''
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "worker": "./packages/cli/bin/n8n worker",
     "dev:computer-use": "pnpm --filter @n8n/computer-use build && node packages/@n8n/computer-use/dist/cli.js serve",
     "stop:computer-use": "lsof -ti :7655 | xargs kill 2>/dev/null; echo 'computer-use stopped'",
-    "install-workflow-scripts": "pnpm install --dir .github/scripts --lockfile-dir . --ignore-workspace"
+    "install-workflow-scripts": "pnpm install --dir .github/scripts --lockfile-dir \"$PWD/.github/scripts\" --ignore-workspace"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -569,7 +569,8 @@ try {
 		echo(chalk.yellow('INFO: Generating SBOM and rendering THIRD_PARTY_LICENSES.md...'));
 		try {
 			const toolingDir = path.join(config.rootDir, '.github', 'scripts');
-			await $`cd ${config.rootDir} && pnpm install --frozen-lockfile --dir .github/scripts --lockfile-dir . --ignore-workspace`;
+			// pnpm resolves a relative --lockfile-dir against --dir, so pass an absolute path.
+			await $`cd ${config.rootDir} && pnpm install --frozen-lockfile --dir .github/scripts --lockfile-dir ${toolingDir} --ignore-workspace`;
 			const generateProcess = $`cd ${toolingDir} && pnpm generate-licenses`;
 			generateProcess.pipe(process.stdout);
 			await generateProcess;


### PR DESCRIPTION
## Summary

The workflow-scripts install passed `--lockfile-dir .`, which is ambiguous. pnpm resolves a relative `--lockfile-dir` against `--dir`, not the current directory, and pnpm 11 and 12 resolve it from different locations. This PR passes an absolute path in all 26 call sites, so the lockfile is always read from and written to `.github/scripts`.

`ci-owners-required-reviews.yml` already used the absolute form. This PR applies the same form everywhere else:

- 24 workflow files (26 lines): `--lockfile-dir ${{ github.workspace }}/.github/scripts`
- `package.json`, script `install-workflow-scripts`: `--lockfile-dir "$PWD/.github/scripts"`
- `scripts/build-n8n.mjs`: `--lockfile-dir ${toolingDir}`, the absolute path that the line above already computes

An absolute path is necessary. A literal relative `.github/scripts` resolves against `--dir` and writes to `.github/scripts/.github/scripts/pnpm-lock.yaml`.

## How to test

Behavior must not change on pnpm 12. Run the root script and make sure the lockfile stays in place:

```bash
pnpm run install-workflow-scripts
git status .github/scripts   # no changes, and no nested .github/scripts directory
```

To see the resolution rule, run this in an empty directory with pnpm 12:

```bash
pnpm install --dir sub --lockfile-dir sub --ignore-workspace
# writes sub/sub/pnpm-lock.yaml
```

CI coverage: every changed workflow installs the scripts through `./.github/actions/setup-nodejs`. A green run of the workflows on this PR shows the path is correct.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://linear.app/n8n/issue/DEVP-1062, which moved the monorepo to pnpm 12 and added the first absolute `--lockfile-dir`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- CI-only change; the workflows themselves are the coverage. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

