### PR TITLE
feat(core): Add v3 migration report rule for external secrets project roles (no-changelog)

### DIFF
--- a/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.rule-discovery.test.ts
+++ b/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.rule-discovery.test.ts
@@ -1,10 +1,18 @@
+import { SettingsRepository } from '@n8n/db';
 import { BreakingChangeRuleMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { mock } from 'vitest-mock-extended';
 
 import '../rules';
 import type { IBreakingChangeRule } from '../types';
 
 describe('Breaking change rules auto-discovery', () => {
+	beforeAll(() => {
+		// Some rules inject repositories that need a live DataSource. Provide a
+		// mock so the container can resolve every rule without a database.
+		Container.set(SettingsRepository, mock<SettingsRepository>());
+	});
+
 	it('should register all rules grouped by version', () => {
 		const metadata = Container.get(BreakingChangeRuleMetadata);
 		const entries = metadata.getEntries();

--- a/packages/cli/src/modules/breaking-changes/rules/index.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/index.ts
@@ -31,6 +31,7 @@ import './v3/compression-node-limits.rule';
 import './v3/docker-only-deployment.rule';
 import './v3/execute-workflow-each-mode.rule';
 import './v3/execute-workflow-source-modes.rule';
+import './v3/external-secrets-project-roles-default.rule';
 import './v3/get-paired-item.rule';
 import './v3/gmail-trigger-version.rule';
 import './v3/in-memory-binary-data.rule';

--- a/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/external-secrets-project-roles-default.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/external-secrets-project-roles-default.rule.test.ts
@@ -1,0 +1,65 @@
+import type { LicenseState } from '@n8n/backend-common';
+import type { Settings, SettingsRepository } from '@n8n/db';
+import { EXTERNAL_SECRETS_SYSTEM_ROLES_ENABLED_SETTING } from '@n8n/permissions';
+import { mock } from 'vitest-mock-extended';
+
+import { ExternalSecretsProjectRolesDefaultRule } from '../external-secrets-project-roles-default.rule';
+
+describe('ExternalSecretsProjectRolesDefaultRule', () => {
+	const licenseState = mock<LicenseState>();
+	const settingsRepository = mock<SettingsRepository>();
+
+	const rule = new ExternalSecretsProjectRolesDefaultRule(licenseState, settingsRepository);
+
+	const settingRow = (value: string) =>
+		mock<Settings>({ key: EXTERNAL_SECRETS_SYSTEM_ROLES_ENABLED_SETTING.key, value });
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('detect()', () => {
+		it('should not be affected when external secrets is not licensed', async () => {
+			licenseState.isExternalSecretsLicensed.mockReturnValue(false);
+
+			const result = await rule.detect();
+
+			expect(result.isAffected).toBe(false);
+			expect(result.instanceIssues).toHaveLength(0);
+			expect(result.recommendations).toHaveLength(0);
+			expect(settingsRepository.findByKeys).not.toHaveBeenCalled();
+		});
+
+		it('should not be affected when licensed and the toggle is on', async () => {
+			licenseState.isExternalSecretsLicensed.mockReturnValue(true);
+			settingsRepository.findByKeys.mockResolvedValue([settingRow('true')]);
+
+			const result = await rule.detect();
+
+			expect(result.isAffected).toBe(false);
+			expect(result.instanceIssues).toHaveLength(0);
+		});
+
+		it('should be affected when licensed and the setting is missing', async () => {
+			licenseState.isExternalSecretsLicensed.mockReturnValue(true);
+			settingsRepository.findByKeys.mockResolvedValue([]);
+
+			const result = await rule.detect();
+
+			expect(result.isAffected).toBe(true);
+			expect(result.instanceIssues).toHaveLength(1);
+			expect(result.instanceIssues[0].level).toBe('warning');
+			expect(result.recommendations).toHaveLength(1);
+		});
+
+		it('should be affected when licensed and the toggle is off', async () => {
+			licenseState.isExternalSecretsLicensed.mockReturnValue(true);
+			settingsRepository.findByKeys.mockResolvedValue([settingRow('false')]);
+
+			const result = await rule.detect();
+
+			expect(result.isAffected).toBe(true);
+			expect(result.instanceIssues).toHaveLength(1);
+		});
+	});
+});

--- a/packages/cli/src/modules/breaking-changes/rules/v3/external-secrets-project-roles-default.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/external-secrets-project-roles-default.rule.ts
@@ -1,0 +1,74 @@
+import { LicenseState } from '@n8n/backend-common';
+import { SettingsRepository } from '@n8n/db';
+import { BreakingChangeRule } from '@n8n/decorators';
+import { EXTERNAL_SECRETS_SYSTEM_ROLES_ENABLED_SETTING } from '@n8n/permissions';
+
+import type {
+	BreakingChangeRuleMetadata,
+	IBreakingChangeInstanceRule,
+	InstanceDetectionReport,
+} from '../../types';
+import { BreakingChangeCategory } from '../../types';
+
+@BreakingChangeRule({ version: 'v3' })
+export class ExternalSecretsProjectRolesDefaultRule implements IBreakingChangeInstanceRule {
+	constructor(
+		private readonly licenseState: LicenseState,
+		private readonly settingsRepository: SettingsRepository,
+	) {}
+
+	id: string = 'external-secrets-project-roles-default-v3';
+
+	getMetadata(): BreakingChangeRuleMetadata {
+		return {
+			version: 'v3',
+			title: 'External secrets access for project roles is on by default',
+			description:
+				'In v3, project editors and admins get external-secrets scopes in their projects by default, and the Settings → External Secrets toggle is removed. Instances that keep this toggle off today widen these role permissions after the update.',
+			category: BreakingChangeCategory.environment,
+			severity: 'medium',
+			documentationUrl: 'https://docs.n8n.io/external-secrets/#access-for-project-roles',
+		};
+	}
+
+	async detect(): Promise<InstanceDetectionReport> {
+		// Project-scoped external secrets apply only on licensed instances.
+		if (!this.licenseState.isExternalSecretsLicensed()) {
+			return { isAffected: false, instanceIssues: [], recommendations: [] };
+		}
+
+		// The toggle already matching the v3 default means no behaviour change.
+		if (await this.isSystemRolesEnabled()) {
+			return { isAffected: false, instanceIssues: [], recommendations: [] };
+		}
+
+		return {
+			isAffected: true,
+			instanceIssues: [
+				{
+					title: 'Project editors and admins gain external-secrets access',
+					description:
+						'The external secrets feature is licensed and the Settings → External Secrets toggle is off. After the update, project editors and admins get external-secrets scopes in their projects by default, and the toggle is removed. These roles can read and use external secrets that they cannot access today.',
+					level: 'warning',
+				},
+			],
+			recommendations: [
+				{
+					action: 'Review project editors and admins who gain access',
+					description:
+						'Check which project editors and admins get external-secrets access under the new default. No action is needed to keep the new default. To limit access, review project memberships before the update.',
+				},
+			],
+		};
+	}
+
+	private async isSystemRolesEnabled(): Promise<boolean> {
+		const rows = await this.settingsRepository.findByKeys([
+			EXTERNAL_SECRETS_SYSTEM_ROLES_ENABLED_SETTING.key,
+		]);
+		const value = rows.find(
+			(r) => r.key === EXTERNAL_SECRETS_SYSTEM_ROLES_ENABLED_SETTING.key,
+		)?.value;
+		return value === 'true';
+	}
+}


### PR DESCRIPTION
## Summary

[video demo](https://www.loom.com/share/f518f9aa66ff47eda0b7c8c9a99b3e2f)

Add a v3 instance rule to the breaking-changes migration report. Before v3, it warns admins that the Settings → External Secrets toggle (“Enable external secrets for project roles”) is going away, and that project editors and admins will get external-secrets scopes by default.

This is the non-breaking deprecation notice only. Removing the toggle, setting, and scope gating is a separate 3.x PR.

The rule flags an instance as affected only when external secrets are licensed and the toggle is off or unset (on = already matches the v3 default).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-1073

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

