### PR TITLE
feat(core): Add node type availability endpoint for a project (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -12,6 +12,7 @@ export type * from './quick-connect';
 export * from './agents/index';
 export * from './instance-registry-types';
 export type * from './worker-pools';
+export type * from './node-type-availability';
 export * from './redaction-enforcement';
 export * from './redaction-enforcement-floor';
 export * from './workflow-reviews-policy';

--- a/packages/@n8n/api-types/src/node-type-availability.ts
+++ b/packages/@n8n/api-types/src/node-type-availability.ts
@@ -1,0 +1,21 @@
+/** The scope whose policy decided a node type's availability. */
+export type NodeTypeAvailabilityScope = 'instance' | 'project';
+
+/**
+ * One node type's effective availability in a project, composed from the instance and
+ * project policies. Optional fields are present only on unavailable entries, so the
+ * response stays cheap for the common case of a fully available type.
+ */
+export type NodeTypeAvailability = {
+	name: string;
+	available: boolean;
+	/** The denying scope. */
+	scope?: NodeTypeAvailabilityScope;
+	/** The rule that denied, absent when the scope's default action decided. */
+	matchedRuleId?: string;
+	/** The instance policy delegates this type, so the project can allow it for itself. */
+	optInAvailable?: boolean;
+};
+
+/** Response of `GET /projects/:projectId/available-types`. */
+export type AvailableTypesResponse = NodeTypeAvailability[];

--- a/packages/cli/src/modules/type-availability-policies/__tests__/available-types.controller.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/available-types.controller.test.ts
@@ -1,0 +1,144 @@
+import { LICENSE_FEATURES } from '@n8n/constants';
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { Request, Response } from 'express';
+import { mock } from 'vitest-mock-extended';
+
+import type { NodeTypes } from '@/node-types';
+
+import { AvailableTypesController } from '../available-types.controller';
+import type {
+	ComposedTypeVerdict,
+	TypeAvailabilityPolicyService,
+} from '../type-availability-policy.service';
+
+/**
+ * Reading effective availability requires only project membership, so this route is gated by
+ * `project:read` — not the `nodeTypePolicy:manage` scope that authoring the policy takes.
+ */
+describe('AvailableTypesController route access scopes', () => {
+	const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+		AvailableTypesController as never,
+	);
+	const routeCases = Array.from(metadata.routes.entries()).map(([handlerName, route]) => ({
+		handlerName,
+		route,
+	}));
+
+	it('registers at least one route', () => {
+		expect(routeCases.length).toBeGreaterThan(0);
+	});
+
+	it.each(routeCases)(
+		'$handlerName is gated by a project-scoped project:read check',
+		({ route }) => {
+			expect(route.accessScope).toBeDefined();
+			expect(route.accessScope?.globalOnly).toBe(false);
+			expect(route.accessScope?.scope).toBe('project:read');
+		},
+	);
+
+	it('is gated by the node type policies license feature', () => {
+		for (const { route } of routeCases) {
+			expect(route.licenseFeature).toBe(LICENSE_FEATURES.NODE_TYPE_POLICIES);
+		}
+	});
+});
+
+describe('AvailableTypesController.getAvailableTypes', () => {
+	const service = mock<TypeAvailabilityPolicyService>();
+	const nodeTypes = mock<NodeTypes>();
+	const controller = new AvailableTypesController(service, nodeTypes);
+
+	const request = mock<Request>();
+	const response = mock<Response>();
+
+	const verdict = (overrides: Partial<ComposedTypeVerdict>): ComposedTypeVerdict => ({
+		name: 'n8n-nodes-base.slack',
+		action: 'allow',
+		scope: 'instance',
+		matchedRuleId: null,
+		optInAvailable: false,
+		...overrides,
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		nodeTypes.getKnownTypes.mockReturnValue({});
+	});
+
+	it('evaluates every known type name, including synthesized tool variants', async () => {
+		nodeTypes.getKnownTypes.mockReturnValue({
+			'n8n-nodes-base.slack': { className: 'Slack', sourcePath: '' },
+			'n8n-nodes-base.slackTool': { className: 'Slack', sourcePath: '' },
+		});
+		service.evaluateComposedTypes.mockResolvedValue([]);
+
+		await controller.getAvailableTypes(request, response, 'project-1');
+
+		expect(service.evaluateComposedTypes).toHaveBeenCalledWith('node-types', 'project-1', [
+			'n8n-nodes-base.slack',
+			'n8n-nodes-base.slackTool',
+		]);
+	});
+
+	it('reports an available type without a reason', async () => {
+		service.evaluateComposedTypes.mockResolvedValue([verdict({ matchedRuleId: 'r1' })]);
+
+		const result = await controller.getAvailableTypes(request, response, 'project-1');
+
+		expect(result).toStrictEqual([{ name: 'n8n-nodes-base.slack', available: true }]);
+	});
+
+	it('reports the denying scope and rule of an unavailable type', async () => {
+		service.evaluateComposedTypes.mockResolvedValue([
+			verdict({ action: 'deny', scope: 'project', matchedRuleId: 'r1' }),
+		]);
+
+		const result = await controller.getAvailableTypes(request, response, 'project-1');
+
+		expect(result).toEqual([
+			{
+				name: 'n8n-nodes-base.slack',
+				available: false,
+				scope: 'project',
+				matchedRuleId: 'r1',
+			},
+		]);
+	});
+
+	it('omits matchedRuleId when the scope default action denied', async () => {
+		service.evaluateComposedTypes.mockResolvedValue([
+			verdict({ action: 'deny', scope: 'project' }),
+		]);
+
+		const result = await controller.getAvailableTypes(request, response, 'project-1');
+
+		expect(result).toStrictEqual([
+			{ name: 'n8n-nodes-base.slack', available: false, scope: 'project' },
+		]);
+	});
+
+	it('marks an unmet delegation as opt-in available', async () => {
+		service.evaluateComposedTypes.mockResolvedValue([
+			verdict({
+				action: 'deny',
+				scope: 'instance',
+				matchedRuleId: 'delegate-rule',
+				optInAvailable: true,
+			}),
+		]);
+
+		const result = await controller.getAvailableTypes(request, response, 'project-1');
+
+		expect(result).toEqual([
+			{
+				name: 'n8n-nodes-base.slack',
+				available: false,
+				scope: 'instance',
+				matchedRuleId: 'delegate-rule',
+				optInAvailable: true,
+			},
+		]);
+	});
+});

