### PR TITLE
feat(engine): Add the control plane route that resolves credentials for the data plane (no-changelog)

### DIFF
--- a/packages/cli/src/modules/engine-v2/__tests__/engine-control-plane-server.test.ts
+++ b/packages/cli/src/modules/engine-v2/__tests__/engine-control-plane-server.test.ts
@@ -1,10 +1,12 @@
 import type { Logger } from '@n8n/backend-common';
 import type { EngineConfig } from '@n8n/config';
 import { mintActionToken, mintIdentityToken, type LifecycleEvent } from '@n8n/engine';
+import type { Request, Response } from 'express';
 import request from 'supertest';
 import { mock } from 'vitest-mock-extended';
 
 import { EngineControlPlaneServer } from '../engine-control-plane-server';
+import type { EngineCredentialsController } from '../engine-credentials.controller';
 import type { EngineLifecycleEventPushRelay } from '../engine-lifecycle-event-push-relay';
 import { EngineLifecycleEventController } from '../engine-lifecycle-event.controller';
 
@@ -24,6 +26,7 @@ describe('EngineControlPlaneServer', () => {
 	let server: EngineControlPlaneServer;
 	let serverLogger: Logger;
 	let pushRelay: EngineLifecycleEventPushRelay;
+	let credentialsController: EngineCredentialsController;
 	let baseUrl: string;
 
 	const engineConfig = (overrides: Partial<EngineConfig> = {}) =>
@@ -38,10 +41,12 @@ describe('EngineControlPlaneServer', () => {
 	beforeEach(async () => {
 		serverLogger = mock<Logger>();
 		pushRelay = mock<EngineLifecycleEventPushRelay>();
+		credentialsController = mock<EngineCredentialsController>();
 		const controller = new EngineLifecycleEventController(pushRelay);
 		server = new EngineControlPlaneServer(
 			engineConfig(),
 			controller,
+			credentialsController,
 			mock<Logger>({ scoped: vi.fn().mockReturnValue(serverLogger) }),
 		);
 		await server.start();
@@ -55,6 +60,12 @@ describe('EngineControlPlaneServer', () => {
 
 	const post = (body: unknown, token?: string) => {
 		const req = request(baseUrl).post('/internal/status-callback');
+		if (token) req.set('Authorization', `Bearer ${token}`);
+		return req.send(body as object);
+	};
+
+	const postResolve = (body: unknown, token?: string) => {
+		const req = request(baseUrl).post('/internal/credentials/resolve');
 		if (token) req.set('Authorization', `Bearer ${token}`);
 		return req.send(body as object);
 	};
@@ -133,6 +144,42 @@ describe('EngineControlPlaneServer', () => {
 		const response = await post({ events: [{ type: 'nope' }] });
 
 		expect(response.status).toBe(401);
+	});
+
+	describe('credential resolve route', () => {
+		const body = { credential: { id: 'cred-1' } };
+
+		beforeEach(() => {
+			vi.mocked(credentialsController.resolveCredential).mockImplementation(
+				async (_req: Request, res: Response) => {
+					res.status(200).json({ data: {} });
+				},
+			);
+		});
+
+		it('hands an authenticated request with its parsed body to the controller', async () => {
+			const response = await postResolve(body, mintActionToken(authSecret, 'credentials:read'));
+
+			expect(response.status).toBe(200);
+			expect(credentialsController.resolveCredential).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ body }),
+				expect.anything(),
+			);
+		});
+
+		it.each([
+			['no token', undefined],
+			['a lifecycle token', mintActionToken(authSecret, 'lifecycle-events:write')],
+			[
+				'a token signed with a different secret',
+				mintActionToken('b'.repeat(32), 'credentials:read'),
+			],
+		])('rejects %s before the controller sees it', async (_label, token) => {
+			const response = await postResolve(body, token);
+
+			expect(response.status).toBe(401);
+			expect(credentialsController.resolveCredential).not.toHaveBeenCalled();
+		});
 	});
 
 	it('stops listening when stopped', async () => {

--- a/packages/cli/src/modules/engine-v2/__tests__/engine-credentials.controller.test.ts
+++ b/packages/cli/src/modules/engine-v2/__tests__/engine-credentials.controller.test.ts
@@ -1,0 +1,163 @@
+import type { Logger } from '@n8n/backend-common';
+import type { Request, Response } from 'express';
+import type { IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import type { Mocked } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsHelper } from '@/credentials-helper';
+import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
+
+import type { ResolveCredentialRequest } from '../engine-credentials.contract';
+import { EngineCredentialsController } from '../engine-credentials.controller';
+
+const mocks = vi.hoisted(() => ({ getBase: vi.fn() }));
+vi.mock('@/workflow-execute-additional-data', () => ({ getBase: mocks.getBase }));
+
+const resolveRequest: ResolveCredentialRequest = {
+	credential: { id: 'cred-1', name: 'Acme API', type: 'httpHeaderAuth' },
+	execution: { executionId: 'exec-1', workflowId: 'wf-1', mode: 'manual' },
+	context: { userId: 'user-1', projectId: 'project-1' },
+	consumer: { nodeType: 'n8n-nodes-base.httpRequest' },
+};
+
+const decrypted = { name: 'X-Api-Key', value: 'secret' };
+
+describe('EngineCredentialsController', () => {
+	let permissionChecker: CredentialsPermissionChecker;
+	let credentialsHelper: CredentialsHelper;
+	let logger: Logger;
+	let controller: EngineCredentialsController;
+	let additionalData: IWorkflowExecuteAdditionalData;
+
+	const newResponse = () => {
+		const res = { status: vi.fn(), json: vi.fn() };
+		res.status.mockReturnValue(res);
+		return res as unknown as Mocked<Response>;
+	};
+
+	const newRequest = (body: unknown = resolveRequest) => ({ body }) as unknown as Request;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		permissionChecker = mock<CredentialsPermissionChecker>();
+		credentialsHelper = mock<CredentialsHelper>();
+		logger = mock<Logger>();
+		controller = new EngineCredentialsController(
+			permissionChecker,
+			credentialsHelper,
+			mock<Logger>({ scoped: vi.fn().mockReturnValue(logger) }),
+		);
+
+		additionalData = {} as IWorkflowExecuteAdditionalData;
+		mocks.getBase.mockResolvedValue(additionalData);
+		vi.mocked(permissionChecker.findInaccessible).mockResolvedValue({
+			homeProject: mock(),
+			inaccessibleIds: [],
+		});
+		vi.mocked(credentialsHelper.getDecrypted).mockResolvedValue(decrypted);
+	});
+
+	describe('resolveCredential', () => {
+		it('answers 200 with the decrypted data', async () => {
+			const res = newResponse();
+
+			await controller.resolveCredential(newRequest(), res);
+
+			expect(res.status).toHaveBeenCalledExactlyOnceWith(200);
+			expect(res.json).toHaveBeenCalledExactlyOnceWith({ data: decrypted });
+		});
+
+		it('decrypts with the credential, mode and consumer node type from the request', async () => {
+			await controller.resolveCredential(newRequest(), newResponse());
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledExactlyOnceWith(
+				additionalData,
+				{ id: 'cred-1', name: 'Acme API' },
+				'httpHeaderAuth',
+				'manual',
+				expect.objectContaining({
+					node: expect.objectContaining({ type: 'n8n-nodes-base.httpRequest' }),
+				}),
+			);
+		});
+
+		it('builds additional data for the execution in the request', async () => {
+			await controller.resolveCredential(newRequest(), newResponse());
+
+			expect(mocks.getBase).toHaveBeenCalledExactlyOnceWith({
+				userId: 'user-1',
+				workflowId: 'wf-1',
+				projectId: 'project-1',
+			});
+			// The engine's id, so `$execution.id` in a credential reads the right one.
+			expect(additionalData.executionId).toBe('exec-1');
+		});
+
+		it('checks that the workflow may use the credential before decrypting', async () => {
+			await controller.resolveCredential(newRequest(), newResponse());
+
+			expect(permissionChecker.findInaccessible).toHaveBeenCalledExactlyOnceWith('wf-1', [
+				'cred-1',
+			]);
+		});
+
+		it.each([
+			[
+				'a body without a credential id',
+				{ ...resolveRequest, credential: { name: 'x', type: 'y' } },
+			],
+			[
+				'a body with an unknown mode',
+				{ ...resolveRequest, execution: { ...resolveRequest.execution, mode: 'nope' } },
+			],
+			['a body that is not a request at all', { hello: 'world' }],
+		])('rejects %s without a reason', async (_label, body) => {
+			const res = newResponse();
+
+			await expect(controller.resolveCredential(newRequest(body), res)).rejects.toThrow(
+				BadRequestError,
+			);
+			expect(res.status).not.toHaveBeenCalled();
+			// Unvalidated input must never reach the access check or the store.
+			expect(permissionChecker.findInaccessible).not.toHaveBeenCalled();
+			expect(credentialsHelper.getDecrypted).not.toHaveBeenCalled();
+		});
+
+		it('refuses a credential the workflow may not use, and logs it', async () => {
+			vi.mocked(permissionChecker.findInaccessible).mockResolvedValue({
+				homeProject: mock(),
+				inaccessibleIds: ['cred-1'],
+			});
+			const res = newResponse();
+
+			await expect(controller.resolveCredential(newRequest(), res)).rejects.toThrow(ForbiddenError);
+			expect(res.status).not.toHaveBeenCalled();
+			expect(credentialsHelper.getDecrypted).not.toHaveBeenCalled();
+			// The client discards the body, so the operator's record is the log.
+			expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+				expect.stringContaining('Refused credential "cred-1" to workflow "wf-1"'),
+			);
+		});
+
+		it('answers 404 when the store has no credential with that id and type', async () => {
+			vi.mocked(credentialsHelper.getDecrypted).mockRejectedValue(
+				new CredentialNotFoundError('cred-1', 'httpHeaderAuth'),
+			);
+
+			await expect(controller.resolveCredential(newRequest(), newResponse())).rejects.toThrow(
+				NotFoundError,
+			);
+		});
+
+		it('passes on any other decryption error unchanged', async () => {
+			const error = new Error('cipher unavailable');
+			vi.mocked(credentialsHelper.getDecrypted).mockRejectedValue(error);
+
+			await expect(controller.resolveCredential(newRequest(), newResponse())).rejects.toBe(error);
+		});
+	});
+});

--- a/packages/cli/src/modules/engine-v2/__tests__/engine-credentials.controller.test.ts
+++ b/packages/cli/src/modules/engine-v2/__tests__/engine-credentials.controller.test.ts
@@ -1,21 +1,13 @@
-import type { Logger } from '@n8n/backend-common';
 import type { Request, Response } from 'express';
-import type { IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import type { CredentialsHelper } from '@/credentials-helper';
-import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import type { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
 
 import type { ResolveCredentialRequest } from '../engine-credentials.contract';
 import { EngineCredentialsController } from '../engine-credentials.controller';
-
-const mocks = vi.hoisted(() => ({ getBase: vi.fn() }));
-vi.mock('@/workflow-execute-additional-data', () => ({ getBase: mocks.getBase }));
+import type { EngineCredentialsService } from '../engine-credentials.service';
 
 const resolveRequest: ResolveCredentialRequest = {
 	credential: { id: 'cred-1', name: 'Acme API', type: 'httpHeaderAuth' },
@@ -27,11 +19,8 @@ const resolveRequest: ResolveCredentialRequest = {
 const decrypted = { name: 'X-Api-Key', value: 'secret' };
 
 describe('EngineCredentialsController', () => {
-	let permissionChecker: CredentialsPermissionChecker;
-	let credentialsHelper: CredentialsHelper;
-	let logger: Logger;
+	let credentialsService: EngineCredentialsService;
 	let controller: EngineCredentialsController;
-	let additionalData: IWorkflowExecuteAdditionalData;
 
 	const newResponse = () => {
 		const res = { status: vi.fn(), json: vi.fn() };
@@ -42,23 +31,10 @@ describe('EngineCredentialsController', () => {
 	const newRequest = (body: unknown = resolveRequest) => ({ body }) as unknown as Request;
 
 	beforeEach(() => {
-		vi.resetAllMocks();
-		permissionChecker = mock<CredentialsPermissionChecker>();
-		credentialsHelper = mock<CredentialsHelper>();
-		logger = mock<Logger>();
-		controller = new EngineCredentialsController(
-			permissionChecker,
-			credentialsHelper,
-			mock<Logger>({ scoped: vi.fn().mockReturnValue(logger) }),
-		);
+		credentialsService = mock<EngineCredentialsService>();
+		controller = new EngineCredentialsController(credentialsService);
 
-		additionalData = {} as IWorkflowExecuteAdditionalData;
-		mocks.getBase.mockResolvedValue(additionalData);
-		vi.mocked(permissionChecker.findInaccessible).mockResolvedValue({
-			homeProject: mock(),
-			inaccessibleIds: [],
-		});
-		vi.mocked(credentialsHelper.getDecrypted).mockResolvedValue(decrypted);
+		vi.mocked(credentialsService.resolve).mockResolvedValue(decrypted);
 	});
 
 	describe('resolveCredential', () => {
@@ -71,38 +47,10 @@ describe('EngineCredentialsController', () => {
 			expect(res.json).toHaveBeenCalledExactlyOnceWith({ data: decrypted });
 		});
 
-		it('decrypts with the credential, mode and consumer node type from the request', async () => {
+		it('hands the validated body to the service', async () => {
 			await controller.resolveCredential(newRequest(), newResponse());
 
-			expect(credentialsHelper.getDecrypted).toHaveBeenCalledExactlyOnceWith(
-				additionalData,
-				{ id: 'cred-1', name: 'Acme API' },
-				'httpHeaderAuth',
-				'manual',
-				expect.objectContaining({
-					node: expect.objectContaining({ type: 'n8n-nodes-base.httpRequest' }),
-				}),
-			);
-		});
-
-		it('builds additional data for the execution in the request', async () => {
-			await controller.resolveCredential(newRequest(), newResponse());
-
-			expect(mocks.getBase).toHaveBeenCalledExactlyOnceWith({
-				userId: 'user-1',
-				workflowId: 'wf-1',
-				projectId: 'project-1',
-			});
-			// The engine's id, so `$execution.id` in a credential reads the right one.
-			expect(additionalData.executionId).toBe('exec-1');
-		});
-
-		it('checks that the workflow may use the credential before decrypting', async () => {
-			await controller.resolveCredential(newRequest(), newResponse());
-
-			expect(permissionChecker.findInaccessible).toHaveBeenCalledExactlyOnceWith('wf-1', [
-				'cred-1',
-			]);
+			expect(credentialsService.resolve).toHaveBeenCalledExactlyOnceWith(resolveRequest);
 		});
 
 		it.each([
@@ -123,41 +71,16 @@ describe('EngineCredentialsController', () => {
 			);
 			expect(res.status).not.toHaveBeenCalled();
 			// Unvalidated input must never reach the access check or the store.
-			expect(permissionChecker.findInaccessible).not.toHaveBeenCalled();
-			expect(credentialsHelper.getDecrypted).not.toHaveBeenCalled();
+			expect(credentialsService.resolve).not.toHaveBeenCalled();
 		});
 
-		it('refuses a credential the workflow may not use, and logs it', async () => {
-			vi.mocked(permissionChecker.findInaccessible).mockResolvedValue({
-				homeProject: mock(),
-				inaccessibleIds: ['cred-1'],
-			});
+		it('passes a service error on without writing a response', async () => {
+			const error = new ForbiddenError('Credential is not shared with the workflow');
+			vi.mocked(credentialsService.resolve).mockRejectedValue(error);
 			const res = newResponse();
 
-			await expect(controller.resolveCredential(newRequest(), res)).rejects.toThrow(ForbiddenError);
+			await expect(controller.resolveCredential(newRequest(), res)).rejects.toBe(error);
 			expect(res.status).not.toHaveBeenCalled();
-			expect(credentialsHelper.getDecrypted).not.toHaveBeenCalled();
-			// The client discards the body, so the operator's record is the log.
-			expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
-				expect.stringContaining('Refused credential "cred-1" to workflow "wf-1"'),
-			);
-		});
-
-		it('answers 404 when the store has no credential with that id and type', async () => {
-			vi.mocked(credentialsHelper.getDecrypted).mockRejectedValue(
-				new CredentialNotFoundError('cred-1', 'httpHeaderAuth'),
-			);
-
-			await expect(controller.resolveCredential(newRequest(), newResponse())).rejects.toThrow(
-				NotFoundError,
-			);
-		});
-
-		it('passes on any other decryption error unchanged', async () => {
-			const error = new Error('cipher unavailable');
-			vi.mocked(credentialsHelper.getDecrypted).mockRejectedValue(error);
-
-			await expect(controller.resolveCredential(newRequest(), newResponse())).rejects.toBe(error);
 		});
 	});
 });

--- a/packages/cli/src/modules/engine-v2/__tests__/engine-credentials.service.test.ts
+++ b/packages/cli/src/modules/engine-v2/__tests__/engine-credentials.service.test.ts
@@ -1,0 +1,121 @@
+import type { Logger } from '@n8n/backend-common';
+import type { IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsHelper } from '@/credentials-helper';
+import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
+
+import type { ResolveCredentialRequest } from '../engine-credentials.contract';
+import { EngineCredentialsService } from '../engine-credentials.service';
+
+const mocks = vi.hoisted(() => ({ getBase: vi.fn() }));
+vi.mock('@/workflow-execute-additional-data', () => ({ getBase: mocks.getBase }));
+
+const resolveRequest: ResolveCredentialRequest = {
+	credential: { id: 'cred-1', name: 'Acme API', type: 'httpHeaderAuth' },
+	execution: { executionId: 'exec-1', workflowId: 'wf-1', mode: 'manual' },
+	context: { userId: 'user-1', projectId: 'project-1' },
+	consumer: { nodeType: 'n8n-nodes-base.httpRequest' },
+};
+
+const decrypted = { name: 'X-Api-Key', value: 'secret' };
+
+describe('EngineCredentialsService', () => {
+	let permissionChecker: CredentialsPermissionChecker;
+	let credentialsHelper: CredentialsHelper;
+	let logger: Logger;
+	let service: EngineCredentialsService;
+	let additionalData: IWorkflowExecuteAdditionalData;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		permissionChecker = mock<CredentialsPermissionChecker>();
+		credentialsHelper = mock<CredentialsHelper>();
+		logger = mock<Logger>();
+		service = new EngineCredentialsService(
+			permissionChecker,
+			credentialsHelper,
+			mock<Logger>({ scoped: vi.fn().mockReturnValue(logger) }),
+		);
+
+		additionalData = {} as IWorkflowExecuteAdditionalData;
+		mocks.getBase.mockResolvedValue(additionalData);
+		vi.mocked(permissionChecker.findInaccessible).mockResolvedValue({
+			homeProject: mock(),
+			inaccessibleIds: [],
+		});
+		vi.mocked(credentialsHelper.getDecrypted).mockResolvedValue(decrypted);
+	});
+
+	describe('resolve', () => {
+		it('returns the decrypted data', async () => {
+			await expect(service.resolve(resolveRequest)).resolves.toBe(decrypted);
+		});
+
+		it('decrypts with the credential, mode and consumer node type from the request', async () => {
+			await service.resolve(resolveRequest);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledExactlyOnceWith(
+				additionalData,
+				{ id: 'cred-1', name: 'Acme API' },
+				'httpHeaderAuth',
+				'manual',
+				expect.objectContaining({
+					node: expect.objectContaining({ type: 'n8n-nodes-base.httpRequest' }),
+				}),
+			);
+		});
+
+		it('builds additional data for the execution in the request', async () => {
+			await service.resolve(resolveRequest);
+
+			expect(mocks.getBase).toHaveBeenCalledExactlyOnceWith({
+				userId: 'user-1',
+				workflowId: 'wf-1',
+				projectId: 'project-1',
+			});
+			// The engine's id, so `$execution.id` in a credential reads the right one.
+			expect(additionalData.executionId).toBe('exec-1');
+		});
+
+		it('checks that the workflow may use the credential before decrypting', async () => {
+			await service.resolve(resolveRequest);
+
+			expect(permissionChecker.findInaccessible).toHaveBeenCalledExactlyOnceWith('wf-1', [
+				'cred-1',
+			]);
+		});
+
+		it('refuses a credential the workflow may not use, and logs it', async () => {
+			vi.mocked(permissionChecker.findInaccessible).mockResolvedValue({
+				homeProject: mock(),
+				inaccessibleIds: ['cred-1'],
+			});
+
+			await expect(service.resolve(resolveRequest)).rejects.toThrow(ForbiddenError);
+			expect(credentialsHelper.getDecrypted).not.toHaveBeenCalled();
+			// The client discards the body, so the operator's record is the log.
+			expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+				expect.stringContaining('Refused credential "cred-1" to workflow "wf-1"'),
+			);
+		});
+
+		it('reports not found when the store has no credential with that id and type', async () => {
+			vi.mocked(credentialsHelper.getDecrypted).mockRejectedValue(
+				new CredentialNotFoundError('cred-1', 'httpHeaderAuth'),
+			);
+
+			await expect(service.resolve(resolveRequest)).rejects.toThrow(NotFoundError);
+		});
+
+		it('passes on any other decryption error unchanged', async () => {
+			const error = new Error('cipher unavailable');
+			vi.mocked(credentialsHelper.getDecrypted).mockRejectedValue(error);
+
+			await expect(service.resolve(resolveRequest)).rejects.toBe(error);
+		});
+	});
+});

--- a/packages/cli/src/modules/engine-v2/engine-control-plane-server.ts
+++ b/packages/cli/src/modules/engine-v2/engine-control-plane-server.ts
@@ -9,12 +9,15 @@ import { bodyParser, rawBodyReader } from '@/middlewares';
 import { send } from '@/response-helper';
 
 import { createEngineControlPlaneAuthMiddleware } from './engine-control-plane-auth.middleware';
-import { STATUS_CALLBACK_PATH } from './engine-v2.constants';
+import { EngineCredentialsController } from './engine-credentials.controller';
 import { EngineLifecycleEventController } from './engine-lifecycle-event.controller';
+import { CREDENTIALS_RESOLVE_PATH, STATUS_CALLBACK_PATH } from './engine-v2.constants';
 
 /**
- * Receives lifecycle events from the data plane. Its own server, not a route on
- * n8n's main one, so this surface can be isolated from the editor API.
+ * Receives lifecycle events from the data plane and resolves credentials for
+ * it. It listens on its own host and port, separate from the REST API server,
+ * so an operator can restrict these internal routes to the network that the
+ * data plane uses without touching the editor's routes.
  */
 @Service()
 export class EngineControlPlaneServer {
@@ -28,6 +31,7 @@ export class EngineControlPlaneServer {
 	constructor(
 		private readonly engineConfig: EngineConfig,
 		private readonly lifecycleEventController: EngineLifecycleEventController,
+		private readonly credentialsController: EngineCredentialsController,
 		private readonly logger: Logger,
 	) {
 		this.logger = this.logger.scoped('engine-v2');
@@ -101,6 +105,14 @@ export class EngineControlPlaneServer {
 			send(
 				async (req, res) => await this.lifecycleEventController.receiveLifecycleEvents(req, res),
 			),
+		);
+
+		app.post(
+			CREDENTIALS_RESOLVE_PATH,
+			createEngineControlPlaneAuthMiddleware(this.engineConfig, this.logger, 'credentials:read'),
+			rawBodyReader,
+			bodyParser,
+			send(async (req, res) => await this.credentialsController.resolveCredential(req, res)),
 		);
 	}
 }

--- a/packages/cli/src/modules/engine-v2/engine-credentials.controller.ts
+++ b/packages/cli/src/modules/engine-v2/engine-credentials.controller.ts
@@ -1,92 +1,29 @@
-import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import type { Request, Response } from 'express';
-import type { IExecuteData } from 'n8n-workflow';
 
-import { CredentialsHelper } from '@/credentials-helper';
-import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
-import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
 import type { ResolveCredentialResponse } from './engine-credentials.contract';
 import { resolveCredentialRequestSchema } from './engine-credentials.contract';
-
-/**
- * `getDecrypted` reads the consumer node type for the policy check from
- * `executeData.node.type`. The data plane sends the type only, so the rest of
- * the node is a placeholder. Nothing else in `getDecrypted` reads it: the node
- * has no parameters, so credential expressions resolve as they do with no
- * `executeData` at all.
- */
-function toExecuteData(nodeType: string): IExecuteData {
-	return {
-		node: { id: '', name: '', type: nodeType, typeVersion: 0, position: [0, 0], parameters: {} },
-		data: {},
-		source: null,
-	};
-}
+import { EngineCredentialsService } from './engine-credentials.service';
 
 /**
  * Serves `POST /internal/credentials/resolve` for the engine 2.0 data plane.
- * The data plane has no credential store and no encryption key, so this is
- * the only place where a step's credential is decrypted.
+ * Validates the body and writes the response. `EngineCredentialsService`
+ * decides access and decrypts.
  */
 @Service()
 export class EngineCredentialsController {
-	constructor(
-		private readonly permissionChecker: CredentialsPermissionChecker,
-		private readonly credentialsHelper: CredentialsHelper,
-		private readonly logger: Logger,
-	) {
-		this.logger = this.logger.scoped('engine-v2');
-	}
+	constructor(private readonly credentialsService: EngineCredentialsService) {}
 
 	async resolveCredential(req: Request, res: Response): Promise<void> {
 		const parsed = resolveCredentialRequestSchema.safeParse(req.body);
 
 		if (!parsed.success) throw new BadRequestError('Invalid credential resolve request');
 
-		const { credential, execution, context, consumer } = parsed.data;
+		const data = await this.credentialsService.resolve(parsed.data);
 
-		// Checked on every request. The token proves the caller is the engine,
-		// not that this workflow may use this credential. The dispatcher ran the
-		// same check when the execution started, but a credential can be unshared
-		// from the workflow's project while the execution is still running.
-		const { inaccessibleIds } = await this.permissionChecker.findInaccessible(
-			execution.workflowId,
-			[credential.id],
-		);
-		if (inaccessibleIds.length > 0) {
-			this.logger.warn(
-				`Refused credential "${credential.id}" to workflow "${execution.workflowId}" - not shared with its projects`,
-			);
-			throw new ForbiddenError('Credential is not shared with the workflow');
-		}
-
-		const additionalData = await WorkflowExecuteAdditionalData.getBase({
-			userId: context.userId,
-			workflowId: execution.workflowId,
-			projectId: context.projectId,
-		});
-		additionalData.executionId = execution.executionId;
-
-		try {
-			const data = await this.credentialsHelper.getDecrypted(
-				additionalData,
-				{ id: credential.id, name: credential.name },
-				credential.type,
-				execution.mode,
-				toExecuteData(consumer.nodeType),
-			);
-
-			const body: ResolveCredentialResponse = { data };
-			res.status(200).json(body);
-		} catch (error) {
-			if (error instanceof CredentialNotFoundError) throw new NotFoundError(error.message);
-			throw error;
-		}
+		const body: ResolveCredentialResponse = { data };
+		res.status(200).json(body);
 	}
 }

--- a/packages/cli/src/modules/engine-v2/engine-credentials.controller.ts
+++ b/packages/cli/src/modules/engine-v2/engine-credentials.controller.ts
@@ -1,0 +1,92 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type { Request, Response } from 'express';
+import type { IExecuteData } from 'n8n-workflow';
+
+import { CredentialsHelper } from '@/credentials-helper';
+import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+
+import type { ResolveCredentialResponse } from './engine-credentials.contract';
+import { resolveCredentialRequestSchema } from './engine-credentials.contract';
+
+/**
+ * `getDecrypted` reads the consumer node type for the policy check from
+ * `executeData.node.type`. The data plane sends the type only, so the rest of
+ * the node is a placeholder. Nothing else in `getDecrypted` reads it: the node
+ * has no parameters, so credential expressions resolve as they do with no
+ * `executeData` at all.
+ */
+function toExecuteData(nodeType: string): IExecuteData {
+	return {
+		node: { id: '', name: '', type: nodeType, typeVersion: 0, position: [0, 0], parameters: {} },
+		data: {},
+		source: null,
+	};
+}
+
+/**
+ * Serves `POST /internal/credentials/resolve` for the engine 2.0 data plane.
+ * The data plane has no credential store and no encryption key, so this is
+ * the only place where a step's credential is decrypted.
+ */
+@Service()
+export class EngineCredentialsController {
+	constructor(
+		private readonly permissionChecker: CredentialsPermissionChecker,
+		private readonly credentialsHelper: CredentialsHelper,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('engine-v2');
+	}
+
+	async resolveCredential(req: Request, res: Response): Promise<void> {
+		const parsed = resolveCredentialRequestSchema.safeParse(req.body);
+
+		if (!parsed.success) throw new BadRequestError('Invalid credential resolve request');
+
+		const { credential, execution, context, consumer } = parsed.data;
+
+		// Checked on every request. The token proves the caller is the engine,
+		// not that this workflow may use this credential. The dispatcher ran the
+		// same check when the execution started, but a credential can be unshared
+		// from the workflow's project while the execution is still running.
+		const { inaccessibleIds } = await this.permissionChecker.findInaccessible(
+			execution.workflowId,
+			[credential.id],
+		);
+		if (inaccessibleIds.length > 0) {
+			this.logger.warn(
+				`Refused credential "${credential.id}" to workflow "${execution.workflowId}" - not shared with its projects`,
+			);
+			throw new ForbiddenError('Credential is not shared with the workflow');
+		}
+
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			userId: context.userId,
+			workflowId: execution.workflowId,
+			projectId: context.projectId,
+		});
+		additionalData.executionId = execution.executionId;
+
+		try {
+			const data = await this.credentialsHelper.getDecrypted(
+				additionalData,
+				{ id: credential.id, name: credential.name },
+				credential.type,
+				execution.mode,
+				toExecuteData(consumer.nodeType),
+			);
+
+			const body: ResolveCredentialResponse = { data };
+			res.status(200).json(body);
+		} catch (error) {
+			if (error instanceof CredentialNotFoundError) throw new NotFoundError(error.message);
+			throw error;
+		}
+	}
+}

--- a/packages/cli/src/modules/engine-v2/engine-credentials.service.ts
+++ b/packages/cli/src/modules/engine-v2/engine-credentials.service.ts
@@ -1,0 +1,91 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type { ICredentialDataDecryptedObject, IExecuteData } from 'n8n-workflow';
+
+import { CredentialsHelper } from '@/credentials-helper';
+import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { CredentialsPermissionChecker } from '@/executions/pre-execution-checks';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+
+import type { ResolveCredentialRequest } from './engine-credentials.contract';
+
+/**
+ * `getDecrypted` reads the consumer node type for the policy check from
+ * `executeData.node.type`. The data plane sends the type only, so the rest of
+ * the node is a placeholder. Nothing else in `getDecrypted` reads it: the node
+ * has no parameters, so credential expressions resolve as they do with no
+ * `executeData` at all.
+ */
+function toExecuteData(nodeType: string): IExecuteData {
+	return {
+		node: { id: '', name: '', type: nodeType, typeVersion: 0, position: [0, 0], parameters: {} },
+		data: {},
+		source: null,
+	};
+}
+
+/**
+ * Resolves a credential for the engine 2.0 data plane. The data plane has no
+ * credential store and no encryption key, so this is the only place where a
+ * step's credential is decrypted.
+ */
+@Service()
+export class EngineCredentialsService {
+	constructor(
+		private readonly permissionChecker: CredentialsPermissionChecker,
+		private readonly credentialsHelper: CredentialsHelper,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('engine-v2');
+	}
+
+	/**
+	 * Throws `ForbiddenError` when the credential is not shared with one of the
+	 * workflow's projects, and `NotFoundError` when no credential has that id
+	 * and type. An unknown id is refused as forbidden, because the access check
+	 * runs before the credential row is loaded.
+	 */
+	async resolve({
+		credential,
+		execution,
+		context,
+		consumer,
+	}: ResolveCredentialRequest): Promise<ICredentialDataDecryptedObject> {
+		// Checked on every request. The token proves the caller is the engine,
+		// not that this workflow may use this credential. The dispatcher ran the
+		// same check when the execution started, but a credential can be unshared
+		// from the workflow's project while the execution is still running.
+		const { inaccessibleIds } = await this.permissionChecker.findInaccessible(
+			execution.workflowId,
+			[credential.id],
+		);
+		if (inaccessibleIds.length > 0) {
+			this.logger.warn(
+				`Refused credential "${credential.id}" to workflow "${execution.workflowId}" - not shared with its projects`,
+			);
+			throw new ForbiddenError('Credential is not shared with the workflow');
+		}
+
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			userId: context.userId,
+			workflowId: execution.workflowId,
+			projectId: context.projectId,
+		});
+		additionalData.executionId = execution.executionId;
+
+		try {
+			return await this.credentialsHelper.getDecrypted(
+				additionalData,
+				{ id: credential.id, name: credential.name },
+				credential.type,
+				execution.mode,
+				toExecuteData(consumer.nodeType),
+			);
+		} catch (error) {
+			if (error instanceof CredentialNotFoundError) throw new NotFoundError(error.message);
+			throw error;
+		}
+	}
+}

--- a/packages/cli/src/modules/engine-v2/engine-credentials.service.ts
+++ b/packages/cli/src/modules/engine-v2/engine-credentials.service.ts
@@ -44,8 +44,10 @@ export class EngineCredentialsService {
 	/**
 	 * Throws `ForbiddenError` when the credential is not shared with one of the
 	 * workflow's projects, and `NotFoundError` when no credential has that id
-	 * and type. An unknown id is refused as forbidden, because the access check
-	 * runs before the credential row is loaded.
+	 * and type. The access check runs before the row is loaded, so an unknown
+	 * id is usually refused as forbidden. The one exception is a workflow in the
+	 * personal project of a user with global credential access: the check
+	 * grants every id, so an unknown id is reported as not found.
 	 */
 	async resolve({
 		credential,


### PR DESCRIPTION
## Summary

Follows #38251, which provides `CredentialsPermissionChecker.findInaccessible`.

The Engine 2.0 control plane server gains a second route, `POST /internal/credentials/resolve`. The data plane, the process that runs workflow steps, calls it when a step needs a credential. A new `EngineCredentialsController` handles the route. It validates the request body and writes the response. A new `EngineCredentialsService` checks that the credential is shared with one of the workflow's projects, decrypts the credential through the existing `CredentialsHelper`, and returns the decrypted data. The route uses the same authentication middleware as the lifecycle route, but requires a token minted for the `credentials:read` scope.

## Why

The data plane has no credential store and no encryption key, so every credential a step needs must be decrypted on the control plane and sent back. This route is that path.

The token in the request proves only that the caller is the engine. It does not prove that this workflow may use this credential. Trusting the access check that the dispatcher runs when the execution starts would be wrong, because a credential can be unshared from the workflow's project while the execution is still running. So the controller repeats the access check on every request through `findInaccessible`.

That order has one visible consequence. An unknown or deleted credential id is usually refused with 403, not 404, because the access check runs before the credential row is loaded, and such an id is shared with no project. The exception is a workflow in the personal project of a user with global credential access: the access check grants every id without a lookup, so an unknown id reaches the decrypt step and is refused with 404. Both codes fail the step in the same way. A 404 otherwise occurs only when the id exists but not with the requested credential type.

The credential decrypt policy reads the type of the node that asks for the credential. Passing nothing would leave the policy without that type, so it could not enforce a rule that limits a credential to given node types. `CredentialsHelper.getDecrypted` accepts the node type only inside an `IExecuteData`, so the controller builds a minimal one from the node type in the request. Its node has no parameters, so credential expressions resolve as they would without it.

## How to test

```
pnpm --filter n8n test src/modules/engine-v2
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2926

## Review / Merge checklist

- [x] PR title and summary are descriptive. (conventions)
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.


