### PR TITLE
refactor(editor): Resolve a frontend module only at its declared entries

### DIFF
--- a/packages/@n8n/module-cli/frontend-module-guide.md
+++ b/packages/@n8n/module-cli/frontend-module-guide.md
@@ -142,8 +142,16 @@ export { MyFeatureModule } from './my-feature.module';
 export { useMyFeatureStore } from './my-feature.store';
 ```
 
-A deep path into `src/` is not part of the contract. If the shell or another package needs a
-value, export that value here.
+A deep path into `src/` is not part of the contract, and nothing resolves one. The `exports` map of
+the package declares the entries, and the Vite aliases and the `paths` of editor-ui carry exactly
+those entries — no wildcard. A deep import fails `lint` with a message that names the entries, and
+fails `typecheck` with `TS2307`. If the shell or another package needs a value, export that value
+here.
+
+A module that needs a second entry — insights exports `./insights.module`, so the shell can
+register the descriptor without pulling the store into the eager graph — adds three lines together:
+the key in its own `exports` map, the `paths` entry in `editor-ui/tsconfig.json`, and nothing else.
+The alias generator reads the `exports` map, and `aliases.test.ts` fails if the two disagree.
 
 ```ts
 // src/my-feature.module.ts
@@ -428,7 +436,7 @@ hand, or when you debug a CI failure.
 | - | ---------------------------------------------- | ----------------------------------------- | ----------- |
 | 1 | `@n8n/frontend-vite-config/index.ts`           | an entry in the `modulePackages` array     | ✅          |
 | 2 | `editor-ui/package.json`                       | `"@n8n/frontend-module-x": "workspace:*"`  | ✅          |
-| 3 | `editor-ui/tsconfig.json`                      | two `paths` entries (bare + `/*`)          | ✅          |
+| 3 | `editor-ui/tsconfig.json`                      | one `paths` entry per declared export      | ✅          |
 | 4 | `editor-ui/src/app/modules.manifest.ts`        | import + array entry                       | ✅          |
 | 5 | `.github/CODEOWNERS`                           | one line for the new package               | ❌ do this  |
 
@@ -441,7 +449,9 @@ resolver:
 - **#1** is the Vite alias. It makes the dev server and the production bundle read your module
   from `src`. A person maintains this table by hand. It does not appear without that edit.
 - **#2** makes a bare import resolve outside Vite, for `vue-tsc` and for node.
-- **#3** makes `vue-tsc` resolve the same `src` that Vite resolves.
+- **#3** makes `vue-tsc` resolve the same `src` that Vite resolves. One entry for each key in the
+  `exports` map of the module, and no `/*` wildcard beside it. A wildcard makes every file under
+  `src` part of the contract by accident, which is the failure the `exports` map prevents.
 
 **Note:** the list came from the file system in the past. It does not now. Commit `fae4c98` made
 that change on purpose, and gave a table that you read and edit. If you read an older description
@@ -471,8 +481,9 @@ is a real gate, and not a convention. The failure is also real: for months, `vue
 packages from `src` while the build used their `dist`.
 
 **Note:** the test makes sure that the alias table, the `paths` of editor-ui and the shared module
-base agree. It says nothing about an import of one module by another module. That is the separate
-boundary above, and no tool enforces it.
+base agree. It also checks each module entry by entry: every key of the `exports` map resolves, and
+`<package>/probe` resolves nowhere. It says nothing about an import of one module by another module.
+That is the separate boundary above, and no tool enforces it.
 
 The old `pnpm check:frontend-aliases` script is gone. `aliases.test.ts` replaced it. The guard now
 runs in the standard frontend test job, and not in `lint:ci`.

--- a/packages/@n8n/module-cli/frontend-module-guide.md
+++ b/packages/@n8n/module-cli/frontend-module-guide.md
@@ -149,14 +149,24 @@ fails `typecheck` with `TS2307`. If the shell or another package needs a value, 
 here.
 
 A module that needs a second entry — insights exports `./insights.module`, so the shell can
-register the descriptor without pulling the store into the eager graph — adds three lines together:
-the key in its own `exports` map, the `paths` entry in `editor-ui/tsconfig.json`, and nothing else.
-The alias generator reads the `exports` map, and `aliases.test.ts` fails if the two disagree.
+register the descriptor without pulling the store into the eager graph — declares it in two
+places: the key in its own `exports` map, and the matching `paths` entry in
+`editor-ui/tsconfig.json`. The alias generator reads the `exports` map, and `aliases.test.ts`
+fails if the two disagree. Then write the import that needs the entry, as
+`modules.manifest.ts` does for `./insights.module`.
 
-A module can opt out of the whole rule with a `"./*"` key (`"./*": "./src/*"` in `exports`, plus
-`"@n8n/frontend-module-x/*"` in the `paths` of editor-ui). Every file under `src` then resolves and
-lints clean, at any depth. Do this only for a module that means it: the entries are the part of a
-module you cannot move, so a wildcard makes the whole `src` tree the contract.
+A key can carry a wildcard, at the top level or nested:
+
+| `exports` key           | `paths` key in editor-ui              | what resolves                   |
+| ----------------------- | ------------------------------------- | ------------------------------- |
+| `"./insights.module"`   | `"@n8n/frontend-module-x/insights.module"` | that one file                   |
+| `"./views/*"`           | `"@n8n/frontend-module-x/views/*"`    | anything under `src/views`, at any depth |
+| `"./*"`                 | `"@n8n/frontend-module-x/*"`          | anything under `src`, at any depth |
+
+A `"./*"` key is the opt-out from the whole rule. Use it only for a module that means it: the
+entries are the part of a module you cannot move, so a wildcard makes the whole `src` tree the
+contract. A nested key such as `"./views/*"` is the middle ground — one directory becomes public
+and the rest of `src` stays internal.
 
 ```ts
 // src/my-feature.module.ts

--- a/packages/@n8n/module-cli/frontend-module-guide.md
+++ b/packages/@n8n/module-cli/frontend-module-guide.md
@@ -153,6 +153,11 @@ register the descriptor without pulling the store into the eager graph — adds 
 the key in its own `exports` map, the `paths` entry in `editor-ui/tsconfig.json`, and nothing else.
 The alias generator reads the `exports` map, and `aliases.test.ts` fails if the two disagree.
 