--- a/packages/cli/src/modules/type-availability-policies/__tests__/policy-evaluator.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/policy-evaluator.test.ts
@@ -228,6 +228,7 @@ describe('evaluateComposedType', () => {
 			action: 'deny',
 			scope: 'instance',
 			matchedRuleId: 'instance-deny',
+			optInAvailable: false,
 		});
 	});
 
@@ -239,6 +240,7 @@ describe('evaluateComposedType', () => {
 			action: 'allow',
 			scope: 'project',
 			matchedRuleId: 'project-allow',
+			optInAvailable: false,
 		});
 	});
 
@@ -250,6 +252,7 @@ describe('evaluateComposedType', () => {
 			action: 'deny',
 			scope: 'instance',
 			matchedRuleId: null,
+			optInAvailable: true,
 		});
 	});
 
@@ -261,6 +264,7 @@ describe('evaluateComposedType', () => {
 			action: 'deny',
 			scope: 'instance',
 			matchedRuleId: null,
+			optInAvailable: true,
 		});
 	});
 
@@ -272,6 +276,7 @@ describe('evaluateComposedType', () => {
 			action: 'deny',
 			scope: 'project',
 			matchedRuleId: 'project-deny',
+			optInAvailable: true,
 		});
 	});
 
@@ -283,6 +288,7 @@ describe('evaluateComposedType', () => {
 			action: 'deny',
 			scope: 'project',
 			matchedRuleId: null,
+			optInAvailable: true,
 		});
 	});
 
@@ -294,6 +300,7 @@ describe('evaluateComposedType', () => {
 			action: 'deny',
 			scope: 'project',
 			matchedRuleId: 'project-deny',
+			optInAvailable: false,
 		});
 	});
 
@@ -302,6 +309,7 @@ describe('evaluateComposedType', () => {
 			action: 'allow',
 			scope: 'instance',
 			matchedRuleId: null,
+			optInAvailable: false,
 		});
 	});
 
@@ -313,6 +321,7 @@ describe('evaluateComposedType', () => {
 			action: 'allow',
 			scope: 'project',
 			matchedRuleId: 'project-allow',
+			optInAvailable: false,
 		});
 	});
 });

--- a/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policies.module.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policies.module.test.ts
@@ -18,7 +18,9 @@ describe('TypeAvailabilityPoliciesModule', () => {
 		expect(entry?.licenseFlag).toBe(LICENSE_FEATURES.NODE_TYPE_POLICIES);
 	});
 
