### PR TITLE
fix(core): Reconnect the Postgres Trigger on every publish through the publication service

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/trigger-diff.test.ts
@@ -86,7 +86,7 @@ describe('computeTriggerDiff', () => {
 		expect(computeTriggerDiff([], [])).toEqual({ toAdd: new Set(), toRemove: new Set() });
 	});
 
-	describe('triggers that observe the publication itself', () => {
+	describe('triggers that are always re-registered on a version change', () => {
 		const n8nTrigger = makeNode('n8n', {
 			type: 'n8n-nodes-base.n8nTrigger',
 			parameters: { events: ['update'] },
@@ -129,6 +129,19 @@ describe('computeTriggerDiff', () => {
 			});
 
 			expect(diff).toEqual({ toAdd: new Set(['imap']), toRemove: new Set(['imap']) });
+		});
+
+		test('re-registers an unchanged Postgres Trigger so a republish reconnects its LISTEN connection', () => {
+			const postgresTrigger = makeNode('pg', {
+				type: 'n8n-nodes-base.postgresTrigger',
+				parameters: { triggerMode: 'listenTrigger', channelName: 'n8n_channel' },
+			});
+
+			const diff = computeTriggerDiff([postgresTrigger], [{ ...postgresTrigger }], {
+				versionChanged: true,
+			});
+
+			expect(diff).toEqual({ toAdd: new Set(['pg']), toRemove: new Set(['pg']) });
 		});
 
 		test('does not force other unchanged trigger types when the published version changed', () => {

--- a/packages/cli/src/workflows/publication/trigger-diff.ts
+++ b/packages/cli/src/workflows/publication/trigger-diff.ts
@@ -12,17 +12,15 @@ function registrationEqual(base: INode | undefined, target: INode | undefined): 
 	return isEqual(pick(base, registrationProps), pick(target, registrationProps));
 }
 
-// Before the workflow publication service, we re-registered every trigger on
-// publication. With the new flow, we only re-register triggers that have been
-// modified. However, some triggers relied on the old behaviour, so we force it
-// for those triggers.
+// TODO: remove this list and each special case (CAT-4492). Before the workflow
+// publication service, we re-registered every trigger on publication. With the
+// new flow, we only re-register triggers that have been modified. However, these
+// triggers relied on the old behaviour, so we force it for them.
 const ALWAYS_REREGISTER_TRIGGER_TYPES: ReadonlySet<string> = new Set([
 	'n8n-nodes-base.n8nTrigger',
 	'n8n-nodes-base.workflowTrigger',
-	// Workaround, not a contract: an IMAP connection can go silently half-open
-	// without a close or error event, so the node never asks to be reactivated.
-	// Republishing used to reconnect it. Remove once the node detects this itself.
 	'n8n-nodes-base.emailReadImap',
+	'n8n-nodes-base.postgresTrigger',
 ]);
 
 export interface TriggerDiffOptions {


### PR DESCRIPTION
## Summary

The Postgres Trigger holds a long-lived `LISTEN` connection with no `error` or `end` handler. When that connection drops, the node never calls `emitError`, so the runtime never reactivates it and notifications stop silently. Before the workflow publication service, republishing the workflow tore every trigger down and reconnected it, and users used that as the manual heal. The publication service leaves unchanged triggers running, so a republish no longer touched the trigger.

This PR adds `n8n-nodes-base.postgresTrigger` to `ALWAYS_REREGISTER_TRIGGER_TYPES` in `trigger-diff.ts`. The applier now removes and re-adds the trigger on every publish that changes the version, which reconnects `LISTEN` and, in `createTrigger` mode, re-runs the trigger DDL as it did before.

The comment on the list is now a TODO pointing at https://linear.app/n8n/issue/CAT-4492, which tracks removing the list once each node no longer needs it.

## How to test

Set `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

1. Publish a workflow with a Postgres Trigger connected to a No Op node. Confirm the `LISTEN` connection in `pg_stat_activity`.
2. Add another No Op node (do not touch the trigger) and publish again.
3. The old `LISTEN` connection closes and a new one appears. Before this change, the connection was untouched.
4. Repeat with a Schedule Trigger workflow. The schedule trigger is not re-registered, so the change is scoped to the listed nodes.

Unit test added for the diff entry.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4492
https://linear.app/n8n/issue/CAT-4221
Follow-up to #38153 and #38190.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