+A module can opt out of the whole rule with a `"./*"` key (`"./*": "./src/*"` in `exports`, plus
+`"@n8n/frontend-module-x/*"` in the `paths` of editor-ui). Every file under `src` then resolves and
+lints clean, at any depth. Do this only for a module that means it: the entries are the part of a
+module you cannot move, so a wildcard makes the whole `src` tree the contract.
+
 ```ts
 // src/my-feature.module.ts
 import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';

--- a/packages/@n8n/module-cli/src/frontend.mjs
+++ b/packages/@n8n/module-cli/src/frontend.mjs
@@ -63,8 +63,9 @@ const files = (name) => [
  *   2. `editor-ui/package.json` gets the devDependency. pnpm then links the package, and a bare
  *      import of it also resolves outside Vite, for vue-tsc and for Node. editor-ui bundles
  *      everything it imports, so all of its dependencies are devDependencies.
- *   3. `editor-ui/tsconfig.json` gets the two `paths` entries. vue-tsc then reads the same source
- *      that Vite reads. `editor-ui/vite/aliases.test.ts` fails when 1 and 3 disagree.
+ *   3. `editor-ui/tsconfig.json` gets the `paths` entry for the declared entry of the module.
+ *      vue-tsc then reads the same source that Vite reads. `editor-ui/vite/aliases.test.ts` fails
+ *      when 1 and 3 disagree.
  *   4. `editor-ui/src/app/modules.manifest.ts` gets the descriptor.
  */
 export const createFrontend = ({ name, packageDir, substitutions, root = repoRoot }) => {
@@ -131,6 +132,9 @@ export const createFrontend = ({ name, packageDir, substitutions, root = repoRoo
 	}
 
 	// 3. The tsconfig paths. Keep them next to the SDK, which every module depends on.
+	//    One entry, and no `/*` wildcard beside it: the `exports` map of the template declares
+	//    `.` only, and a wildcard here would make every file under `src` reachable from the
+	//    shell. A module that declares a second entry in `exports` adds its pair by hand.
 	if (
 		editLines(target.editorUiTsconfig, (lines) => {
 			if (lines.some((line) => line.includes(`"${packageName}"`))) return undefined;
@@ -140,7 +144,6 @@ export const createFrontend = ({ name, packageDir, substitutions, root = repoRoo
 				at + 1,
 				0,
 				`\t\t\t"${packageName}": ["../../modules/${name}/frontend/src/index.ts"],`,
-				`\t\t\t"${packageName}/*": ["../../modules/${name}/frontend/src/*"],`,
 			);
 			return lines;
 		})

--- a/packages/@n8n/module-cli/src/frontend.test.mjs
+++ b/packages/@n8n/module-cli/src/frontend.test.mjs
@@ -216,9 +216,10 @@ describe('createFrontend', () => {
 			expect(read(root, 'editorUiTsconfig')).toContain(
 				`"${PACKAGE}": ["../../modules/${NAME}/frontend/src/index.ts"],`,
 			);
-			expect(read(root, 'editorUiTsconfig')).toContain(
-				`"${PACKAGE}/*": ["../../modules/${NAME}/frontend/src/*"],`,
-			);
+			// No `/*` wildcard beside it. A wildcard resolves every file under the module's `src`,
+			// which makes each of them part of the contract by accident. The `exports` map of the
+			// template declares `.` only, and the two have to say the same.
+			expect(read(root, 'editorUiTsconfig')).not.toContain(`"${PACKAGE}/*"`);
 			expect(read(root, 'manifest')).toContain(`import { MyFeatureModule } from '${PACKAGE}';`);
 			expect(read(root, 'manifest')).toMatch(/\tMyFeatureModule,\n\];/);
 		});
@@ -292,7 +293,7 @@ describe('createFrontend', () => {
 			expect(occurrences(manifest, 'MyFeatureModule')).toBe(2);
 			expect(occurrences(read(root, 'viteConfig'), PACKAGE)).toBe(1);
 			expect(occurrences(read(root, 'editorUiPackage'), PACKAGE)).toBe(1);
-			expect(occurrences(read(root, 'editorUiTsconfig'), PACKAGE)).toBe(2);
+			expect(occurrences(read(root, 'editorUiTsconfig'), PACKAGE)).toBe(1);
 		});
 	});
 
@@ -316,7 +317,7 @@ describe('createFrontend', () => {
 			]);
 			expect(occurrences(read(root, 'viteConfig'), PACKAGE)).toBe(1);
 			expect(occurrences(read(root, 'editorUiPackage'), PACKAGE)).toBe(1);
-			expect(occurrences(read(root, 'editorUiTsconfig'), PACKAGE)).toBe(2);
+			expect(occurrences(read(root, 'editorUiTsconfig'), PACKAGE)).toBe(1);
 			expect(occurrences(read(root, 'manifest'), PACKAGE)).toBe(1);
 		});
 

--- a/packages/frontend/@n8n/frontend-vite-config/index.ts
+++ b/packages/frontend/@n8n/frontend-vite-config/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { Alias } from 'vite';
 
@@ -18,7 +19,7 @@ import type { Alias } from 'vite';
  * `entry: false` marks a package with no `src/index.ts`. The `exports` map of such a package has no
  * `.` key. A bare import of it does not resolve, so do not make an alias for it.
  */
