### PR TITLE
feat(core): Enable the policy infrastructure module by default (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -31,7 +31,16 @@ describe('eligibleModules', () => {
 	it('should not include opt-in modules by default', () => {
 		const eligible = Container.get(ModuleRegistry).eligibleModules;
 		expect(eligible).not.toContain('agents');
-		expect(eligible).not.toContain('policy-infrastructure');
+		expect(eligible).not.toContain('type-availability-policies');
+	});
+
+	it('should include policy-infrastructure by default', () => {
+		expect(Container.get(ModuleRegistry).eligibleModules).toContain('policy-infrastructure');
+	});
+
+	it('should allow opting out of policy-infrastructure via env var', () => {
+		process.env.N8N_DISABLED_MODULES = 'policy-infrastructure';
+		expect(Container.get(ModuleRegistry).eligibleModules).not.toContain('policy-infrastructure');
 	});
 
 	it('should include instance-ai by default', () => {
@@ -46,6 +55,7 @@ describe('eligibleModules', () => {
 	it('should consider a module ineligible if it was disabled via env var', () => {
 		process.env.N8N_DISABLED_MODULES = 'insights';
 		expect(Container.get(ModuleRegistry).eligibleModules).toEqual([
+			'policy-infrastructure',
 			'external-secrets',
 			'community-packages',
 			'data-table',
@@ -81,6 +91,7 @@ describe('eligibleModules', () => {
 	it('should consider a module eligible if it was enabled via env var', () => {
 		process.env.N8N_ENABLED_MODULES = 'agents';
 		expect(Container.get(ModuleRegistry).eligibleModules).toEqual([
+			'policy-infrastructure',
 			'insights',
 			'external-secrets',
 			'community-packages',

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -42,6 +42,9 @@ export class ModuleRegistry {
 	) {}
 
 	private readonly defaultModules: ModuleName[] = [
+		// policy-infrastructure leads: it registers the enforcement implementation
+		// that every policy feature's checks are run by.
+		'policy-infrastructure',
 		'insights',
 		'external-secrets',
 		'community-packages',

--- a/packages/cli/src/modules/policy-infrastructure/README.md
+++ b/packages/cli/src/modules/policy-infrastructure/README.md
@@ -12,9 +12,10 @@ Why these six points, why every check must pass, and why a check that does not
 answer blocks: read the policy infrastructure RFC in Notion. This README is the
 working reference for writing a check. It does not restate the RFC.
 
-Opt-in while it is built out: `N8N_ENABLED_MODULES=policy-infrastructure`.
-With the module off, nothing is checked and everything is allowed. That is the
-documented break-glass lever.
+The module is on by default. `N8N_DISABLED_MODULES=policy-infrastructure` turns
+it off: nothing is checked and everything is allowed. That is the documented
+break-glass lever. An instance with no check registered behaves the same either
+way — the module by itself changes nothing a user can see.
 
 ## Architecture
 
@@ -31,7 +32,7 @@ flowchart LR
         pes["PolicyEnforcementService<br/>enforce* · evaluate* · hasChecksFor"]
     end
 
-    subgraph module["policy-infrastructure module (opt-in)"]
+    subgraph module["policy-infrastructure module (default, disable to opt out)"]
         pds["PolicyDecisionService<br/>deadline per check · all checks must pass<br/>crash or timeout = fail closed<br/>one audit line per veto"]
         registry["PolicyCheckMetadata<br/>registry in @n8n/decorators"]
         checks["@PolicyCheck() classes<br/>onWorkflowSave · onWorkflowPublish · …"]

--- a/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
+++ b/packages/cli/src/modules/policy-infrastructure/policy-infrastructure.module.ts
@@ -11,8 +11,7 @@ import { PolicyEnforcementService } from '@/policy/policy-enforcement.service';
  * Runs on all instance types — enforcement points sit on execution paths that
  * also run on workers and webhook processes.
  *
- * Opt-in via `N8N_ENABLED_MODULES=policy-infrastructure` while it is being
- * built out; becomes a default module at GA. Disabling it is the documented
+ * On by default. `N8N_DISABLED_MODULES=policy-infrastructure` is the documented
  * break-glass lever: no checks run and everything is allowed.
  */
 @BackendModule({ name: 'policy-infrastructure' })


### PR DESCRIPTION
## Summary

`policy-infrastructure` was opt-in behind `N8N_ENABLED_MODULES`, so nothing was checked on a default instance and any policy feature built on the layer stayed silently inactive. This PR adds it to `defaultModules` — first in the list, so the enforcement implementation is registered before any policy feature that builds on it — and makes `N8N_DISABLED_MODULES=policy-infrastructure` the documented break-glass lever. The flip is behaviour-neutral today: no production `@PolicyCheck()` class exists yet, so `hasChecksFor` returns `false` at every point and every `enforce*` clears exactly as it did with no implementation registered. The module docblock and README no longer describe the module as opt-in.

Note: the ticket also asked for an integration-test sweep and a docs-entry update. Neither applies. No test sets `N8N_ENABLED_MODULES=policy-infrastructure` — the policy suites pass `modules: ['policy-infrastructure']` to `setupTestServer`, which never reads `eligibleModules`, so those lists are still required. And no operator-facing docs entry for the module exists in this repo.

## How to test

1. Start a fresh instance with **no module env vars**. The boot log at `N8N_LOG_LEVEL=debug` prints `Initialized module "policy-infrastructure"`, and `GET /rest/settings` (authenticated) lists `policy-infrastructure` in `activeModules`.
2. Save, run, publish and transfer a workflow, and create a credential. All of it behaves exactly as before, and no `Policy blocked …` line appears in the log.
3. Restart with `N8N_DISABLED_MODULES=policy-infrastructure`. The module is gone from `activeModules` and the same operations still succeed.
4. Backend suites: `pnpm --filter @n8n/backend-common test`, `pnpm --filter n8n test:unit`, `pnpm --filter n8n test:integration`.

No license or feature flag is needed — the module is unlicensed and runs on every instance type.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1376

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