-	it('registers the instance and project controllers on init', async () => {
+	// The available-types controller injects the node registry, whose import chain takes
+	// several seconds to transform — more than the default per-test timeout.
+	it('registers the instance, project and available-types controllers on init', async () => {
 		const module = new TypeAvailabilityPoliciesModule();
 
 		await module.init();
@@ -29,6 +31,7 @@ describe('TypeAvailabilityPoliciesModule', () => {
 		const { TypeAvailabilityPolicyProjectController } = await import(
 			'../type-availability-policy-project.controller.js'
 		);
+		const { AvailableTypesController } = await import('../available-types.controller.js');
 		const registry = Container.get(ControllerRegistryMetadata);
 
 		expect(
@@ -37,7 +40,10 @@ describe('TypeAvailabilityPoliciesModule', () => {
 		expect(
 			registry.getControllerMetadata(TypeAvailabilityPolicyProjectController as never).routes.size,
 		).toBeGreaterThan(0);
-	});
+		expect(
+			registry.getControllerMetadata(AvailableTypesController as never).routes.size,
+		).toBeGreaterThan(0);
+	}, 30_000);
 
 	it('exposes its entities so the datasource picks them up', async () => {
 		const module = new TypeAvailabilityPoliciesModule();

--- a/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
+++ b/packages/cli/src/modules/type-availability-policies/__tests__/type-availability-policy.service.test.ts
@@ -951,7 +951,12 @@ describe('TypeAvailabilityPolicyService', () => {
 				PROJECT_ID,
 				ROOT,
 			);
-			expect(result).toEqual({ action: 'allow', scope: 'project', matchedRuleId: 'project-allow' });
+			expect(result).toEqual({
+				action: 'allow',
+				scope: 'project',
+				matchedRuleId: 'project-allow',
+				optInAvailable: false,
+			});
 		});
 
 		it('lets an instance deny win over an unconfigured project', async () => {
@@ -970,7 +975,97 @@ describe('TypeAvailabilityPolicyService', () => {
 
 			const result = await service.evaluateComposedType(KIND, PROJECT_ID, TYPE);
 
-			expect(result).toEqual({ action: 'deny', scope: 'instance', matchedRuleId: 'instance-deny' });
+			expect(result).toEqual({
+				action: 'deny',
+				scope: 'instance',
+				matchedRuleId: 'instance-deny',
+				optInAvailable: false,
+			});
+		});
+	});
+
+	describe('evaluateComposedTypes', () => {
+		const PROJECT_ID = 'project-1';
+
+		it('reads each scope once and composes a verdict for every type', async () => {
+			const instanceDeny: PolicyRule = {
+				id: 'instance-deny',
+				action: 'deny',
+				selector: { kind: 'name', value: 'n8n-nodes-base.executeCommand' },
+			};
+			const instanceDelegate: PolicyRule = {
+				id: 'instance-delegate',
+				action: 'delegate',
+				selector: { kind: 'name', value: 'n8n-nodes-base.code' },
+			};
+			const projectDeny: PolicyRule = {
+				id: 'project-deny',
+				action: 'deny',
+				selector: { kind: 'name', value: 'n8n-nodes-base.slack' },
+			};
+			const instanceScope = makeScope({ projectId: null, defaultAction: 'allow' });
+			const projectScope = makeScope({
+				id: 'scope-2',
+				projectId: PROJECT_ID,
+				defaultAction: 'allow',
+			});
+			scopeRepository.findScopeByKindAndProject.mockImplementation(async (_kind, projectId) =>
+				projectId === null ? instanceScope : projectScope,
+			);
+			attachmentRepository.listAttachmentsForScope.mockImplementation(async (scopeId) => [
+				{
+					policyId: 'p1',
+					rules: scopeId === projectScope.id ? [projectDeny] : [instanceDeny, instanceDelegate],
+					priority: 0,
+					isFloor: false,
+				},
+			]);
+
+			const result = await service.evaluateComposedTypes(KIND, PROJECT_ID, [
+				'n8n-nodes-base.gmail',
+				'n8n-nodes-base.executeCommand',
+				'n8n-nodes-base.code',
+				'n8n-nodes-base.slack',
+			]);
+
+			expect(result).toEqual([
+				{
+					name: 'n8n-nodes-base.gmail',
+					action: 'allow',
+					scope: 'instance',
+					matchedRuleId: null,
+					optInAvailable: false,
+				},
+				{
+					name: 'n8n-nodes-base.executeCommand',
+					action: 'deny',
+					scope: 'instance',
+					matchedRuleId: 'instance-deny',
+					optInAvailable: false,
+				},
+				{
+					name: 'n8n-nodes-base.code',
+					action: 'deny',
+					scope: 'instance',
+					matchedRuleId: 'instance-delegate',
+					optInAvailable: true,
+				},
+				{
+					name: 'n8n-nodes-base.slack',
+					action: 'deny',
+					scope: 'project',
+					matchedRuleId: 'project-deny',
+					optInAvailable: false,
+				},
+			]);
+			expect(scopeRepository.findScopeByKindAndProject).toHaveBeenCalledTimes(2);
+			expect(attachmentRepository.listAttachmentsForScope).toHaveBeenCalledTimes(2);
+		});
+
+		it('returns an empty list when there are no types', async () => {
+			const result = await service.evaluateComposedTypes(KIND, PROJECT_ID, []);
+
+			expect(result).toEqual([]);
 		});
 	});
 });

--- a/packages/cli/src/modules/type-availability-policies/available-types.controller.ts
+++ b/packages/cli/src/modules/type-availability-policies/available-types.controller.ts
@@ -1,0 +1,65 @@
+import type { AvailableTypesResponse, NodeTypeAvailability } from '@n8n/api-types';
+import { LICENSE_FEATURES } from '@n8n/constants';
+import { Get, Licensed, Param, ProjectScope, RestController } from '@n8n/decorators';
+import type { Request, Response } from 'express';
+
+import { NodeTypes } from '@/node-types';
+
+import { NODE_TYPES_KIND } from './constants';
+import {
+	TypeAvailabilityPolicyService,
+	type ComposedTypeVerdict,
+} from './type-availability-policy.service';
+
+/**
+ * Only unavailable entries carry a reason, so the response for ~1,400 types stays small on the
+ * common path — the builder fetches it on every workflow open.
+ */
+function toAvailabilityEntry(verdict: ComposedTypeVerdict): NodeTypeAvailability {
+	if (verdict.action === 'allow') return { name: verdict.name, available: true };
+
+	return {
+		name: verdict.name,
+		available: false,
+		scope: verdict.scope,
+		...(verdict.matchedRuleId !== null && { matchedRuleId: verdict.matchedRuleId }),
+		...(verdict.optInAvailable && { optInAvailable: true }),
+	};
+}
+
+/**
+ * The effective node type set for one project — the builder UI's only source for what a member
+ * may use and why. Gated on `project:read`: per the RFC, reading effective availability takes
+ * only project membership, while authoring the policy stays with project admins.
+ *
+ * Kept out of `TypeAvailabilityPolicyProjectController` because that controller's whole surface
+ * is admin-gated, and this is the one read every member makes.
+ */
+@RestController('/projects/:projectId/available-types')
+export class AvailableTypesController {
+	constructor(
+		private readonly service: TypeAvailabilityPolicyService,
+		private readonly nodeTypes: NodeTypes,
+	) {}
+
+	@Get('/')
+	@Licensed(LICENSE_FEATURES.NODE_TYPE_POLICIES)
+	@ProjectScope('project:read')
+	async getAvailableTypes(
+		_req: Request,
+		_res: Response,
+		@Param('projectId') projectId: string,
+	): Promise<AvailableTypesResponse> {
+		// The known-nodes registry, not the type descriptions: those are released from memory
+		// after startup, and availability needs nothing but the names.
+		const typeNames = Object.keys(this.nodeTypes.getKnownTypes());
+
+		const verdicts = await this.service.evaluateComposedTypes(
+			NODE_TYPES_KIND,
+			projectId,
+			typeNames,
+		);
+
+		return verdicts.map(toAvailabilityEntry);
+	}
+}

--- a/packages/cli/src/modules/type-availability-policies/constants.ts
+++ b/packages/cli/src/modules/type-availability-policies/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * The one `kind` this module's REST surface manages. Other kinds (e.g. credential types)
+ * would get their own controller mounted on their own path, reusing the same service and DTOs.
+ */
+export const NODE_TYPES_KIND = 'node-types';

--- a/packages/cli/src/modules/type-availability-policies/policy-evaluator.ts
+++ b/packages/cli/src/modules/type-availability-policies/policy-evaluator.ts
@@ -1,3 +1,5 @@
+import type { NodeTypeAvailabilityScope } from '@n8n/api-types';
+
 import type {
 	PolicyAction,
 	PolicyAttachment,
@@ -20,10 +22,13 @@ export type ScopePolicy = {
  * `optInAvailable` marks a denial the project can lift on its own, because the instance
  * delegated the type. It says nothing about who denied: a project that denied a delegated
  * type itself can still opt back in, so the flag is about the delegation, not the scope.
+ *
+ * `scope` reuses the response type's scope union, so the verdict and what the API reports
+ * cannot drift apart.
  */
 export type ComposedVerdict = {
 	readonly action: 'allow' | 'deny';
-	readonly scope: 'instance' | 'project';
+	readonly scope: NodeTypeAvailabilityScope;
 	readonly matchedRuleId: string | null;
 	readonly optInAvailable: boolean;
 };

--- a/packages/cli/src/modules/type-availability-policies/policy-evaluator.ts
+++ b/packages/cli/src/modules/type-availability-policies/policy-evaluator.ts
@@ -16,11 +16,16 @@ export type ScopePolicy = {
  *
  * `matchedRuleId` carries the same "explicit rule vs. default action" distinction as
  * `PolicyVerdict`, from whichever scope's verdict is reported.
+ *
+ * `optInAvailable` marks a denial the project can lift on its own, because the instance
+ * delegated the type. It says nothing about who denied: a project that denied a delegated
+ * type itself can still opt back in, so the flag is about the delegation, not the scope.
  */
 export type ComposedVerdict = {
 	readonly action: 'allow' | 'deny';
 	readonly scope: 'instance' | 'project';
 	readonly matchedRuleId: string | null;
+	readonly optInAvailable: boolean;
 };
 
 /**
@@ -101,33 +106,59 @@ export function evaluateComposedType(
 	const instanceVerdict = evaluateType(instance.attachments, instance.defaultAction, typeName);
 
 	if (instanceVerdict.action === 'deny') {
-		return { action: 'deny', scope: 'instance', matchedRuleId: instanceVerdict.matchedRuleId };
+		return {
+			action: 'deny',
+			scope: 'instance',
+			matchedRuleId: instanceVerdict.matchedRuleId,
+			optInAvailable: false,
+		};
 	}
 
 	const projectVerdict = evaluateType(project.attachments, project.defaultAction, typeName);
 
 	if (instanceVerdict.action === 'delegate') {
 		if (projectVerdict.action === 'allow' && projectVerdict.matchedRuleId !== null) {
-			return { action: 'allow', scope: 'project', matchedRuleId: projectVerdict.matchedRuleId };
+			return {
+				action: 'allow',
+				scope: 'project',
+				matchedRuleId: projectVerdict.matchedRuleId,
+				optInAvailable: false,
+			};
 		}
 		// The project restricted the type itself, by rule or by a `deny` default: the denial
 		// is the project's decision, not the unsatisfied delegation's.
 		if (projectVerdict.action !== 'allow') {
-			return { action: 'deny', scope: 'project', matchedRuleId: projectVerdict.matchedRuleId };
+			return {
+				action: 'deny',
+				scope: 'project',
+				matchedRuleId: projectVerdict.matchedRuleId,
+				optInAvailable: true,
+			};
 		}
 		// A bare project `allow` default never satisfies a delegation, so the unsatisfied
 		// instance `delegate` is what denies here.
-		return { action: 'deny', scope: 'instance', matchedRuleId: instanceVerdict.matchedRuleId };
+		return {
+			action: 'deny',
+			scope: 'instance',
+			matchedRuleId: instanceVerdict.matchedRuleId,
+			optInAvailable: true,
+		};
 	}
 
 	// instanceVerdict.action === 'allow': the project's own verdict decides.
 	if (projectVerdict.action !== 'allow') {
-		return { action: 'deny', scope: 'project', matchedRuleId: projectVerdict.matchedRuleId };
+		return {
+			action: 'deny',
+			scope: 'project',
+			matchedRuleId: projectVerdict.matchedRuleId,
+			optInAvailable: false,
+		};
 	}
 
 	return {
 		action: 'allow',
 		scope: projectVerdict.matchedRuleId !== null ? 'project' : 'instance',
 		matchedRuleId: projectVerdict.matchedRuleId ?? instanceVerdict.matchedRuleId,
+		optInAvailable: false,
 	};
 }

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policies.module.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policies.module.ts
@@ -16,6 +16,7 @@ export class TypeAvailabilityPoliciesModule implements ModuleInterface {
 		// Side-effecting imports: register the controllers' routes via `@RestController`.
 		await import('./type-availability-policy-instance.controller.js');
 		await import('./type-availability-policy-project.controller.js');
+		await import('./available-types.controller.js');
 	}
 
 	async entities() {

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policy-instance.controller.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policy-instance.controller.ts
@@ -16,17 +16,12 @@ import type { Response } from 'express';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
+import { NODE_TYPES_KIND } from './constants';
 import { CreatePolicyDocumentDto } from './dto/create-policy-document.dto';
 import { PutInstancePolicyDto } from './dto/put-instance-policy.dto';
 import { ReplaceAttachmentsDto } from './dto/replace-attachments.dto';
 import { UpdatePolicyDocumentDto } from './dto/update-policy-document.dto';
 import { TypeAvailabilityPolicyService } from './type-availability-policy.service';
-
-/**
- * The one `kind` this REST surface manages. Other kinds (e.g. credential types) would get
- * their own controller mounted on their own path, reusing the same service and DTOs.
- */
-const NODE_TYPES_KIND = 'node-types';
 
 /**
  * Instance-scope REST surface for node type availability policies. Every route requires

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policy-project.controller.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policy-project.controller.ts
@@ -3,13 +3,9 @@ import { AuthenticatedRequest } from '@n8n/db';
 import { Body, Get, Licensed, ProjectScope, Put, RestController } from '@n8n/decorators';
 import type { Response } from 'express';
 
+import { NODE_TYPES_KIND } from './constants';
 import { PutProjectPolicyDto } from './dto/put-project-policy.dto';
 import { TypeAvailabilityPolicyService } from './type-availability-policy.service';
-
-/**
- * The one `kind` this REST surface manages — see `TypeAvailabilityPolicyInstanceController`.
- */
-const NODE_TYPES_KIND = 'node-types';
 
 /**
  * Project-scope REST surface for a project's own node type availability policy row. Every

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
@@ -46,6 +46,9 @@ export type EffectivePolicy = {
 	readonly attachments: readonly PolicyAttachment[];
 };
 
+/** One type's composed verdict, as `evaluateComposedTypes` reports it. */
+export type ComposedTypeVerdict = ComposedVerdict & { readonly name: string };
+
 type PolicyDocumentWrite = {
 	readonly policy: TypeAvailabilityPolicy;
 	readonly warnings: readonly ShadowWarning[];
@@ -681,20 +684,49 @@ export class TypeAvailabilityPolicyService {
 	}
 
 	/**
-	 * Composes the instance and project verdicts for one type, per `evaluateComposedType`. Reads
-	 * both scopes' effective policies in parallel — point-in-time snapshots, not one transaction,
-	 * which is fine for an evaluation path (unlike a write).
+	 * Composes the instance and project verdicts for one type, per `evaluateComposedType`.
 	 */
 	async evaluateComposedType(
 		kind: string,
 		projectId: string,
 		typeName: string,
 	): Promise<ComposedVerdict> {
+		const { instance, project } = await this.readComposedScopes(kind, projectId);
+
+		return evaluateComposedType(instance, project, typeName);
+	}
+
+	/**
+	 * Composes the verdict for many types against one project, reading each scope once and
+	 * evaluating in memory. There is no materialized effective set — recomputing every loaded
+	 * type against a realistic rule list is cheaper than keeping a cached one fresh.
+	 */
+	async evaluateComposedTypes(
+		kind: string,
+		projectId: string,
+		typeNames: readonly string[],
+	): Promise<ComposedTypeVerdict[]> {
+		const { instance, project } = await this.readComposedScopes(kind, projectId);
+
+		return typeNames.map((name) => ({
+			name,
+			...evaluateComposedType(instance, project, name),
+		}));
+	}
+
+	/**
+	 * Reads both scopes in parallel — point-in-time snapshots, not one transaction, which is
+	 * fine for an evaluation path (unlike a write).
+	 */
+	private async readComposedScopes(
+		kind: string,
+		projectId: string,
+	): Promise<{ instance: EffectivePolicy; project: EffectivePolicy }> {
 		const [instance, project] = await Promise.all([
 			this.getEffectivePolicy(kind, null),
 			this.getEffectivePolicy(kind, projectId),
 		]);
 
-		return evaluateComposedType(instance, project, typeName);
+		return { instance, project };
 	}
 }

--- a/packages/cli/test/integration/policy/available-types.controller.test.ts
+++ b/packages/cli/test/integration/policy/available-types.controller.test.ts
@@ -1,0 +1,241 @@
+import {
+	createTeamProject,
+	getPersonalProject,
+	linkUserToProject,
+	mockInstance,
+	testDb,
+} from '@n8n/backend-test-utils';
+import { LICENSE_FEATURES } from '@n8n/constants';
+import type { Project, User } from '@n8n/db';
+
+import { NodeTypes } from '@/node-types';
+import { createMember, createOwner } from '@test-integration/db/users';
+import * as utils from '@test-integration/utils';
+
+const nodeTypes = mockInstance(NodeTypes);
+
+const testServer = utils.setupTestServer({
+	endpointGroups: ['type-availability-policies'],
+	modules: ['type-availability-policies'],
+	enabledFeatures: [LICENSE_FEATURES.NODE_TYPE_POLICIES],
+});
+
+let owner: User;
+let projectAdmin: User;
+let projectEditor: User;
+let projectViewer: User;
+let otherProjectAdmin: User;
+let project: Project;
+
+const availableTypesRoute = (projectId: string) => `/projects/${projectId}/available-types`;
+const projectPolicyRoute = (projectId: string) =>
+	`/projects/${projectId}/node-type-policies/project`;
+
+const SLACK = 'n8n-nodes-base.slack';
+const CODE = 'n8n-nodes-base.code';
+const EXECUTE_COMMAND = 'n8n-nodes-base.executeCommand';
+const GMAIL = 'n8n-nodes-base.gmail';
+
+const KNOWN_TYPES = [SLACK, CODE, EXECUTE_COMMAND, GMAIL];
+
+const rule = (id: string, action: 'allow' | 'deny' | 'delegate', value: string) => ({
+	id,
+	action,
+	selector: { kind: 'name', value },
+});
+
+async function setInstancePolicy(rules: Array<ReturnType<typeof rule>>) {
+	const response = await testServer
+		.authAgentFor(owner)
+		.put('/node-type-policies/instance')
+		.send({ rules, defaultAction: 'allow', version: 0 });
+	expect(response.statusCode).toBe(200);
+}
+
+async function setProjectPolicy(projectId: string, rules: Array<ReturnType<typeof rule>>) {
+	const response = await testServer
+		.authAgentFor(projectAdmin)
+		.put(projectPolicyRoute(projectId))
+		.send({ rules, defaultAction: 'allow', version: 0 });
+	expect(response.statusCode).toBe(200);
+}
+
+beforeAll(async () => {
+	owner = await createOwner();
+	projectAdmin = await createMember();
+	projectEditor = await createMember();
+	projectViewer = await createMember();
+	otherProjectAdmin = await createMember();
+
+	project = await createTeamProject('Policy project', projectAdmin);
+	await createTeamProject('Other project', otherProjectAdmin);
+	await linkUserToProject(projectEditor, project, 'project:editor');
+	await linkUserToProject(projectViewer, project, 'project:viewer');
+});
+
+beforeEach(() => {
+	nodeTypes.getKnownTypes.mockReturnValue(
+		Object.fromEntries(KNOWN_TYPES.map((name) => [name, { className: name, sourcePath: '' }])),
+	);
+});
+
+afterEach(async () => {
+	await testDb.truncate([
+		'TypeAvailabilityPolicyAttachment',
+		'TypeAvailabilityPolicyScope',
+		'TypeAvailabilityPolicy',
+	]);
+});
+
+/**
+ * Reading effective availability takes project membership only — every member must see what
+ * they can use and why, including the roles that cannot author the policy.
+ */
+describe('available types endpoint RBAC', () => {
+	test.each([
+		['a project admin', () => projectAdmin],
+		['a project editor', () => projectEditor],
+		['a project viewer', () => projectViewer],
+		['an instance owner without a project role', () => owner],
+	])('allows %s', async (_label, user) => {
+		const response = await testServer.authAgentFor(user()).get(availableTypesRoute(project.id));
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	test('rejects the admin of a different project with 403', async () => {
+		const response = await testServer
+			.authAgentFor(otherProjectAdmin)
+			.get(availableTypesRoute(project.id));
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('rejects an unauthenticated caller with 401', async () => {
+		const response = await testServer.authlessAgent.get(availableTypesRoute(project.id));
+
+		expect(response.statusCode).toBe(401);
+	});
+});
+
+describe('available types endpoint license gating', () => {
+	afterEach(() => {
+		testServer.license.enable(LICENSE_FEATURES.NODE_TYPE_POLICIES);
+	});
+
+	test('rejects a member with 403 when the license feature is disabled', async () => {
+		testServer.license.disable(LICENSE_FEATURES.NODE_TYPE_POLICIES);
+
+		const response = await testServer
+			.authAgentFor(projectEditor)
+			.get(availableTypesRoute(project.id));
+
+		expect(response.statusCode).toBe(403);
+	});
+});
+
+describe('available types endpoint', () => {
+	test('reports every known type as available when no policy is configured', async () => {
+		const response = await testServer
+			.authAgentFor(projectViewer)
+			.get(availableTypesRoute(project.id));
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toEqual(KNOWN_TYPES.map((name) => ({ name, available: true })));
+	});
+
+	test('explains every unavailable type with the scope and rule that denied it', async () => {
+		await setInstancePolicy([
+			rule('instance-deny', 'deny', EXECUTE_COMMAND),
+			rule('instance-delegate', 'delegate', CODE),
+		]);
+		await setProjectPolicy(project.id, [rule('project-deny', 'deny', SLACK)]);
+
+		const response = await testServer
+			.authAgentFor(projectViewer)
+			.get(availableTypesRoute(project.id));
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toEqual([
+			{ name: SLACK, available: false, scope: 'project', matchedRuleId: 'project-deny' },
+			{
+				name: CODE,
+				available: false,
+				scope: 'instance',
+				matchedRuleId: 'instance-delegate',
+				optInAvailable: true,
+			},
+			{
+				name: EXECUTE_COMMAND,
+				available: false,
+				scope: 'instance',
+				matchedRuleId: 'instance-deny',
+			},
+			{ name: GMAIL, available: true },
+		]);
+	});
+
+	test('reports a delegated type as available once the project opts in', async () => {
+		await setInstancePolicy([rule('instance-delegate', 'delegate', CODE)]);
+		await setProjectPolicy(project.id, [rule('project-allow', 'allow', CODE)]);
+
+		const response = await testServer
+			.authAgentFor(projectViewer)
+			.get(availableTypesRoute(project.id));
+
+		expect(response.body.data).toContainEqual({ name: CODE, available: true });
+	});
+
+	test('an instance deny is not opt-in available, even for a project that allows the type', async () => {
+		await setInstancePolicy([rule('instance-deny', 'deny', CODE)]);
+		await setProjectPolicy(project.id, [rule('project-allow', 'allow', CODE)]);
+
+		const response = await testServer
+			.authAgentFor(projectViewer)
+			.get(availableTypesRoute(project.id));
+
+		expect(response.body.data).toContainEqual({
+			name: CODE,
+			available: false,
+			scope: 'instance',
+			matchedRuleId: 'instance-deny',
+		});
+	});
+
+	test('applies the instance policy to a personal project, which has no policy of its own', async () => {
+		await setInstancePolicy([rule('instance-deny', 'deny', EXECUTE_COMMAND)]);
+		const personalProject = await getPersonalProject(projectEditor);
+
+		const response = await testServer
+			.authAgentFor(projectEditor)
+			.get(availableTypesRoute(personalProject.id));
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toContainEqual({
+			name: EXECUTE_COMMAND,
+			available: false,
+			scope: 'instance',
+			matchedRuleId: 'instance-deny',
+		});
+	});
+
+	test('the same type can be available in one project and blocked in another', async () => {
+		await setProjectPolicy(project.id, [rule('project-deny', 'deny', SLACK)]);
+		const personalProject = await getPersonalProject(projectAdmin);
+
+		const blocked = await testServer
+			.authAgentFor(projectAdmin)
+			.get(availableTypesRoute(project.id));
+		const allowed = await testServer
+			.authAgentFor(projectAdmin)
+			.get(availableTypesRoute(personalProject.id));
+
+		expect(blocked.body.data).toContainEqual({
+			name: SLACK,
+			available: false,
+			scope: 'project',
+			matchedRuleId: 'project-deny',
+		});
+		expect(allowed.body.data).toContainEqual({ name: SLACK, available: true });
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds `GET /rest/projects/:projectId/available-types`. It returns every loaded node type as an object — `{ name, available, scope?, matchedRuleId?, optInAvailable? }` — so an unavailable type carries the scope and the rule that denied it, and `optInAvailable` marks a type the instance delegated to the project. The set is composed on demand from the instance and project policies, so there is no materialized set to keep fresh, and the `nodes.json` type-metadata pipeline stays untouched. Any project member can read the route (`project:read`), because a member must see what they can use and why; authoring the policy keeps its admin-only `nodeTypePolicy:manage` scope, so the route lives in its own controller. The response type is in `@n8n/api-types` for the frontend client to share.

Two notes for reviewers: the type list comes from `NodeTypes.getKnownTypes()`, because the full type descriptions are released from memory after startup; and `optInAvailable` is a new field on `ComposedVerdict`, which is why the evaluator tests change.

## How to test

The module is licensed and opt-in. Start an instance with the `type-availability-policies` module enabled and the node type policies license feature, then:

1. `PUT /rest/node-type-policies/instance` as an instance owner with `{ "rules": [{ "id": "r1", "action": "deny", "selector": { "kind": "name", "value": "n8n-nodes-base.executeCommand" } }], "defaultAction": "allow", "version": 0 }`.
2. `PUT /rest/projects/<teamProjectId>/node-type-policies/project` as a project admin with a `deny` rule for another type.
3. `GET /rest/projects/<teamProjectId>/available-types` as a project **viewer**. Both types report `available: false` with the scope and rule that denied them, and every other type reports `available: true`.
4. Change the instance rule action to `delegate` and repeat step 3. The type now reports `scope: "instance"` and `optInAvailable: true`. Add an explicit project `allow` rule for it, and it becomes available.

Automated coverage: `pnpm --filter n8n vitest run src/modules/type-availability-policies` and `pnpm --filter n8n test:integration test/integration/policy/available-types.controller.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1145

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