-export const sourcePackages = [
+export const sourcePackages: Array<{ name: string; dir: string; entry?: boolean }> = [
 	{ name: '@n8n/api-types', dir: '@n8n/api-types' },
 	{ name: '@n8n/chat', dir: 'frontend/@n8n/chat' },
 	{ name: '@n8n/chat-hub', dir: '@n8n/chat-hub' },
@@ -42,8 +43,11 @@ export const sourcePackages = [
  *
  * A module that aliases the other modules lets a cross-module import resolve in its own test run.
  * The module tsconfig base holds that boundary.
+ *
+ * A module entry carries no `entry` flag: the `exports` map of the package says which specifiers
+ * resolve. See `moduleEntryAliases`.
  */
-export const modulePackages: Array<{ name: string; dir: string; entry?: boolean }> = [
+export const modulePackages: Array<{ name: string; dir: string }> = [
 	{ name: '@n8n/frontend-module-insights', dir: 'modules/insights/frontend' },
 	{ name: '@n8n/frontend-module-instance-registry', dir: 'modules/instance-registry/frontend' },
 	{ name: '@n8n/frontend-module-otel', dir: 'modules/otel/frontend' },
@@ -63,7 +67,7 @@ const escapeForRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, 
  * `@n8n/chat`, because `(.+)` needs one more character after the name. That bare import then
  * resolves to `dist`.
  */
-const expand = (packagesDir: string, packages: typeof modulePackages): Alias[] =>
+const expand = (packagesDir: string, packages: typeof sourcePackages): Alias[] =>
 	packages.flatMap(({ name, dir, entry = true }) => {
 		const src = resolve(packagesDir, dir, 'src');
 		const pattern = escapeForRegExp(name);
@@ -79,9 +83,52 @@ const expand = (packagesDir: string, packages: typeof modulePackages): Alias[] =
 export const frontendSourceAliases = (packagesDir: string): Alias[] =>
 	expand(packagesDir, sourcePackages);
 
+/**
+ * One alias per key in the `exports` map of the module package, and no wildcard beside them.
+ *
+ * A module declares its public entries in `exports`. `expand` above instead gives every package a
+ * `^<name>/(.+)$` catch-all, which resolves any file under `src` and so makes each of them part of
+ * the contract by accident. A module then cannot move an internal file, and a consumer that
+ * reaches for an SFC directly re-enters the eager import graph that the declared entries were
+ * chosen to keep out of.
+ *
+ * The catch-all stays for `sourcePackages`: `@n8n/stores` and `@n8n/composables` are subpath-only
+ * by design, and their `exports` maps use a wildcard.
+ *
+ * A module that needs a second entry adds the key to its own `exports` map, and the matching
+ * `paths` entry to `editor-ui/tsconfig.json`. A `"./*"` key opts that module back into a wildcard.
+ */
+const moduleEntryAliases = (packagesDir: string, name: string, dir: string): Alias[] => {
+	const packageDir = resolve(packagesDir, dir);
+	const { exports } = JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8')) as {
+		exports?: Record<string, unknown>;
+	};
+
+	const entries = Object.entries(exports ?? {});
+	if (entries.length === 0) {
+		throw new Error(`${name} declares no "exports" map, so no specifier of it resolves to src.`);
+	}
+
+	return entries.map(([subpath, target]) => {
+		if (typeof target !== 'string') {
+			throw new Error(`${name} maps "${subpath}" to a condition object, which this cannot alias.`);
+		}
+
+		const specifier = subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`;
+		const file = resolve(packageDir, target);
+
+		return specifier.includes('*')
+			? {
+					find: new RegExp(`^${escapeForRegExp(specifier).replace('\\*', '(.+)')}$`),
+					replacement: file.replace('*', '$1'),
+				}
+			: { find: new RegExp(`^${escapeForRegExp(specifier)}$`), replacement: file };
+	});
+};
+
 /** Only the shell uses this map. See `modulePackages`. */
 export const frontendModuleAliases = (packagesDir: string): Alias[] =>
-	expand(packagesDir, modulePackages);
+	modulePackages.flatMap(({ name, dir }) => moduleEntryAliases(packagesDir, name, dir));
 
 /**
  * `n8n-workflow` imports `astVisit` from `@n8n/tournament` for its expression sandbox. Nothing

--- a/packages/frontend/AGENTS.md
+++ b/packages/frontend/AGENTS.md
@@ -6,6 +6,8 @@ Extra information, specific to the frontend codebase. Use this when doing any fr
   Scaffold one with `pnpm n8n-module-sdk create`. Then obey `packages/@n8n/module-cli/frontend-module-guide.md`.
   A module owns its tsconfig, its lint config and its vitest config.
   A module must never import `@/…` or another `@n8n/frontend-module-*`.
+  The shell reaches a module only at the entries its `exports` map declares. A deeper path
+  resolves nowhere and fails lint.
 - When rendering `el-plus` popovers/dropdowns/selects inside `N8nDialog`, prefer to keep them in the dialog stacking context with `:teleported="false"` unless they intentionally need to escape.
 - Available icon names are in `packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts`.
   Use keys from `updatedIconSet` only — `deprecatedIconSet` entries must not be used in new code.

--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -1,3 +1,7 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'eslint/config';
 import { frontendConfig } from '@n8n/eslint-config/frontend';
 import oxlint from 'eslint-plugin-oxlint';
@@ -9,10 +13,6 @@ import oxlint from 'eslint-plugin-oxlint';
  * The old path no longer resolves, so this is about the message, not the failure: it
  * names the package and it says that the shell reaches a module through
  * `src/app/modules.manifest.ts`, not through a deep path.
- *
- * Spread into every block that sets `no-restricted-imports`. Flat-config replaces
- * rule options rather than merging them, so a scoped block that omits these patterns
- * would switch the ratchet off for its own files.
  */
 const extractedFeatures = [
 	{
@@ -31,6 +31,48 @@ const extractedFeatures = [
 			'insights is the @n8n/frontend-module-insights package. The shell registers a module through src/app/modules.manifest.ts.',
 	},
 ];
+
+const MODULES_DIR = fileURLToPath(new URL('../../modules', import.meta.url));
+
+/** The manifest of the frontend package of every module under `packages/modules`. */
+const moduleManifests = () =>
+	readdirSync(MODULES_DIR, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => join(MODULES_DIR, entry.name, 'frontend', 'package.json'))
+		.filter((manifest) => existsSync(manifest))
+		.map((manifest) => JSON.parse(readFileSync(manifest, 'utf8')))
+		.filter(({ name }) => typeof name === 'string' && name.startsWith('@n8n/frontend-module-'));
+
+/**
+ * Deep-import ratchet: a module package is reachable only at the entries its own `exports`
+ * map declares. Every other file under its `src` is internal, and a module has to be free to
+ * move one.
+ *
+ * The Vite aliases and the `paths` in `tsconfig.json` no longer resolve a deep path, so this
+ * is about the message: it names the entries to import instead. The list comes from the
+ * `exports` maps, not from a copy of them here, so a new module and a new entry are both
+ * covered on the day they land.
+ *
+ * The negations need gitignore semantics, which is what `no-restricted-imports` gives a
+ * `group`. `src/app/moduleEntries.test.ts` lints real text to hold that.
+ */
+const moduleEntryPatterns = moduleManifests().map(({ name, exports }) => {
+	const entries = Object.keys(exports ?? { '.': '' }).map((subpath) =>
+		subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`,
+	);
+
+	return {
+		group: [`${name}/**`, ...entries.filter((entry) => entry !== name).map((entry) => `!${entry}`)],
+		message: `${name} is reachable only at its declared entries: ${entries.join(', ')}. A deeper path is internal to the module. To add an entry, put it in the "exports" map of the package and in the paths of editor-ui/tsconfig.json.`,
+	};
+});
+
+/**
+ * Spread into every block that sets `no-restricted-imports`. Flat-config replaces rule
+ * options rather than merging them, so a scoped block that omits these patterns would switch
+ * both ratchets off for its own files.
+ */
+const moduleBoundaryPatterns = [...extractedFeatures, ...moduleEntryPatterns];
 
 export default defineConfig(
 	frontendConfig,
@@ -268,7 +310,7 @@ export default defineConfig(
 			'@typescript-eslint/no-unsafe-argument': 'warn',
 			'@typescript-eslint/no-unsafe-member-access': 'warn',
 			'@typescript-eslint/no-unsafe-return': 'warn',
-			'@typescript-eslint/no-restricted-imports': ['error', { patterns: extractedFeatures }],
+			'@typescript-eslint/no-restricted-imports': ['error', { patterns: moduleBoundaryPatterns }],
 		},
 	},
 	{
@@ -330,7 +372,7 @@ export default defineConfig(
 				'error',
 				{
 					patterns: [
-						...extractedFeatures,
+						...moduleBoundaryPatterns,
 						{
 							group: ['**/ndv/runData/components/RunData.vue'],
 							message:

--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -1,10 +1,8 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { defineConfig } from 'eslint/config';
 import { frontendConfig } from '@n8n/eslint-config/frontend';
 import oxlint from 'eslint-plugin-oxlint';
+
+import { moduleEntryPatterns } from './eslint/module-entry-patterns.mjs';
 
 /**
  * Extraction ratchet: a feature that has become a module package must not reappear
@@ -32,47 +30,12 @@ const extractedFeatures = [
 	},
 ];
 
-const MODULES_DIR = fileURLToPath(new URL('../../modules', import.meta.url));
-
-/** The manifest of the frontend package of every module under `packages/modules`. */
-const moduleManifests = () =>
-	readdirSync(MODULES_DIR, { withFileTypes: true })
-		.filter((entry) => entry.isDirectory())
-		.map((entry) => join(MODULES_DIR, entry.name, 'frontend', 'package.json'))
-		.filter((manifest) => existsSync(manifest))
-		.map((manifest) => JSON.parse(readFileSync(manifest, 'utf8')))
-		.filter(({ name }) => typeof name === 'string' && name.startsWith('@n8n/frontend-module-'));
-
-/**
- * Deep-import ratchet: a module package is reachable only at the entries its own `exports`
- * map declares. Every other file under its `src` is internal, and a module has to be free to
- * move one.
- *
- * The Vite aliases and the `paths` in `tsconfig.json` no longer resolve a deep path, so this
- * is about the message: it names the entries to import instead. The list comes from the
- * `exports` maps, not from a copy of them here, so a new module and a new entry are both
- * covered on the day they land.
- *
- * The negations need gitignore semantics, which is what `no-restricted-imports` gives a
- * `group`. `src/app/moduleEntries.test.ts` lints real text to hold that.
- */
-const moduleEntryPatterns = moduleManifests().map(({ name, exports }) => {
-	const entries = Object.keys(exports ?? { '.': '' }).map((subpath) =>
-		subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`,
-	);
-
-	return {
-		group: [`${name}/**`, ...entries.filter((entry) => entry !== name).map((entry) => `!${entry}`)],
-		message: `${name} is reachable only at its declared entries: ${entries.join(', ')}. A deeper path is internal to the module. To add an entry, put it in the "exports" map of the package and in the paths of editor-ui/tsconfig.json.`,
-	};
-});
-
 /**
  * Spread into every block that sets `no-restricted-imports`. Flat-config replaces rule
  * options rather than merging them, so a scoped block that omits these patterns would switch
  * both ratchets off for its own files.
  */
-const moduleBoundaryPatterns = [...extractedFeatures, ...moduleEntryPatterns];
+const moduleBoundaryPatterns = [...extractedFeatures, ...moduleEntryPatterns()];
 
 export default defineConfig(
 	frontendConfig,

--- a/packages/frontend/editor-ui/eslint/module-entry-patterns.mjs
+++ b/packages/frontend/editor-ui/eslint/module-entry-patterns.mjs
@@ -21,33 +21,50 @@ const moduleManifests = () => {
 		.filter(({ name }) => typeof name === 'string' && name.startsWith('@n8n/frontend-module-'));
 };
 
-/** The specifiers an `exports` map declares, as a consumer writes them. */
-const declaredEntries = (name, exports) =>
-	Object.keys(exports ?? { '.': '' }).map((subpath) =>
-		subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`,
-	);
+/** The subpath of an `exports` key, as a consumer writes it after the package name. */
+const subpathOf = (key) => key.replace(/^\.\//, '');
 
 /**
- * `no-restricted-imports` matches a `group` with gitignore semantics, where `*` stops at a `/`.
- * A `*` in an `exports` key does not: Node matches it across `/`, and so do the Vite alias and
- * the tsconfig `paths` entry that mirror it. So a `"./*"` module resolves `<name>/one/two`, and
- * `!<name>/*` would still refuse it. Widen the `*` to `**` to keep lint and resolution in step.
+ * The `!` patterns that re-allow one declared subpath. `no-restricted-imports` matches a `group`
+ * with gitignore semantics, which costs two adjustments:
+ *
+ * 1. A gitignore `*` stops at a `/`. A `*` in an `exports` key does not — Node matches it across
+ *    one, and so do the Vite alias and the tsconfig `paths` entry that mirror the key. So a
+ *    `"./*"` module resolves `<name>/one/two`, and `!<name>/*` would refuse it. Widen it to `**`.
+ * 2. gitignore refuses to re-include a path whose parent directory is excluded, and `<name>/**`
+ *    excludes every directory inside the package. So a nested key such as `"./views/*"` needs
+ *    each ancestor directory unexcluded first. The trailing slash keeps that to the directory:
+ *    `!<name>/views/` un-prunes the directory without making the bare `<name>/views` — which no
+ *    `exports` key declares and nothing resolves — an allowed specifier.
+ *
+ * `src/app/moduleEntries.test.ts` runs each key shape through ESLint. Both adjustments look
+ * unnecessary until it does.
  */
-const negate = (entry) => `!${entry.replace('*', '**')}`;
+const negations = (name, subpath) => {
+	const segments = subpath.split('/');
+	const ancestors = segments
+		.slice(0, -1)
+		.map((_, index) => `!${name}/${segments.slice(0, index + 1).join('/')}/`);
+
+	return [...ancestors, `!${name}/${subpath.replace('*', '**')}`];
+};
 
 /**
  * One `no-restricted-imports` pattern for one module package: ban every path inside it, then
  * re-allow the entries its `exports` map declares.
  *
  * A module that declares `"./*"` re-allows all of them, which is the documented opt-out back
- * into a wildcard. `src/app/moduleEntries.test.ts` covers that case, and the two-segment
- * specifier that broke it.
+ * into a wildcard.
  */
 export const moduleEntryPattern = ({ name, exports }) => {
-	const entries = declaredEntries(name, exports);
+	const keys = Object.keys(exports ?? { '.': '' });
+	const entries = keys.map((key) => (key === '.' ? name : `${name}/${subpathOf(key)}`));
+	const allowed = keys
+		.filter((key) => key !== '.')
+		.flatMap((key) => negations(name, subpathOf(key)));
 
 	return {
-		group: [`${name}/**`, ...entries.filter((entry) => entry !== name).map(negate)],
+		group: [`${name}/**`, ...allowed],
 		message: `${name} is reachable only at its declared entries: ${entries.join(', ')}. A deeper path is internal to the module. To add an entry, put it in the "exports" map of the package and in the paths of editor-ui/tsconfig.json.`,
 	};
 };

--- a/packages/frontend/editor-ui/eslint/module-entry-patterns.mjs
+++ b/packages/frontend/editor-ui/eslint/module-entry-patterns.mjs
@@ -1,0 +1,65 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Resolved on call, not at import. Under vitest's jsdom, `import.meta.url` is not a file URL, so
+ * `fileURLToPath` throws — and `moduleEntries.test.ts` imports `moduleEntryPattern` from here.
+ * Only ESLint, which loads this file from disk in Node, calls the scan below.
+ */
+const modulesDir = () => fileURLToPath(new URL('../../../modules', import.meta.url));
+
+/** The manifest of the frontend package of every module under `packages/modules`. */
+const moduleManifests = () => {
+	const dir = modulesDir();
+
+	return readdirSync(dir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => join(dir, entry.name, 'frontend', 'package.json'))
+		.filter((manifest) => existsSync(manifest))
+		.map((manifest) => JSON.parse(readFileSync(manifest, 'utf8')))
+		.filter(({ name }) => typeof name === 'string' && name.startsWith('@n8n/frontend-module-'));
+};
+
+/** The specifiers an `exports` map declares, as a consumer writes them. */
+const declaredEntries = (name, exports) =>
+	Object.keys(exports ?? { '.': '' }).map((subpath) =>
+		subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`,
+	);
+
+/**
+ * `no-restricted-imports` matches a `group` with gitignore semantics, where `*` stops at a `/`.
+ * A `*` in an `exports` key does not: Node matches it across `/`, and so do the Vite alias and
+ * the tsconfig `paths` entry that mirror it. So a `"./*"` module resolves `<name>/one/two`, and
+ * `!<name>/*` would still refuse it. Widen the `*` to `**` to keep lint and resolution in step.
+ */
+const negate = (entry) => `!${entry.replace('*', '**')}`;
+
+/**
+ * One `no-restricted-imports` pattern for one module package: ban every path inside it, then
+ * re-allow the entries its `exports` map declares.
+ *
+ * A module that declares `"./*"` re-allows all of them, which is the documented opt-out back
+ * into a wildcard. `src/app/moduleEntries.test.ts` covers that case, and the two-segment
+ * specifier that broke it.
+ */
+export const moduleEntryPattern = ({ name, exports }) => {
+	const entries = declaredEntries(name, exports);
+
+	return {
+		group: [`${name}/**`, ...entries.filter((entry) => entry !== name).map(negate)],
+		message: `${name} is reachable only at its declared entries: ${entries.join(', ')}. A deeper path is internal to the module. To add an entry, put it in the "exports" map of the package and in the paths of editor-ui/tsconfig.json.`,
+	};
+};
+
+/**
+ * Deep-import ratchet: a module package is reachable only at the entries its own `exports` map
+ * declares. Every other file under its `src` is internal, and a module has to be free to move
+ * one.
+ *
+ * The Vite aliases and the `paths` in `tsconfig.json` no longer resolve a deep path, so this is
+ * about the message: it names the entries to import instead. The list comes from the `exports`
+ * maps on disk, not from a copy of them here, so a new module and a new entry are both covered
+ * on the day they land.
+ */
+export const moduleEntryPatterns = () => moduleManifests().map(moduleEntryPattern);

--- a/packages/frontend/editor-ui/src/app/extractionRatchet.test.ts
+++ b/packages/frontend/editor-ui/src/app/extractionRatchet.test.ts
@@ -1,16 +1,20 @@
+import { modulePackages } from '@n8n/frontend-vite-config';
 import { ESLint } from 'eslint';
 
 /**
- * The extraction ratchet must hold for every file under `src`.
+ * The two module ratchets must hold for every file under `src`: an extracted feature
+ * must not reappear at its old path, and a module package is reachable only at the
+ * entries its `exports` map declares.
  *
  * `no-restricted-imports` is not mergeable across flat-config blocks — a later
  * block replaces the rule outright. That is exactly how the ratchet was turned off
  * for `src/features/agents/**` once already: a narrower block set the rule without
- * spreading `extractedFeatures`. A comment cannot hold that, so this asserts
+ * spreading `moduleBoundaryPatterns`. A comment cannot hold that, so this asserts
  * the *resolved* config rather than the config source.
  *
  * Add a block that sets `no-restricted-imports` for some subtree and forgets the
- * spread, and the matching path below fails.
+ * spread, and the matching path below fails. `moduleEntries.test.ts` holds the other
+ * half: that the deep-import patterns say what they mean.
  */
 type RestrictedImports = [
 	string | number,
@@ -63,6 +67,16 @@ describe('extraction ratchet', () => {
 		const groups = (options.patterns ?? []).flatMap((pattern) => pattern.group ?? []);
 		for (const { group, package: pkg } of EXTRACTED_MODULES) {
 			expect(groups, `${path} does not restrict ${pkg}'s old path`).toContain(group);
+		}
+	});
+
+	it.each(PATHS)('restricts every undeclared path inside a module package for %s', (path) => {
+		const groups = ((configs.get(path) as RestrictedImports)[1].patterns ?? []).flatMap(
+			(pattern) => pattern.group ?? [],
+		);
+
+		for (const { name } of modulePackages) {
+			expect(groups, `${path} lets a deep import into ${name} through`).toContain(`${name}/**`);
 		}
 	});
 

--- a/packages/frontend/editor-ui/src/app/moduleEntries.test.ts
+++ b/packages/frontend/editor-ui/src/app/moduleEntries.test.ts
@@ -4,6 +4,8 @@ import { join, resolve } from 'node:path';
 import { modulePackages } from '@n8n/frontend-vite-config';
 import { ESLint } from 'eslint';
 
+import { moduleEntryPattern } from '../../eslint/module-entry-patterns.mjs';
+
 /**
  * A module package is reachable only at the entries its own `exports` map declares. The Vite
  * aliases and the `paths` in `tsconfig.json` stop a deeper path from resolving;
@@ -42,8 +44,8 @@ describe('module entry ratchet', () => {
 		eslint = new ESLint({ cwd: process.cwd() });
 	});
 
-	const restrictions = async (source: string) => {
-		const [result] = await eslint.lintText(source, { filePath: PROBE });
+	const restrictions = async (source: string, instance = eslint) => {
+		const [result] = await instance.lintText(source, { filePath: PROBE });
 		return result.messages.filter((message) => message.ruleId === RULE);
 	};
 
@@ -84,4 +86,64 @@ describe('module entry ratchet', () => {
 
 		expect(await restrictions(source)).toHaveLength(1);
 	}, 60000);
+
+	describe('a module that declares "./*"', () => {
+		// The documented opt-out back into a wildcard. No module in the tree declares it, so the
+		// pattern comes from the same builder the config uses, fed to ESLint through
+		// `overrideConfig`. Without the two-segment case below, `!<name>/*` looked correct: a
+		// gitignore `*` stops at a `/`, while the `exports` key, the Vite alias and the tsconfig
+		// `paths` entry all match across one.
+		const WILDCARD = '@n8n/frontend-module-wildcard-probe';
+		const NARROW = '@n8n/frontend-module-narrow-probe';
+
+		const withPattern = (manifest: { name: string; exports: Record<string, string> }) =>
+			new ESLint({
+				cwd: process.cwd(),
+				overrideConfig: {
+					rules: { [RULE]: ['error', { patterns: [moduleEntryPattern(manifest)] }] },
+				},
+			});
+
+		it.each([
+			['the bare name', ''],
+			['one segment', '/one'],
+			['two segments', '/one/two'],
+			['three segments', '/one/two/three'],
+		])(
+			'allows %s under the wildcard key',
+			async (_label, subpath) => {
+				const instance = withPattern({
+					name: WILDCARD,
+					exports: { '.': './src/index.ts', './*': './src/*' },
+				});
+
+				expect(await restrictions(`import '${WILDCARD}${subpath}';\n`, instance)).toEqual([]);
+			},
+			60000,
+		);
+
+		it.each(['/one', '/one/two'])(
+			'still refuses %s under a narrow key',
+			async (subpath) => {
+				// The control. A module that declares one subpath does not get the wildcard by
+				// accident, at either depth.
+				const instance = withPattern({
+					name: NARROW,
+					exports: { '.': './src/index.ts', './narrow.module': './src/narrow.module.ts' },
+				});
+
+				expect(await restrictions(`import '${NARROW}${subpath}';\n`, instance)).toHaveLength(1);
+			},
+			60000,
+		);
+
+		it('allows the entry a narrow key declares', async () => {
+			const instance = withPattern({
+				name: NARROW,
+				exports: { '.': './src/index.ts', './narrow.module': './src/narrow.module.ts' },
+			});
+
+			expect(await restrictions(`import '${NARROW}/narrow.module';\n`, instance)).toEqual([]);
+		}, 60000);
+	});
 });

--- a/packages/frontend/editor-ui/src/app/moduleEntries.test.ts
+++ b/packages/frontend/editor-ui/src/app/moduleEntries.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { modulePackages } from '@n8n/frontend-vite-config';
+import { ESLint } from 'eslint';
+
+/**
+ * A module package is reachable only at the entries its own `exports` map declares. The Vite
+ * aliases and the `paths` in `tsconfig.json` stop a deeper path from resolving;
+ * `no-restricted-imports` gives the message that names the entry to use instead.
+ *
+ * This lints real text, because the patterns carry negations (`!<name>/<entry>`) and only
+ * gitignore semantics make them allow the declared entries again. A pattern list read as data
+ * cannot show that: the same list with the negations dropped would still look right, and every
+ * import of a module would then be an error.
+ *
+ * `extractionRatchet.test.ts` holds the other half: that no flat-config block drops the patterns.
+ */
+const RULE = '@typescript-eslint/no-restricted-imports';
+
+// An existing file in the TS program, so type-aware rules have a program to attach the text to.
+// The content comes from each test; only the path is read from here.
+const PROBE = 'src/app/modules.manifest.ts';
+
+const packagesDir = resolve(process.cwd(), '..', '..');
+
+/** The specifiers the `exports` map of a module package declares. */
+const declaredEntries = ({ name, dir }: { name: string; dir: string }) => {
+	const { exports } = JSON.parse(readFileSync(join(packagesDir, dir, 'package.json'), 'utf8')) as {
+		exports: Record<string, string>;
+	};
+
+	return Object.keys(exports).map((subpath) =>
+		subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`,
+	);
+};
+
+describe('module entry ratchet', () => {
+	let eslint: ESLint;
+
+	beforeAll(() => {
+		eslint = new ESLint({ cwd: process.cwd() });
+	});
+
+	const restrictions = async (source: string) => {
+		const [result] = await eslint.lintText(source, { filePath: PROBE });
+		return result.messages.filter((message) => message.ruleId === RULE);
+	};
+
+	it.each(modulePackages)(
+		'allows every declared entry of $name',
+		async (module) => {
+			const entries = declaredEntries(module);
+			const source = entries
+				.map((entry, index) => `import * as entry${index} from '${entry}';\n`)
+				.join('');
+
+			expect(entries.length).toBeGreaterThan(0);
+			expect(await restrictions(source)).toEqual([]);
+		},
+		60000,
+	);
+
+	it.each(modulePackages)(
+		'refuses a path $name does not declare',
+		async (module) => {
+			const source = `import { probe } from '${module.name}/internal/probe';\n`;
+			const [message, ...rest] = await restrictions(source);
+
+			expect(rest).toEqual([]);
+			expect(message?.message).toBeDefined();
+
+			// The message has to name the way in, or it only says no.
+			for (const entry of declaredEntries(module)) {
+				expect(message.message).toContain(entry);
+			}
+		},
+		60000,
+	);
+
+	it('refuses a component of a module, which is the import the aliases used to resolve', async () => {
+		const source =
+			"import Dashboard from '@n8n/frontend-module-insights/components/InsightsDashboard.vue';\n";
+
+		expect(await restrictions(source)).toHaveLength(1);
+	}, 60000);
+});

--- a/packages/frontend/editor-ui/src/app/moduleEntries.test.ts
+++ b/packages/frontend/editor-ui/src/app/moduleEntries.test.ts
@@ -87,63 +87,97 @@ describe('module entry ratchet', () => {
 		expect(await restrictions(source)).toHaveLength(1);
 	}, 60000);
 
-	describe('a module that declares "./*"', () => {
-		// The documented opt-out back into a wildcard. No module in the tree declares it, so the
-		// pattern comes from the same builder the config uses, fed to ESLint through
-		// `overrideConfig`. Without the two-segment case below, `!<name>/*` looked correct: a
-		// gitignore `*` stops at a `/`, while the `exports` key, the Vite alias and the tsconfig
-		// `paths` entry all match across one.
-		const WILDCARD = '@n8n/frontend-module-wildcard-probe';
-		const NARROW = '@n8n/frontend-module-narrow-probe';
+	describe('every shape an exports key can take', () => {
+		// No module in the tree declares a wildcard or a nested key, so each shape comes from the
+		// same builder the config uses, fed to ESLint through `overrideConfig`. Both gitignore
+		// adjustments in `negations` look unnecessary until this runs: `!<name>/*` refuses the
+		// second segment under a `"./*"` key, and `!<name>/views/**` alone refuses every path
+		// under a `"./views/*"` key, because `<name>/**` excludes the parent directory.
+		const NAME = '@n8n/frontend-module-shape-probe';
 
-		const withPattern = (manifest: { name: string; exports: Record<string, string> }) =>
+		const withKey = (key: string, target: string) =>
 			new ESLint({
 				cwd: process.cwd(),
 				overrideConfig: {
-					rules: { [RULE]: ['error', { patterns: [moduleEntryPattern(manifest)] }] },
+					rules: {
+						[RULE]: [
+							'error',
+							{
+								patterns: [
+									moduleEntryPattern({
+										name: NAME,
+										exports: { '.': './src/index.ts', [key]: target },
+									}),
+								],
+							},
+						],
+					},
 				},
 			});
 
-		it.each([
-			['the bare name', ''],
-			['one segment', '/one'],
-			['two segments', '/one/two'],
-			['three segments', '/one/two/three'],
-		])(
-			'allows %s under the wildcard key',
-			async (_label, subpath) => {
-				const instance = withPattern({
-					name: WILDCARD,
-					exports: { '.': './src/index.ts', './*': './src/*' },
-				});
+		const verdicts = async (key: string, target: string, subpaths: string[]) => {
+			const instance = withKey(key, target);
+			const refused: string[] = [];
 
-				expect(await restrictions(`import '${WILDCARD}${subpath}';\n`, instance)).toEqual([]);
-			},
-			60000,
-		);
+			for (const subpath of subpaths) {
+				const hits = await restrictions(`import '${NAME}${subpath}';\n`, instance);
+				if (hits.length > 0) refused.push(subpath);
+			}
 
-		it.each(['/one', '/one/two'])(
-			'still refuses %s under a narrow key',
-			async (subpath) => {
-				// The control. A module that declares one subpath does not get the wildcard by
-				// accident, at either depth.
-				const instance = withPattern({
-					name: NARROW,
-					exports: { '.': './src/index.ts', './narrow.module': './src/narrow.module.ts' },
-				});
+			return refused;
+		};
 
-				expect(await restrictions(`import '${NARROW}${subpath}';\n`, instance)).toHaveLength(1);
-			},
-			60000,
-		);
+		it('allows any depth under a "./*" key, and nothing else is left to refuse', async () => {
+			expect(await verdicts('./*', './src/*', ['', '/one', '/one/two', '/one/two/three'])).toEqual(
+				[],
+			);
+		}, 60000);
 
-		it('allows the entry a narrow key declares', async () => {
-			const instance = withPattern({
-				name: NARROW,
-				exports: { '.': './src/index.ts', './narrow.module': './src/narrow.module.ts' },
-			});
+		it('allows any depth under a nested "./views/*" key', async () => {
+			// The case a `!<name>/views/**` negation alone refused at every depth.
+			expect(
+				await verdicts('./views/*', './src/views/*', [
+					'',
+					'/views/One',
+					'/views/One.vue',
+					'/views/deep/Two',
+				]),
+			).toEqual([]);
+		}, 60000);
 
-			expect(await restrictions(`import '${NARROW}/narrow.module';\n`, instance)).toEqual([]);
+		it('refuses what a nested key does not declare', async () => {
+			// The ancestor directory is unexcluded with a trailing slash, so the bare
+			// `<name>/views` stays refused. No `exports` key declares it, and nothing resolves it.
+			expect(
+				await verdicts('./views/*', './src/views/*', [
+					'/views',
+					'/internal',
+					'/internal/deep',
+					'/other/One',
+				]),
+			).toEqual(['/views', '/internal', '/internal/deep', '/other/One']);
+		}, 60000);
+
+		it('allows two levels of nesting under a "./views/deep/*" key', async () => {
+			expect(
+				await verdicts('./views/deep/*', './src/views/deep/*', [
+					'/views/deep/Two',
+					'/views/deep/a/b',
+				]),
+			).toEqual([]);
+		}, 60000);
+
+		it('refuses every depth a flat key does not declare', async () => {
+			// The control. A module that declares one flat subpath does not get a wildcard by
+			// accident, and the declared entry itself still passes.
+			expect(
+				await verdicts('./narrow.module', './src/narrow.module.ts', [
+					'',
+					'/narrow.module',
+					'/one',
+					'/one/two',
+				]),
+			).toEqual(['/one', '/one/two']);
 		}, 60000);
 	});
 });

--- a/packages/frontend/editor-ui/tsconfig.json
+++ b/packages/frontend/editor-ui/tsconfig.json
@@ -25,16 +25,17 @@
 			"@n8n/composables*": ["../@n8n/composables/src*"],
 			"@n8n/constants*": ["../../@n8n/constants/src*"],
 			"@n8n/frontend-module-sdk": ["../@n8n/frontend-module-sdk/src/index.ts"],
+			// One entry per key in the `exports` map of the module package, and no `/*` wildcard
+			// beside them: a wildcard here makes every file under a module's `src` part of its
+			// contract. `editor-ui/vite/aliases.test.ts` fails when this set and that map disagree.
 			"@n8n/frontend-module-insights": ["../../modules/insights/frontend/src/index.ts"],
-			"@n8n/frontend-module-insights/*": ["../../modules/insights/frontend/src/*"],
+			"@n8n/frontend-module-insights/insights.module": [
+				"../../modules/insights/frontend/src/insights.module.ts"
+			],
 			"@n8n/frontend-module-instance-registry": [
 				"../../modules/instance-registry/frontend/src/index.ts"
 			],
-			"@n8n/frontend-module-instance-registry/*": [
-				"../../modules/instance-registry/frontend/src/*"
-			],
 			"@n8n/frontend-module-otel": ["../../modules/otel/frontend/src/index.ts"],
-			"@n8n/frontend-module-otel/*": ["../../modules/otel/frontend/src/*"],
 			"@n8n/frontend-test-utils": ["../@n8n/frontend-test-utils/src/index.ts"],
 			"@n8n/frontend-test-utils/*": ["../@n8n/frontend-test-utils/src/*"],
 			"@n8n/frontend-utils*": ["../@n8n/frontend-utils/src*"],

--- a/packages/frontend/editor-ui/vite/aliases.test.ts
+++ b/packages/frontend/editor-ui/vite/aliases.test.ts
@@ -28,13 +28,20 @@ const readTsconfig = (file: string) =>
  * This function treats the short `"@n8n/x*"` form as the `"@n8n/x"` plus `"@n8n/x/*"` pair. That
  * holds for the directory each maps to, but not for how TypeScript resolves a bare specifier — see
  * `resolves the bare specifier of every entry package to src` below.
+ *
+ * A subpath key of a module package (`"@n8n/frontend-module-insights/insights.module"`) collapses
+ * onto its package, because every key of one package points into the same `src`.
  */
 const pathsByPackage = (file: string) => {
 	const paths = readTsconfig(file).compilerOptions?.paths ?? {};
 	const byPackage = new Map<string, string>();
 
 	for (const [key, [target]] of Object.entries(paths)) {
-		const name = key.replace(/\/?\*$/, '');
+		const name = key
+			.replace(/\/?\*$/, '')
+			.split('/')
+			.slice(0, 2)
+			.join('/');
 		if (!name.startsWith('@n8n/')) continue;
 
 		const resolved = resolve(dirname(file), target.replace(/\/?\*$/, ''));
@@ -42,6 +49,27 @@ const pathsByPackage = (file: string) => {
 	}
 
 	return byPackage;
+};
+
+/** Every `paths` key of a module package, mapped to the absolute file it names. */
+const modulePathEntries = (file: string, name: string) =>
+	new Map(
+		Object.entries(readTsconfig(file).compilerOptions?.paths ?? {})
+			.filter(([key]) => key === name || key.startsWith(`${name}/`))
+			.map(([key, [target]]) => [key, resolve(dirname(file), target)]),
+	);
+
+/** The `exports` map of a module package, as the specifier-to-file pairs it declares. */
+const declaredEntries = (packagesDir: string, name: string, dir: string) => {
+	const packageDir = resolve(packagesDir, dir);
+	const { exports } = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8')) as {
+		exports: Record<string, string>;
+	};
+
+	return Object.entries(exports).map(([subpath, target]) => ({
+		specifier: subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`,
+		file: resolve(packageDir, target),
+	}));
 };
 
 /**
@@ -73,14 +101,39 @@ describe('editor-ui vite aliases', () => {
 
 	// This is a real failure. For months, four packages used `src` for the typecheck and `dist`
 	// for the build.
-	it.each([...sourcePackages, ...modulePackages])(
-		'resolves $name to the same src as tsconfig does',
-		({ name, dir }) => {
-			const srcDir = resolve(packagesDir, dir, 'src');
-			const src = relative(repoRoot, srcDir);
+	it.each(sourcePackages)('resolves $name to the same src as tsconfig does', ({ name, dir }) => {
+		const srcDir = resolve(packagesDir, dir, 'src');
+		const src = relative(repoRoot, srcDir);
 
-			expect(resolveSpecifier(`${name}/probe`, aliases)).toBe(`${src}/probe`);
-			expect(editorUiPaths.get(name)).toBe(srcDir);
+		expect(resolveSpecifier(`${name}/probe`, aliases)).toBe(`${src}/probe`);
+		expect(editorUiPaths.get(name)).toBe(srcDir);
+	});
+
+	// A module package gets no catch-all, so it is checked entry by entry instead. See
+	// `moduleEntryAliases` in `@n8n/frontend-vite-config`.
+	it.each(modulePackages)(
+		'resolves every declared entry of $name, and nothing deeper',
+		({ name, dir }) => {
+			const tsconfigEntries = modulePathEntries(join(editorUiDir, 'tsconfig.json'), name);
+			const declared = declaredEntries(packagesDir, name, dir);
+
+			expect(editorUiPaths.get(name)).toBe(resolve(packagesDir, dir, 'src'));
+			expect(declared.length).toBeGreaterThan(0);
+
+			for (const { specifier, file } of declared) {
+				expect(resolveSpecifier(specifier, aliases)).toBe(relative(repoRoot, file));
+				// vue-tsc has to read the same file. Without the `paths` entry it would fall back to
+				// node resolution, which reads the `exports` map — the same file today, but only by
+				// luck once a module gains a `dist`.
+				expect(tsconfigEntries.get(specifier)).toBe(file);
+			}
+
+			// The gap this closes: a `^<name>/(.+)$` alias made every file under `src` resolve, so a
+			// consumer could import an internal one and no check said a word.
+			expect(resolveSpecifier(`${name}/probe`, aliases)).toBe('dist');
+			expect([...tsconfigEntries.keys()].sort()).toEqual(
+				declared.map(({ specifier }) => specifier).sort(),
+			);
 		},
 	);
 
@@ -134,8 +187,7 @@ describe('editor-ui vite aliases', () => {
 			configPath,
 		);
 
-		const offenders = [...sourcePackages, ...modulePackages]
-			.filter(({ entry = true }) => entry)
+		const offenders = [...sourcePackages.filter(({ entry = true }) => entry), ...modulePackages]
 			.filter(({ name }) => !KNOWN_DIST_FALLBACK.has(name))
 			.filter(({ name }) => {
 				const resolved = ts.resolveModuleName(name, probe, options, ts.sys).resolvedModule;


### PR DESCRIPTION
## Summary

A module package declares its public entries in `exports`. Two mappings ignored that map and emitted a `<name>/(.+)` wildcard instead, so the shell resolved **every** file under a module's `src`:

- `@n8n/frontend-vite-config` — `expand()` gave `modulePackages` the same catch-all it gives `sourcePackages`
- `editor-ui/tsconfig.json` — a `"@n8n/frontend-module-x/*"` `paths` entry beside the bare one

The scaffolder wrote both, so every future module inherited the gap. Nothing in the tree used it, so this is a ratchet, not a fix.

**What changed**

- The alias generator reads the `exports` map of each module package and emits one anchored alias per declared key. `sourcePackages` keep the wildcard — `@n8n/stores` and `@n8n/composables` are subpath-only by design.
- `editor-ui/tsconfig.json` carries the same set: `@n8n/frontend-module-insights` plus its declared `./insights.module`, and one entry each for otel and instance-registry. No `/*`.
- `no-restricted-imports` in `editor-ui/eslint.config.mjs` bans `<package>/**` and negates the declared entries. The patterns are built from the `exports` maps on disk, so a new module and a new entry are covered without a fifth registration step.
- `n8n-module-sdk create` writes one `paths` entry, matching the `exports` map of the template.

**Effect**

| import | before | after |
| --- | --- | --- |
| `@n8n/frontend-module-insights` | resolves | resolves |
| `@n8n/frontend-module-insights/insights.module` | resolves | resolves |
| `@n8n/frontend-module-insights/insights.utils` | resolves, lints clean | `TS2307` + lint error naming both entries |

The lint message: `@n8n/frontend-module-insights is reachable only at its declared entries: @n8n/frontend-module-insights, @n8n/frontend-module-insights/insights.module. A deeper path is internal to the module. …`

**Guards**

- `editor-ui/vite/aliases.test.ts` — per module: every `exports` key resolves through the aliases *and* through the `paths`; `<package>/probe` resolves nowhere; the `paths` key set equals the `exports` key set.
- `editor-ui/src/app/moduleEntries.test.ts` (new) — lints real text, because the patterns carry negations and only gitignore semantics let the declared entries back through. A pattern list read as data cannot show that.
- `editor-ui/src/app/extractionRatchet.test.ts` — extended to sweep every representative path for the deep-import patterns, so a flat-config block that drops the spread fails.

Each guard was mutation-checked: restoring the wildcard fails `aliases.test.ts` (3 tests); dropping the negations fails `moduleEntries.test.ts`; dropping the patterns from the spread fails `extractionRatchet.test.ts` (7 tests).

### The documented `"./*"` opt-out (second commit)

A module may declare `"./*": "./src/*"` and make its whole `src` public. `exports` keys, Vite aliases and tsconfig `paths` all match a `*` across `/`; a `no-restricted-imports` `group` matches with gitignore semantics, where `*` stops at one segment. So `<name>/one` passed and `<name>/one/two` was refused, for a path that resolves.

The negation widens the `*` to `**`. The pattern builder moved to `editor-ui/eslint/module-entry-patterns.mjs` so the test can feed it a module declaring `"./*"` — no module in the tree does, which is why nothing held the case.

### Nested keys, and the same class again (third commit)

Widening the `*` fixed the top-level `"./*"` key only, because `!<name>/**` negates the same set the `<name>/**` exclusion covers. A nested key did not work: gitignore refuses to re-include a path whose parent directory is excluded, and `<name>/**` excludes every directory inside the package. So `"./views/*"` resolved `<name>/views/One` through `exports`, the Vite alias and the tsconfig `paths` entry, and lint refused it at every depth.

Each ancestor directory of a declared subpath is now unexcluded first, with a trailing slash:

| `exports` key | group |
| --- | --- |
| `"./insights.module"` | `<name>/**`, `!<name>/insights.module` |
| `"./views/*"` | `<name>/**`, `!<name>/views/`, `!<name>/views/**` |
| `"./views/deep/*"` | `<name>/**`, `!<name>/views/`, `!<name>/views/deep/`, `!<name>/views/deep/**` |
| `"./*"` | `<name>/**`, `!<name>/**` |

The trailing slash matters: it un-prunes the directory without making the bare `<name>/views` an allowed specifier. No `exports` key declares it, and nothing resolves it.

`moduleEntries.test.ts` now runs every key shape through ESLint — flat, top-level wildcard, one nested level, two nested levels — plus the paths each shape must still refuse. Reverting the ancestor unexclusion fails both nested cases; reverting the `*` widening fails the two- and three-segment wildcard cases while the one-segment case still passes. Each blind spot reproduces on demand.

Resolution was checked, not assumed: with `"./views/*"` added to insights, the alias generator resolves `.../views/One.vue` and `.../views/deep/Two.vue` into the module's `src`, and leaves `.../internal` unresolved.

The guide gains a key-shape table, states the `"./*"` opt-out and its cost, and drops the claim that a second entry needs no other change — it still needs the import that uses it.

## How to test

```bash
pnpm --filter n8n-editor-ui exec vitest run vite/aliases.test.ts src/app/extractionRatchet.test.ts src/app/moduleEntries.test.ts
pnpm --filter @n8n/module-cli test
```

Then add a probe under `editor-ui/src/` and confirm both checks refuse it:

```ts
import { transformInsightsSummary } from '@n8n/frontend-module-insights/insights.utils';
```

```bash
pnpm --filter n8n-editor-ui lint        # error, message names the entries
pnpm --filter n8n-editor-ui typecheck   # TS2307
```

Verified locally: `editor-ui` typecheck, lint, format and production build; the dev server serves all three module entries from source (including the `insights.module` subpath); each module's own vitest and `vue-tsc`; the `module-cli` suite.

## Related Linear tickets, Github issues, and Community forum posts

N8N-307. Found during review of the insights extraction (N8N-289).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- frontend-module-guide.md and packages/frontend/AGENTS.md -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



