### PR TITLE
chore: Update isolated-vm to 7.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,7 +540,7 @@ catalogs:
       specifier: 0.6.3
       version: 0.6.3
     isolated-vm:
-      specifier: ^7.0.0
+      specifier: ^7.0.1
       version: 7.0.1
     js-base64:
       specifier: 3.7.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -218,7 +218,7 @@ catalog:
   http-proxy-agent: 7.0.2
   https-proxy-agent: 7.0.6
   iconv-lite: 0.6.3
-  isolated-vm: ^7.0.0
+  isolated-vm: ^7.0.1
   js-base64: 3.7.8
   js-tiktoken: 1.0.21
   json-schema: 0.4.0


### PR DESCRIPTION
## Summary

Raises the `isolated-vm` catalog range from `^7.0.0` to `^7.0.1`.

The lockfile already resolves `7.0.1`, but the caret floor still permits `7.0.0`, which upstream lists as the last affected version of [GHSA-864f-rcv7-6rh4](https://github.com/laverdet/isolated-vm/security/advisories/GHSA-864f-rcv7-6rh4) (patched in `7.0.1` and `6.2.0`).

### Changes

- `pnpm-workspace.yaml`: catalog entry `isolated-vm: ^7.0.0` → `^7.0.1`.
- `pnpm-lock.yaml`: refreshed with `pnpm install --lockfile-only`. Only the recorded `specifier` changes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-1000

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

