### PR TITLE
feat(core): Add a hashing package writer (no-changelog)

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/export-git-blob-parity.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-git-blob-parity.integration.test.ts
@@ -1,28 +1,41 @@
 import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
-import { WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
-import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { simpleGit } from 'simple-git';
 
+import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
+import { EventService } from '@/events/event.service';
+import { mockDataTableSizeValidator } from '@/modules/data-table/__tests__/test-helpers';
+import { DataTableService } from '@/modules/data-table/data-table.service';
+import { saveCredential } from '@test-integration/db/credentials';
+import { createFolder } from '@test-integration/db/folders';
+import { createTag } from '@test-integration/db/tags';
 import { createOwner } from '@test-integration/db/users';
+import { createProjectVariable } from '@test-integration/db/variables';
 
-import { WorkflowSerializer } from '../entities/workflow/workflow.serializer';
-import { formatEntityFile } from '../io/entity-file-format';
+import { DirectoryPackageWriter } from '../io/directory/directory-package-writer';
+import { HashingPackageWriter } from '../io/hashing-package-writer';
 import { N8nPackagesService } from '../n8n-packages.service';
 import { packageManifestSchema } from '../spec/manifest.schema';
 
-/** SHA-1 over git's blob object format: `blob <byte length>\0<content>`. */
-function gitBlobHash(content: string): string {
-	const bytes = Buffer.from(content, 'utf-8');
-	const header = Buffer.from(`blob ${bytes.length}\0`, 'utf-8');
-	return createHash('sha1')
-		.update(Buffer.concat([header, bytes]))
-		.digest('hex');
+async function readGitFileHashes() {
+	const git = simpleGit(repoDir);
+	await git.init(['--object-format=sha1']);
+	await git.addConfig('core.autocrlf', 'false');
+	await git.add('.');
+	const tree = (await git.raw(['write-tree'])).trim();
+	const entries = await git.raw(['ls-tree', '-r', '-z', tree]);
+	return entries
+		.split('\0')
+		.filter(Boolean)
+		.map((entry) => {
+			const [metadata, path] = entry.split('\t');
+			return { path, blobSha: metadata.split(' ')[2] };
+		});
 }
 
 let service: N8nPackagesService;
@@ -30,7 +43,7 @@ let owner: User;
 let repoDir: string;
 
 beforeAll(async () => {
-	await testModules.loadModules(['n8n-packages']);
+	await testModules.loadModules(['n8n-packages', 'data-table']);
 	await testDb.init();
 	service = Container.get(N8nPackagesService);
 });
@@ -40,33 +53,66 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'ProjectRelation', 'Project']);
+	await testDb.truncate([
+		'Folder',
+		'WorkflowEntity',
+		'SharedWorkflow',
+		'CredentialsEntity',
+		'SharedCredentials',
+		'DataTable',
+		'DataTableColumn',
+		'Variables',
+		'TagEntity',
+		'ProjectRelation',
+		'Project',
+	]);
+	await Container.get(VariablesService).updateCache();
+	mockDataTableSizeValidator();
 	owner = await createOwner();
 	repoDir = await mkdtemp(join(tmpdir(), 'n8n-export-parity-'));
 });
 
 afterEach(async () => {
-	await rm(repoDir, { recursive: true, force: true });
+	vi.restoreAllMocks();
+	await rm(repoDir, { recursive: true, force: true, maxRetries: 3 });
 });
 
 describe('exported files vs git blob hashes', () => {
-	it('hashes a workflow serialized through formatEntityFile to the blob sha git records for its exported file', async () => {
+	it('matches Git for every file in a project export and returns its manifest and counts', async () => {
 		const project = await createTeamProject('Parity Project', owner);
+		const folder = await createFolder(project, { name: 'Nested' });
+		await createProjectVariable('API_URL', 'https://example.com', project);
+		const credential = await saveCredential(
+			{ name: 'Header', type: 'httpHeaderAuth', data: { name: 'X-Auth', value: 'secret' } },
+			{ project, role: 'credential:owner' },
+		);
+		const table = await Container.get(DataTableService).createDataTable(project.id, {
+			name: 'Customers',
+			columns: [{ name: 'email', type: 'string' }],
+		});
 		const workflow = await createWorkflow(
 			{
-				// Non-ASCII content pins the utf-8 byte length in the blob header.
 				name: 'Zürich Parity Flow',
+				parentFolder: folder,
 				nodes: [
 					{
-						id: 'set-greeting',
-						name: 'Set',
-						type: 'n8n-nodes-base.set',
-						typeVersion: 3.4,
+						id: 'http',
+						name: 'HTTP',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 1,
 						position: [200, 0],
+						parameters: { url: '={{ $vars.API_URL }}', body: 'grüße ✓' },
+						credentials: { httpHeaderAuth: { id: credential.id, name: credential.name } },
+					},
+					{
+						id: 'table',
+						name: 'Table',
+						type: 'n8n-nodes-base.dataTable',
+						typeVersion: 1,
+						position: [400, 0],
 						parameters: {
-							assignments: {
-								assignments: [{ id: 'a1', name: 'greeting', type: 'string', value: 'grüße ✓' }],
-							},
+							operation: 'get',
+							dataTableId: { __rl: true, mode: 'id', value: table.id },
 						},
 					},
 				],
@@ -74,36 +120,62 @@ describe('exported files vs git blob hashes', () => {
 			},
 			project,
 		);
+		await createTag({ name: 'Production' }, workflow);
+		const emit = vi.spyOn(Container.get(EventService), 'emit');
+		const writer = new HashingPackageWriter();
+		const directoryWriter = new DirectoryPackageWriter(repoDir);
 
-		await service.exportPackageToDirectory(
-			{ user: owner, workflowIds: [workflow.id] },
-			{ targetDir: repoDir },
+		const result = await service.exportPackageToWriter(
+			{ user: owner, projectIds: [project.id] },
+			{
+				async writeFile(path, content) {
+					writer.writeFile(path, content);
+					await directoryWriter.writeFile(path, content);
+				},
+				async writeDirectory(path) {
+					writer.writeDirectory(path);
+					await directoryWriter.writeDirectory(path);
+				},
+			},
 		);
 
-		const git = simpleGit(repoDir);
-		await git.init();
-		await git.addConfig('user.email', 'parity@example.com');
-		await git.addConfig('user.name', 'Parity');
-		await git.addConfig('commit.gpgsign', 'false');
-		await git.add('.');
-		await git.commit('export');
-
-		const manifest = packageManifestSchema.parse(
-			jsonParse(await readFile(join(repoDir, 'manifest.json'), 'utf-8')),
+		expect(result.counts).toEqual({
+			workflows: 1,
+			folders: 1,
+			credentials: 1,
+			dataTables: 1,
+			variables: 1,
+			tags: 1,
+		});
+		expect(result.manifest).toEqual(
+			packageManifestSchema.parse(
+				jsonParse(await readFile(join(repoDir, 'manifest.json'), 'utf-8')),
+			),
 		);
-		const workflowPath = `${manifest.workflows![0].target}/workflow.json`;
-		const lsTree = await git.raw(['ls-tree', 'HEAD', '--', workflowPath]);
-		const committedHash = lsTree.trim().split('\t')[0].split(' ')[2];
-		expect(committedHash).toBeDefined();
-
-		const persistedWorkflow = await Container.get(WorkflowRepository).findOneOrFail({
-			where: { id: workflow.id },
-			relations: { parentFolder: true, tags: true },
+		const files = writer.finalize();
+		const gitFiles = await readGitFileHashes();
+		expect(files).toHaveLength(gitFiles.length);
+		expect(files).toEqual(expect.arrayContaining(gitFiles));
+		expect(files).toContainEqual({
+			path: `${result.manifest.workflows![0].target}/workflow-lifecycle.json`,
+			blobSha: expect.any(String),
 		});
-		const serialized = Container.get(WorkflowSerializer).serialize(persistedWorkflow, {
-			includeTags: true,
-		});
+		expect(emit).not.toHaveBeenCalledWith('n8n-package-exported', expect.anything());
+	});
 
-		expect(gitBlobHash(formatEntityFile(serialized))).toBe(committedHash);
+	it('matches Git for empty and binary files and replaces hashes only at the same path', async () => {
+		const writer = new HashingPackageWriter();
+		const directoryWriter = new DirectoryPackageWriter(repoDir);
+		const files = [
+			{ path: './projects/one/shared-id/data.json', content: 'first' },
+			{ path: 'projects/one/shared-id/data.json', content: Buffer.from([0, 255, 13, 10]) },
+			{ path: 'projects/two/shared-id/data.json', content: '' },
+		];
+		for (const { path, content } of files) {
+			writer.writeFile(path, content);
+			await directoryWriter.writeFile(path, content);
+		}
+
+		expect(writer.finalize()).toEqual(await readGitFileHashes());
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/io/hashing-package-writer.ts
+++ b/packages/cli/src/modules/n8n-packages/io/hashing-package-writer.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'node:crypto';
+
+import type { PackageWriter } from './package-writer';
+
+export class HashingPackageWriter implements PackageWriter {
+	private readonly hashes = new Map<string, string>();
+
+	writeFile(path: string, content: string | Buffer): void {
+		const normalised = path.startsWith('./') ? path.slice(2) : path;
+		const blobSha = createHash('sha1')
+			.update(`blob ${Buffer.byteLength(content)}\0`)
+			.update(content)
+			.digest('hex');
+		this.hashes.set(normalised, blobSha);
+	}
+
+	writeDirectory(_path: string): void {
+		return;
+	}
+
+	finalize(): Array<{ path: string; blobSha: string }> {
+		return Array.from(this.hashes, ([path, blobSha]) => ({ path, blobSha }));
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -65,6 +65,7 @@ import {
 import type { PackageRequirements } from './spec/requirements.schema';
 
 interface WrittenExport {
+	manifest: PackageManifest;
 	counts: ExportPackageEventCounts;
 	workflowIds: string[];
 	folderIds: string[];
@@ -125,9 +126,17 @@ export class N8nPackagesService {
 		target: { targetDir: string },
 	): Promise<ExportPackageSummary> {
 		const writer = new DirectoryPackageWriter(target.targetDir);
-		const result = await this.writeExport(writer, request);
+		const result = await this.exportPackageToWriter(request, writer);
 		await writer.finalize();
 		return { counts: result.counts };
+	}
+
+	async exportPackageToWriter(
+		request: ExportPackageRequest,
+		writer: PackageWriter,
+	): Promise<ExportPackageSummary & { manifest: PackageManifest }> {
+		const { manifest, counts } = await this.writeExport(writer, request);
+		return { manifest, counts };
 	}
 
 	private async writeExport(
@@ -355,6 +364,7 @@ export class N8nPackagesService {
 		};
 
 		return {
+			manifest,
 			counts,
 			workflowIds: allWorkflowsInPackage.map(({ id }) => id),
 			folderIds: allFolders.map(({ id }) => id),


### PR DESCRIPTION
## Summary

Add the instance-side hashing writer for package comparison.

- Add `HashingPackageWriter`. Hash the exact exporter bytes with Git's blob SHA-1 format. Return `{ path, blobSha }` records without retaining file contents.
- Add `exportPackageToWriter()`. Reuse the existing export pipeline and return its manifest and counts. Internal exports do not emit the archive-export event.
- Extend the existing Git-parity integration test. Cover every entity type, workflow lifecycle files, UTF-8 text, binary buffers, empty files, and repeated writes.

The writer hashes every emitted file, including `manifest.json` and `workflow-lifecycle.json`. LIGO-1050 will compare the two outputs. That comparison must exclude manifest export metadata and include workflow lifecycle changes.

This branch starts from master. It does not depend on the Git-side listing PR.

## How to test

Use Node 24. Run these commands from `packages/cli` after dependency setup and builds:

```bash
pnpm test:integration src/modules/n8n-packages --maxWorkers=4
pnpm test:unit src/modules/n8n-packages --maxWorkers=4
pnpm typecheck
pnpm lint
pnpm build > /tmp/n8n-hashing-writer-build.log 2>&1
```

All 465 package integration tests and 651 existing unit tests pass. CLI lint, typecheck, and build pass. The focused Git-parity suite also passes after the final test-fixture cleanup.

This change adds no endpoint or UI. The integration tests load the `n8n-packages` and `data-table` modules.

## Related Linear tickets, Github issues, and Community forum posts

[LIGO-1130](https://linear.app/n8n/issue/LIGO-1130)

[Git-side listing PR #38115](https://github.com/n8n-io/n8n/pull/38115)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

