### PR TITLE
feat(API): Add node type policy document and attachment endpoints (no-changelog)

### DIFF
--- a/docs/generated/postgres-schema/public.type_availability_policy.md
+++ b/docs/generated/postgres-schema/public.type_availability_policy.md
@@ -29,6 +29,7 @@
 
 | Name | Definition |
 | ---- | ---------- |
+| IDX_type_availability_policy_kind_createdAt_id | CREATE INDEX "IDX_type_availability_policy_kind_createdAt_id" ON public.type_availability_policy USING btree (kind, "createdAt", id) |
 | PK_7dc9809c6d53a6b8b8a62cd7798 | CREATE UNIQUE INDEX "PK_7dc9809c6d53a6b8b8a62cd7798" ON public.type_availability_policy USING btree (id) |
 
 ## Relations

--- a/docs/generated/sqlite-schema/type_availability_policy.md
+++ b/docs/generated/sqlite-schema/type_availability_policy.md
@@ -34,6 +34,7 @@ CREATE TABLE "type_availability_policy" ("id" varchar(36) PRIMARY KEY NOT NULL, 
 
 | Name | Definition |
 | ---- | ---------- |
+| IDX_type_availability_policy_kind_createdAt_id | CREATE INDEX "IDX_type_availability_policy_kind_createdAt_id" ON "type_availability_policy" ("kind", "createdAt", "id")  |
 | sqlite_autoindex_type_availability_policy_1 | PRIMARY KEY (id) |
 
 ## Relations

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -276,6 +276,11 @@ export { CreatePolicyDocumentDto } from './node-type-policies/create-policy-docu
 export { UpdatePolicyDocumentDto } from './node-type-policies/update-policy-document.dto';
 export { ReplaceAttachmentsDto } from './node-type-policies/replace-attachments.dto';
 export {
+	ListNodeTypePolicyDocumentsQueryDto,
+	NodeTypePolicyAttachmentsPublicDto,
+	NodeTypePolicyDocumentListPublicDto,
+	NodeTypePolicyDocumentPublicDto,
+	NodeTypePolicyDocumentWriteResultPublicDto,
 	NodeTypePolicyEffectivePublicDto,
 	NodeTypePolicyEffectiveWriteResultPublicDto,
 } from './node-type-policies/node-type-policy-public.dto';

--- a/packages/@n8n/api-types/src/dto/node-type-policies/node-type-policy-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/node-type-policies/node-type-policy-public.dto.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { policyActionSchema, policyRuleSchema } from './policy-rule.schema';
 import { Z } from '../../zod-class';
+import { publicApiPaginationSchema } from '../pagination/pagination.dto';
 
 /**
  * Response shapes for the public node type policy routes. Request bodies reuse the internal
@@ -33,4 +34,47 @@ export class NodeTypePolicyEffectivePublicDto extends Z.class(effectivePolicySch
 export class NodeTypePolicyEffectiveWriteResultPublicDto extends Z.class({
 	...effectivePolicySchema.shape,
 	warnings: z.array(shadowWarningSchema),
+}) {}
+
+const policyDocumentSchema = z.object({
+	id: z.string(),
+	kind: z.string(),
+	rules: policyRulesSchema,
+	version: z.number().int().positive(),
+	/** A user id, or the literal `environment` for env-bootstrap writes. */
+	updatedBy: z.string(),
+	createdAt: z.string().datetime(),
+	updatedAt: z.string().datetime(),
+});
+
+/** One reusable policy document. */
+export class NodeTypePolicyDocumentPublicDto extends Z.class(policyDocumentSchema.shape) {}
+
+/** Create or update of a policy document: the document plus shadowing warnings. */
+export class NodeTypePolicyDocumentWriteResultPublicDto extends Z.class({
+	policy: policyDocumentSchema,
+	warnings: z.array(shadowWarningSchema),
+}) {}
+
+export class NodeTypePolicyDocumentListPublicDto extends Z.class({
+	data: z.array(policyDocumentSchema),
+	nextCursor: z.string().nullable(),
+}) {}
+
+export class ListNodeTypePolicyDocumentsQueryDto extends Z.class({
+	limit: publicApiPaginationSchema.limit,
+	cursor: z.string().optional(),
+}) {}
+
+const policyAttachmentSchema = z.object({
+	policyId: z.string(),
+	rules: policyRulesSchema,
+	priority: z.number().int(),
+	isFloor: z.boolean(),
+});
+
+/** The attachments on one scope after a replace, with the scope's bumped version. */
+export class NodeTypePolicyAttachmentsPublicDto extends Z.class({
+	attachments: z.array(policyAttachmentSchema),
+	version: z.number().int().positive(),
 }) {}

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -131,6 +131,8 @@ export { n8nIdSchema } from './schemas/id.schema';
 export {
 	credentialIdParamSchema,
 	executionIdParamSchema,
+	nodeTypePolicyIdParamSchema,
+	nodeTypePolicyScopeIdParamSchema,
 	projectIdParamSchema,
 	promotionConnectionIdParamSchema,
 	promotionDirectionParamSchema,

--- a/packages/@n8n/api-types/src/schemas/public-api-path-params.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/public-api-path-params.schema.ts
@@ -32,3 +32,9 @@ export const promotionDirectionParamSchema = z
 	.openapi({ param: { description: 'The direction of the promotion: apply or promote.' } });
 export const credentialIdParamSchema = stringIdParamSchema('The ID of the credential.');
 export const variableIdParamSchema = stringIdParamSchema('The ID of the variable.');
+export const nodeTypePolicyIdParamSchema = stringIdParamSchema(
+	'The ID of the node type policy document.',
+);
+export const nodeTypePolicyScopeIdParamSchema = stringIdParamSchema(
+	'The ID of the node type policy scope.',
+);

--- a/packages/@n8n/db/src/migrations/common/1789137988234-AddKindCreatedAtIndexToTypeAvailabilityPolicy.ts
+++ b/packages/@n8n/db/src/migrations/common/1789137988234-AddKindCreatedAtIndexToTypeAvailabilityPolicy.ts
@@ -1,0 +1,20 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const tableName = 'type_availability_policy';
+const columns = ['kind', 'createdAt', 'id'];
+
+/**
+ * Supports the public API's policy document list: `WHERE kind ORDER BY createdAt, id`. Without
+ * this index, that query scans the whole table.
+ */
+export class AddKindCreatedAtIndexToTypeAvailabilityPolicy1789137988234
+	implements ReversibleMigration
+{
+	async up(context: MigrationContext) {
+		await context.schemaBuilder.createIndex(tableName, columns);
+	}
+
+	async down(context: MigrationContext) {
+		await context.schemaBuilder.dropIndex(tableName, columns, { skipIfMissing: true });
+	}
+}

--- a/packages/cli/src/modules/type-availability-policies/database/entities/type-availability-policy.entity.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/entities/type-availability-policy.entity.ts
@@ -1,5 +1,5 @@
 import { JsonColumn, WithTimestampsAndStringId } from '@n8n/db';
-import { Column, Entity } from '@n8n/typeorm';
+import { Column, Entity, Index } from '@n8n/typeorm';
 
 import type { PolicyRule } from '../../policy-rule.types';
 
@@ -11,6 +11,7 @@ import type { PolicyRule } from '../../policy-rule.types';
  * needs no migration. It has no CHECK constraint for that reason — callers validate it.
  */
 @Entity('type_availability_policy')
+@Index(['kind', 'createdAt', 'id'])
 export class TypeAvailabilityPolicy extends WithTimestampsAndStringId {
 	@Column({ type: 'varchar', length: 64 })
 	kind: string;

--- a/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy.repository.ts
+++ b/packages/cli/src/modules/type-availability-policies/database/repositories/type-availability-policy.repository.ts
@@ -88,6 +88,27 @@ export class TypeAvailabilityPolicyRepository extends BaseRepository<TypeAvailab
 		return await this.managerFor(ctx).findBy(TypeAvailabilityPolicy, { kind });
 	}
 
+	/**
+	 * One page of policy documents of one kind, for the public API's cursor pagination. Ordered
+	 * by `createdAt` then `id` so a cursor walks a stable sequence when two rows share a
+	 * timestamp.
+	 */
+	async findPageByKind(
+		kind: string,
+		offset: number,
+		limit: number,
+		ctx: OperationContext,
+	): Promise<{ items: TypeAvailabilityPolicy[]; count: number }> {
+		const [items, count] = await this.managerFor(ctx).findAndCount(TypeAvailabilityPolicy, {
+			where: { kind },
+			order: { createdAt: 'ASC', id: 'ASC' },
+			skip: offset,
+			take: limit,
+		});
+
+		return { items, count };
+	}
+
 	async createPolicy(input: NewPolicy, ctx: OperationContext): Promise<TypeAvailabilityPolicy> {
 		const policy = this.create({
 			kind: input.kind,

--- a/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
+++ b/packages/cli/src/modules/type-availability-policies/type-availability-policy.service.ts
@@ -400,6 +400,15 @@ export class TypeAvailabilityPolicyService {
 		return await this.policyRepository.findByKind(kind, {});
 	}
 
+	/** One page of policy documents, for the public API's cursor-paginated listing. */
+	async listPolicyDocumentsPage(
+		kind: string,
+		offset: number,
+		limit: number,
+	): Promise<{ items: TypeAvailabilityPolicy[]; count: number }> {
+		return await this.policyRepository.findPageByKind(kind, offset, limit, {});
+	}
+
 	/**
 	 * Replaces every attachment on one scope, keyed by `scopeId` rather than `(kind,
 	 * projectId)` — a caller replacing attachments already holds a scope id from a prior

--- a/packages/cli/src/public-api/v1/controllers/__tests__/node-type-policies.public.controller.test.ts
+++ b/packages/cli/src/public-api/v1/controllers/__tests__/node-type-policies.public.controller.test.ts
@@ -36,7 +36,18 @@ describe('NodeTypePoliciesPublicController route metadata', () => {
 
 	it('registers every route of the internal instance and project controllers', () => {
 		expect(routeCases.map(({ handlerName }) => handlerName).sort()).toEqual(
-			['getInstancePolicy', 'getProjectPolicy', 'putInstancePolicy', 'putProjectPolicy'].sort(),
+			[
+				'createPolicyDocument',
+				'deletePolicyDocument',
+				'getInstancePolicy',
+				'getPolicyDocument',
+				'getProjectPolicy',
+				'listPolicyDocuments',
+				'putInstancePolicy',
+				'putProjectPolicy',
+				'replaceAttachments',
+				'updatePolicyDocument',
+			].sort(),
 		);
 	});
 
@@ -98,6 +109,12 @@ describe('NodeTypePoliciesPublicController with the module disabled', () => {
 	it('answers 503 before touching the service', async () => {
 		await expect(controller.getInstancePolicy()).rejects.toThrow(ServiceUnavailableError);
 		await expect(controller.getProjectPolicy(req, res, 'project-id')).rejects.toThrow(
+			ServiceUnavailableError,
+		);
+		await expect(controller.getPolicyDocument(req, res, 'policy-id')).rejects.toThrow(
+			ServiceUnavailableError,
+		);
+		await expect(controller.deletePolicyDocument(req, res, 'policy-id')).rejects.toThrow(
 			ServiceUnavailableError,
 		);
 

--- a/packages/cli/src/public-api/v1/controllers/node-type-policies.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/node-type-policies.public.controller.ts
@@ -1,8 +1,18 @@
 import {
+	CreatePolicyDocumentDto,
+	ListNodeTypePolicyDocumentsQueryDto,
+	NodeTypePolicyAttachmentsPublicDto,
+	NodeTypePolicyDocumentListPublicDto,
+	NodeTypePolicyDocumentPublicDto,
+	NodeTypePolicyDocumentWriteResultPublicDto,
 	NodeTypePolicyEffectivePublicDto,
 	NodeTypePolicyEffectiveWriteResultPublicDto,
 	PutInstancePolicyDto,
 	PutProjectPolicyDto,
+	ReplaceAttachmentsDto,
+	UpdatePolicyDocumentDto,
+	nodeTypePolicyIdParamSchema,
+	nodeTypePolicyScopeIdParamSchema,
 	projectIdParamSchema,
 } from '@n8n/api-types';
 import { ModuleRegistry } from '@n8n/backend-common';
@@ -16,21 +26,42 @@ import {
 	ApiSummary,
 	ApiTags,
 	Body,
+	Delete,
 	Get,
 	GlobalScope,
 	Licensed,
 	Param,
+	Post,
 	ProjectScope,
 	PublicApiController,
 	Put,
+	Query,
 } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import type { Response } from 'express';
 
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
 import { NODE_TYPES_KIND } from '@/modules/type-availability-policies/constants';
+import type { TypeAvailabilityPolicy } from '@/modules/type-availability-policies/database/entities/type-availability-policy.entity';
+import {
+	encodeNextCursor,
+	resolveOffsetPagination,
+} from '@/public-api/v1/shared/services/pagination.service';
 
 const tags = ['NodeTypePolicy'];
+
+function toPublicDocument(policy: TypeAvailabilityPolicy): NodeTypePolicyDocumentPublicDto {
+	return {
+		id: policy.id,
+		kind: policy.kind,
+		rules: [...policy.rules],
+		version: policy.version,
+		updatedBy: policy.updatedBy,
+		createdAt: policy.createdAt.toISOString(),
+		updatedAt: policy.updatedAt.toISOString(),
+	};
+}
 
 /**
  * Public API surface for node type availability policies. Every route delegates to the same
@@ -166,6 +197,166 @@ export class NodeTypePoliciesPublicController {
 			defaultAction: result.defaultAction,
 			version: result.version,
 			warnings: [...result.warnings],
+		};
+	}
+
+	@Get('/policies')
+	@Licensed(LICENSE_FEATURES.NODE_TYPE_POLICIES)
+	@ApiKeyScope('nodeTypePolicy:manage')
+	@GlobalScope('nodeTypePolicy:manage')
+	@ApiSummary('List node type policy documents')
+	@ApiDescription('Returns a cursor-paginated list of reusable policy documents.')
+	@ApiTags(tags)
+	@ApiResponse(200, NodeTypePolicyDocumentListPublicDto)
+	@ApiErrorResponse(503)
+	async listPolicyDocuments(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Query query: ListNodeTypePolicyDocumentsQueryDto,
+	): Promise<NodeTypePolicyDocumentListPublicDto> {
+		const { offset, limit } = resolveOffsetPagination(query);
+
+		const { items, count } = await (await this.service()).listPolicyDocumentsPage(
+			NODE_TYPES_KIND,
+			offset,
+			limit,
+		);
+
+		return {
+			data: items.map(toPublicDocument),
+			nextCursor: encodeNextCursor({ offset, limit, numberOfTotalRecords: count }),
+		};
+	}
+
+	@Post('/policies')
+	@Licensed(LICENSE_FEATURES.NODE_TYPE_POLICIES)
+	@ApiKeyScope('nodeTypePolicy:manage')
+	@GlobalScope('nodeTypePolicy:manage')
+	@ApiSummary('Create a node type policy document')
+	@ApiDescription(
+		'Creates a reusable policy document that is not yet attached to any scope. Rule ids must be unique within the list. `warnings` lists rules that an earlier rule already shadows.',
+	)
+	@ApiTags(tags)
+	@ApiResponse(201, NodeTypePolicyDocumentWriteResultPublicDto)
+	@ApiErrorResponse(503)
+	async createPolicyDocument(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Body dto: CreatePolicyDocumentDto,
+	): Promise<NodeTypePolicyDocumentWriteResultPublicDto> {
+		const { policy, warnings } = await (await this.service()).createPolicyDocument(
+			NODE_TYPES_KIND,
+			dto.rules,
+			req.user.id,
+		);
+
+		return { policy: toPublicDocument(policy), warnings: [...warnings] };
+	}
+
+	@Get('/policies/:policyId')
+	@Licensed(LICENSE_FEATURES.NODE_TYPE_POLICIES)
+	@ApiKeyScope('nodeTypePolicy:manage')
+	@GlobalScope('nodeTypePolicy:manage')
+	@ApiSummary('Retrieve a node type policy document')
+	@ApiTags(tags)
+	@ApiResponse(200, NodeTypePolicyDocumentPublicDto)
+	@ApiErrorResponse(404)
+	@ApiErrorResponse(503)
+	async getPolicyDocument(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Param('policyId', nodeTypePolicyIdParamSchema) policyId: string,
+	): Promise<NodeTypePolicyDocumentPublicDto> {
+		const policy = await (await this.service()).getPolicyDocument(policyId);
+		if (!policy) {
+			throw new NotFoundError(`Policy document not found: ${policyId}`);
+		}
+
+		return toPublicDocument(policy);
+	}
+
+	@Put('/policies/:policyId')
+	@Licensed(LICENSE_FEATURES.NODE_TYPE_POLICIES)
+	@ApiKeyScope('nodeTypePolicy:manage')
+	@GlobalScope('nodeTypePolicy:manage')
+	@ApiSummary('Replace the rules of a node type policy document')
+	@ApiDescription(
+		"Replaces the document's whole rule list. `version` must equal the version last read; a stale value is rejected with 409. Every scope the document is attached to has its version bumped. A `delegate` rule is rejected when the document is attached to a project scope.",
+	)
+	@ApiTags(tags)
+	@ApiResponse(200, NodeTypePolicyDocumentWriteResultPublicDto)
+	@ApiErrorResponse(404)
+	@ApiErrorResponse(409)
+	@ApiErrorResponse(503)
+	async updatePolicyDocument(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('policyId', nodeTypePolicyIdParamSchema) policyId: string,
+		@Body dto: UpdatePolicyDocumentDto,
+	): Promise<NodeTypePolicyDocumentWriteResultPublicDto> {
+		const { policy, warnings } = await (await this.service()).updatePolicyDocument(
+			policyId,
+			dto.rules,
+			dto.version,
+			req.user.id,
+		);
+
+		return { policy: toPublicDocument(policy), warnings: [...warnings] };
+	}
+
+	@Delete('/policies/:policyId')
+	@Licensed(LICENSE_FEATURES.NODE_TYPE_POLICIES)
+	@ApiKeyScope('nodeTypePolicy:manage')
+	@GlobalScope('nodeTypePolicy:manage')
+	@ApiSummary('Delete a node type policy document')
+	@ApiDescription(
+		'Deletes a policy document. A document that is still attached to a scope is rejected with 409; detach it first.',
+	)
+	@ApiTags(tags)
+	@ApiResponse(204)
+	@ApiErrorResponse(404)
+	@ApiErrorResponse(409)
+	@ApiErrorResponse(503)
+	async deletePolicyDocument(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('policyId', nodeTypePolicyIdParamSchema) policyId: string,
+	): Promise<void> {
+		await (await this.service()).deletePolicyDocument(policyId, req.user.id);
+	}
+
+	@Put('/scopes/:scopeId/attachments')
+	@Licensed(LICENSE_FEATURES.NODE_TYPE_POLICIES)
+	@ApiKeyScope('nodeTypePolicy:manage')
+	@GlobalScope('nodeTypePolicy:manage')
+	@ApiSummary("Replace a scope's attached policy documents")
+	@ApiDescription(
+		"Replaces every attachment on a scope. `scopeId` comes from the scope's `GET` response once it has been written. Each `policyId` and each `(isFloor, priority)` pair must be unique within the list. Last write wins; the scope's version is bumped.",
+	)
+	@ApiTags(tags)
+	@ApiResponse(200, NodeTypePolicyAttachmentsPublicDto)
+	@ApiErrorResponse(404)
+	@ApiErrorResponse(503)
+	async replaceAttachments(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('scopeId', nodeTypePolicyScopeIdParamSchema) scopeId: string,
+		@Body dto: ReplaceAttachmentsDto,
+	): Promise<NodeTypePolicyAttachmentsPublicDto> {
+		const result = await (await this.service()).replaceAttachments(
+			scopeId,
+			dto.attachments,
+			req.user.id,
+		);
+
+		return {
+			attachments: result.attachments.map((attachment) => ({
+				policyId: attachment.policyId,
+				rules: [...attachment.rules],
+				priority: attachment.priority,
+				isFloor: attachment.isFloor,
+			})),
+			version: result.version,
 		};
 	}
 }

--- a/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/createPolicyDocument.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/createPolicyDocument.generated.yml
@@ -1,0 +1,79 @@
+operationId: createPolicyDocument
+tags:
+  - NodeTypePolicy
+summary: Create a node type policy document
+description: Creates a reusable policy document that is not yet attached to any scope. Rule ids must be unique within the list. `warnings` lists rules that an earlier rule already shadows.
+x-required-scope: nodeTypePolicy:manage
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          rules:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                  minLength: 1
+                action:
+                  type: string
+                  enum:
+                    - allow
+                    - deny
+                    - delegate
+                selector:
+                  oneOf:
+                    - type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - name
+                        value:
+                          type: string
+                          minLength: 1
+                      required:
+                        - kind
+                        - value
+                    - type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - package
+                        value:
+                          type: string
+                          minLength: 1
+                      required:
+                        - kind
+                        - value
+              required:
+                - id
+                - action
+                - selector
+        required:
+          - rules
+responses:
+  '201':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          $ref: ../../../../shared/spec/schemas/nodeTypePolicyDocumentWriteResultPublicDto.generated.yml
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '415':
+    $ref: ../../../../shared/spec/responses/unsupportedMediaType.yml
+  '503':
+    $ref: ../../../../shared/spec/responses/serviceUnavailable.yml

--- a/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/deletePolicyDocument.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/deletePolicyDocument.generated.yml
@@ -1,0 +1,29 @@
+operationId: deletePolicyDocument
+tags:
+  - NodeTypePolicy
+summary: Delete a node type policy document
+description: Deletes a policy document. A document that is still attached to a scope is rejected with 409; detach it first.
+x-required-scope: nodeTypePolicy:manage
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    description: The ID of the node type policy document.
+    name: policyId
+    in: path
+responses:
+  '204':
+    description: Operation successful.
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml
+  '409':
+    $ref: ../../../../shared/spec/responses/conflict.yml
+  '503':
+    $ref: ../../../../shared/spec/responses/serviceUnavailable.yml

--- a/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/getPolicyDocument.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/getPolicyDocument.generated.yml
@@ -1,0 +1,99 @@
+operationId: getPolicyDocument
+tags:
+  - NodeTypePolicy
+summary: Retrieve a node type policy document
+x-required-scope: nodeTypePolicy:manage
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    description: The ID of the node type policy document.
+    name: policyId
+    in: path
+responses:
+  '200':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            id:
+              type: string
+            kind:
+              type: string
+            rules:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    minLength: 1
+                  action:
+                    type: string
+                    enum:
+                      - allow
+                      - deny
+                      - delegate
+                  selector:
+                    oneOf:
+                      - type: object
+                        properties:
+                          kind:
+                            type: string
+                            enum:
+                              - name
+                          value:
+                            type: string
+                            minLength: 1
+                        required:
+                          - kind
+                          - value
+                      - type: object
+                        properties:
+                          kind:
+                            type: string
+                            enum:
+                              - package
+                          value:
+                            type: string
+                            minLength: 1
+                        required:
+                          - kind
+                          - value
+                required:
+                  - id
+                  - action
+                  - selector
+            version:
+              type: integer
+              minimum: 0
+              exclusiveMinimum: true
+            updatedBy:
+              type: string
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+          required:
+            - id
+            - kind
+            - rules
+            - version
+            - updatedBy
+            - createdAt
+            - updatedAt
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml
+  '503':
+    $ref: ../../../../shared/spec/responses/serviceUnavailable.yml

--- a/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/listPolicyDocuments.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/listPolicyDocuments.generated.yml
@@ -1,0 +1,107 @@
+operationId: listPolicyDocuments
+tags:
+  - NodeTypePolicy
+summary: List node type policy documents
+description: Returns a cursor-paginated list of reusable policy documents.
+x-required-scope: nodeTypePolicy:manage
+parameters:
+  - $ref: ../../../../shared/spec/parameters/limit.yml
+  - $ref: ../../../../shared/spec/parameters/cursor.yml
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+responses:
+  '200':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  kind:
+                    type: string
+                  rules:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          minLength: 1
+                        action:
+                          type: string
+                          enum:
+                            - allow
+                            - deny
+                            - delegate
+                        selector:
+                          oneOf:
+                            - type: object
+                              properties:
+                                kind:
+                                  type: string
+                                  enum:
+                                    - name
+                                value:
+                                  type: string
+                                  minLength: 1
+                              required:
+                                - kind
+                                - value
+                            - type: object
+                              properties:
+                                kind:
+                                  type: string
+                                  enum:
+                                    - package
+                                value:
+                                  type: string
+                                  minLength: 1
+                              required:
+                                - kind
+                                - value
+                      required:
+                        - id
+                        - action
+                        - selector
+                  version:
+                    type: integer
+                    minimum: 0
+                    exclusiveMinimum: true
+                  updatedBy:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                required:
+                  - id
+                  - kind
+                  - rules
+                  - version
+                  - updatedBy
+                  - createdAt
+                  - updatedAt
+            nextCursor:
+              type: string
+              nullable: true
+          required:
+            - data
+            - nextCursor
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '503':
+    $ref: ../../../../shared/spec/responses/serviceUnavailable.yml

--- a/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/replaceAttachments.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/replaceAttachments.generated.yml
@@ -1,0 +1,128 @@
+operationId: replaceAttachments
+tags:
+  - NodeTypePolicy
+summary: Replace a scope's attached policy documents
+description: Replaces every attachment on a scope. `scopeId` comes from the scope's `GET` response once it has been written. Each `policyId` and each `(isFloor, priority)` pair must be unique within the list. Last write wins; the scope's version is bumped.
+x-required-scope: nodeTypePolicy:manage
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    description: The ID of the node type policy scope.
+    name: scopeId
+    in: path
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          attachments:
+            type: array
+            items:
+              type: object
+              properties:
+                policyId:
+                  type: string
+                  minLength: 1
+                priority:
+                  type: integer
+                isFloor:
+                  type: boolean
+              required:
+                - policyId
+                - priority
+                - isFloor
+        required:
+          - attachments
+responses:
+  '200':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            attachments:
+              type: array
+              items:
+                type: object
+                properties:
+                  policyId:
+                    type: string
+                  rules:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          minLength: 1
+                        action:
+                          type: string
+                          enum:
+                            - allow
+                            - deny
+                            - delegate
+                        selector:
+                          oneOf:
+                            - type: object
+                              properties:
+                                kind:
+                                  type: string
+                                  enum:
+                                    - name
+                                value:
+                                  type: string
+                                  minLength: 1
+                              required:
+                                - kind
+                                - value
+                            - type: object
+                              properties:
+                                kind:
+                                  type: string
+                                  enum:
+                                    - package
+                                value:
+                                  type: string
+                                  minLength: 1
+                              required:
+                                - kind
+                                - value
+                      required:
+                        - id
+                        - action
+                        - selector
+                  priority:
+                    type: integer
+                  isFloor:
+                    type: boolean
+                required:
+                  - policyId
+                  - rules
+                  - priority
+                  - isFloor
+            version:
+              type: integer
+              minimum: 0
+              exclusiveMinimum: true
+          required:
+            - attachments
+            - version
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml
+  '415':
+    $ref: ../../../../shared/spec/responses/unsupportedMediaType.yml
+  '503':
+    $ref: ../../../../shared/spec/responses/serviceUnavailable.yml

--- a/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/updatePolicyDocument.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/node-type-policies/spec/paths/updatePolicyDocument.generated.yml
@@ -1,0 +1,94 @@
+operationId: updatePolicyDocument
+tags:
+  - NodeTypePolicy
+summary: Replace the rules of a node type policy document
+description: Replaces the document's whole rule list. `version` must equal the version last read; a stale value is rejected with 409. Every scope the document is attached to has its version bumped. A `delegate` rule is rejected when the document is attached to a project scope.
+x-required-scope: nodeTypePolicy:manage
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+parameters:
+  - schema:
+      type: string
+    required: true
+    description: The ID of the node type policy document.
+    name: policyId
+    in: path
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          rules:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                  minLength: 1
+                action:
+                  type: string
+                  enum:
+                    - allow
+                    - deny
+                    - delegate
+                selector:
+                  oneOf:
+                    - type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - name
+                        value:
+                          type: string
+                          minLength: 1
+                      required:
+                        - kind
+                        - value
+                    - type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - package
+                        value:
+                          type: string
+                          minLength: 1
+                      required:
+                        - kind
+                        - value
+              required:
+                - id
+                - action
+                - selector
+          version:
+            type: integer
+            minimum: 0
+        required:
+          - rules
+          - version
+responses:
+  '200':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          $ref: ../../../../shared/spec/schemas/nodeTypePolicyDocumentWriteResultPublicDto.generated.yml
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml
+  '409':
+    $ref: ../../../../shared/spec/responses/conflict.yml
+  '415':
+    $ref: ../../../../shared/spec/responses/unsupportedMediaType.yml
+  '503':
+    $ref: ../../../../shared/spec/responses/serviceUnavailable.yml

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -41,6 +41,21 @@ paths:
       $ref: ./handlers/node-type-policies/spec/paths/getProjectPolicy.generated.yml
     put:
       $ref: ./handlers/node-type-policies/spec/paths/putProjectPolicy.generated.yml
+  /node-type-policies/policies:
+    get:
+      $ref: ./handlers/node-type-policies/spec/paths/listPolicyDocuments.generated.yml
+    post:
+      $ref: ./handlers/node-type-policies/spec/paths/createPolicyDocument.generated.yml
+  /node-type-policies/policies/{policyId}:
+    get:
+      $ref: ./handlers/node-type-policies/spec/paths/getPolicyDocument.generated.yml
+    put:
+      $ref: ./handlers/node-type-policies/spec/paths/updatePolicyDocument.generated.yml
+    delete:
+      $ref: ./handlers/node-type-policies/spec/paths/deletePolicyDocument.generated.yml
+  /node-type-policies/scopes/{scopeId}/attachments:
+    put:
+      $ref: ./handlers/node-type-policies/spec/paths/replaceAttachments.generated.yml
   /projects:
     get:
       $ref: ./handlers/projects/spec/paths/getProjects.generated.yml

--- a/packages/cli/src/public-api/v1/shared/spec/schemas/nodeTypePolicyDocumentWriteResultPublicDto.generated.yml
+++ b/packages/cli/src/public-api/v1/shared/spec/schemas/nodeTypePolicyDocumentWriteResultPublicDto.generated.yml
@@ -1,0 +1,88 @@
+type: object
+properties:
+  policy:
+    type: object
+    properties:
+      id:
+        type: string
+      kind:
+        type: string
+      rules:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+              minLength: 1
+            action:
+              type: string
+              enum:
+                - allow
+                - deny
+                - delegate
+            selector:
+              oneOf:
+                - type: object
+                  properties:
+                    kind:
+                      type: string
+                      enum:
+                        - name
+                    value:
+                      type: string
+                      minLength: 1
+                  required:
+                    - kind
+                    - value
+                - type: object
+                  properties:
+                    kind:
+                      type: string
+                      enum:
+                        - package
+                    value:
+                      type: string
+                      minLength: 1
+                  required:
+                    - kind
+                    - value
+          required:
+            - id
+            - action
+            - selector
+      version:
+        type: integer
+        minimum: 0
+        exclusiveMinimum: true
+      updatedBy:
+        type: string
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+    required:
+      - id
+      - kind
+      - rules
+      - version
+      - updatedBy
+      - createdAt
+      - updatedAt
+  warnings:
+    type: array
+    items:
+      type: object
+      properties:
+        ruleId:
+          type: string
+        shadowedByRuleId:
+          type: string
+      required:
+        - ruleId
+        - shadowedByRuleId
+required:
+  - policy
+  - warnings

--- a/packages/cli/test/integration/public-api/node-type-policies.test.ts
+++ b/packages/cli/test/integration/public-api/node-type-policies.test.ts
@@ -28,6 +28,7 @@ const DENY_RULE = { id: 'r1', action: 'deny', selector: { kind: 'name', value: '
 const DELEGATE_RULE = { id: 'r2', action: 'delegate', selector: { kind: 'name', value: 'a.b' } };
 
 const EFFECTIVE_KEYS = ['scopeId', 'rules', 'defaultAction', 'version'];
+const DOCUMENT_KEYS = ['id', 'kind', 'rules', 'version', 'updatedBy', 'createdAt', 'updatedAt'];
 
 beforeAll(async () => {
 	owner = await createOwnerWithApiKey();
@@ -65,9 +66,21 @@ describe('node type policies public API authorization', () => {
 	test.each([
 		['GET', '/node-type-policies/instance'],
 		['PUT', '/node-type-policies/instance'],
+		['GET', '/node-type-policies/policies'],
+		['POST', '/node-type-policies/policies'],
+		['GET', '/node-type-policies/policies/does-not-exist'],
+		['PUT', '/node-type-policies/policies/does-not-exist'],
+		['DELETE', '/node-type-policies/policies/does-not-exist'],
+		['PUT', '/node-type-policies/scopes/does-not-exist/attachments'],
 	])('%s %s rejects an owner key without the scope with 403', async (method, path) => {
 		const agent = testServer.publicApiAgentFor(unscopedOwner);
-		const response = await (method === 'GET' ? agent.get(path) : agent.put(path).send({}));
+		const response = await (method === 'GET'
+			? agent.get(path)
+			: method === 'POST'
+				? agent.post(path).send({})
+				: method === 'PUT'
+					? agent.put(path).send({})
+					: agent.delete(path));
 
 		expect(response.statusCode).toBe(403);
 	});
@@ -82,11 +95,23 @@ describe('node type policies public API authorization', () => {
 	test.each([
 		['GET', '/node-type-policies/instance'],
 		['PUT', '/node-type-policies/instance'],
+		['GET', '/node-type-policies/policies'],
+		['POST', '/node-type-policies/policies'],
+		['GET', '/node-type-policies/policies/does-not-exist'],
+		['PUT', '/node-type-policies/policies/does-not-exist'],
+		['DELETE', '/node-type-policies/policies/does-not-exist'],
+		['PUT', '/node-type-policies/scopes/does-not-exist/attachments'],
 	])(
 		'%s %s rejects a project admin with 403 (instance routes are global-only)',
 		async (method, path) => {
 			const agent = testServer.publicApiAgentFor(projectAdmin);
-			const response = await (method === 'GET' ? agent.get(path) : agent.put(path).send({}));
+			const response = await (method === 'GET'
+				? agent.get(path)
+				: method === 'POST'
+					? agent.post(path).send({})
+					: method === 'PUT'
+						? agent.put(path).send({})
+						: agent.delete(path));
 
 			expect(response.statusCode).toBe(403);
 		},
@@ -303,5 +328,262 @@ describe('node type policies public API project scope', () => {
 
 		const unchanged = await agent.get(projectRoute(project.id));
 		expect(unchanged.body.version).toBe(0);
+	});
+
+	test('PUT is rejected with 409 when the project document is also attached to the instance scope', async () => {
+		const adminAgent = testServer.publicApiAgentFor(projectAdmin);
+		const ownerAgent = testServer.publicApiAgentFor(owner);
+
+		const configured = await adminAgent
+			.put(projectRoute(project.id))
+			.send({ rules: [DENY_RULE], defaultAction: 'allow', version: 0 });
+		expect(configured.statusCode).toBe(200);
+
+		const documents = await ownerAgent.get('/node-type-policies/policies');
+		expect(documents.body.data).toHaveLength(1);
+		const documentId = documents.body.data[0].id as string;
+
+		const instancePut = await ownerAgent.put('/node-type-policies/instance').send(ALLOW_ALL);
+		const shared = await ownerAgent
+			.put(`/node-type-policies/scopes/${instancePut.body.scopeId}/attachments`)
+			.send({ attachments: [{ policyId: documentId, priority: 0, isFloor: false }] });
+		expect(shared.statusCode).toBe(200);
+
+		const current = await adminAgent.get(projectRoute(project.id));
+		const response = await adminAgent
+			.put(projectRoute(project.id))
+			.send({ rules: [], defaultAction: 'allow', version: current.body.version });
+
+		expect(response.statusCode).toBe(409);
+	});
+});
+
+describe('node type policies public API policy documents', () => {
+	test('POST creates a document and returns 201 with ISO timestamps', async () => {
+		const response = await testServer
+			.publicApiAgentFor(owner)
+			.post('/node-type-policies/policies')
+			.send({ rules: [DENY_RULE] });
+
+		expect(response.statusCode).toBe(201);
+		expect(Object.keys(response.body).sort()).toEqual(['policy', 'warnings']);
+		expect(Object.keys(response.body.policy).sort()).toEqual([...DOCUMENT_KEYS].sort());
+		expect(response.body.policy).toMatchObject({
+			kind: 'node-types',
+			rules: [DENY_RULE],
+			version: 1,
+			updatedBy: owner.id,
+		});
+		expect(new Date(response.body.policy.createdAt).toISOString()).toBe(
+			response.body.policy.createdAt,
+		);
+		expect(response.body.warnings).toEqual([]);
+	});
+
+	test('POST reports rules shadowed by an earlier rule', async () => {
+		const response = await testServer
+			.publicApiAgentFor(owner)
+			.post('/node-type-policies/policies')
+			.send({ rules: [DENY_RULE, { ...DENY_RULE, id: 'r2', action: 'allow' }] });
+
+		expect(response.statusCode).toBe(201);
+		expect(response.body.warnings).toEqual([{ ruleId: 'r2', shadowedByRuleId: 'r1' }]);
+	});
+
+	test('POST rejects duplicate rule ids with 400', async () => {
+		const response = await testServer
+			.publicApiAgentFor(owner)
+			.post('/node-type-policies/policies')
+			.send({ rules: [DENY_RULE, { ...DENY_RULE, action: 'allow' }] });
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	test('GET list paginates with an opaque cursor', async () => {
+		const agent = testServer.publicApiAgentFor(owner);
+		for (let i = 0; i < 3; i++) {
+			expect(
+				(await agent.post('/node-type-policies/policies').send({ rules: [] })).statusCode,
+			).toBe(201);
+		}
+
+		const firstPage = await agent.get('/node-type-policies/policies?limit=2');
+		expect(firstPage.statusCode).toBe(200);
+		expect(Object.keys(firstPage.body).sort()).toEqual(['data', 'nextCursor']);
+		expect(firstPage.body.data).toHaveLength(2);
+		expect(firstPage.body.nextCursor).toEqual(expect.any(String));
+
+		const secondPage = await agent.get(
+			`/node-type-policies/policies?cursor=${firstPage.body.nextCursor}`,
+		);
+		expect(secondPage.statusCode).toBe(200);
+		expect(secondPage.body.data).toHaveLength(1);
+		expect(secondPage.body.nextCursor).toBeNull();
+
+		const ids = [...firstPage.body.data, ...secondPage.body.data].map((d: { id: string }) => d.id);
+		expect(new Set(ids).size).toBe(3);
+	});
+
+	test('GET list rejects an invalid cursor with 400', async () => {
+		const response = await testServer
+			.publicApiAgentFor(owner)
+			.get('/node-type-policies/policies?cursor=not-a-cursor');
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	test('GET, PUT, and DELETE of one document', async () => {
+		const agent = testServer.publicApiAgentFor(owner);
+		const created = await agent.post('/node-type-policies/policies').send({ rules: [] });
+		const policyId = created.body.policy.id as string;
+
+		const fetched = await agent.get(`/node-type-policies/policies/${policyId}`);
+		expect(fetched.statusCode).toBe(200);
+		expect(Object.keys(fetched.body).sort()).toEqual([...DOCUMENT_KEYS].sort());
+		expect(fetched.body.id).toBe(policyId);
+
+		const updated = await agent
+			.put(`/node-type-policies/policies/${policyId}`)
+			.send({ rules: [DENY_RULE], version: 1 });
+		expect(updated.statusCode).toBe(200);
+		expect(updated.body.policy.version).toBe(2);
+		expect(updated.body.policy.rules).toEqual([DENY_RULE]);
+
+		const stale = await agent
+			.put(`/node-type-policies/policies/${policyId}`)
+			.send({ rules: [], version: 1 });
+		expect(stale.statusCode).toBe(409);
+
+		const missingVersion = await agent
+			.put(`/node-type-policies/policies/${policyId}`)
+			.send({ rules: [] });
+		expect(missingVersion.statusCode).toBe(400);
+
+		const deleted = await agent.delete(`/node-type-policies/policies/${policyId}`);
+		expect(deleted.statusCode).toBe(204);
+		expect(deleted.body).toEqual({});
+
+		const missing = await agent.get(`/node-type-policies/policies/${policyId}`);
+		expect(missing.statusCode).toBe(404);
+
+		const deleteMissing = await agent.delete(`/node-type-policies/policies/${policyId}`);
+		expect(deleteMissing.statusCode).toBe(404);
+	});
+
+	test('PUT on an attached document bumps the instance scope version', async () => {
+		const agent = testServer.publicApiAgentFor(owner);
+		const instancePut = await agent.put('/node-type-policies/instance').send(ALLOW_ALL);
+		const versionBefore = instancePut.body.version as number;
+
+		const documents = await agent.get('/node-type-policies/policies');
+		const document = documents.body.data[0];
+
+		const updated = await agent
+			.put(`/node-type-policies/policies/${document.id}`)
+			.send({ rules: [DENY_RULE], version: document.version });
+		expect(updated.statusCode).toBe(200);
+
+		const instance = await agent.get('/node-type-policies/instance');
+		expect(instance.body.version).toBeGreaterThan(versionBefore);
+		expect(instance.body.rules).toEqual([DENY_RULE]);
+	});
+
+	test('DELETE of an attached document returns 409', async () => {
+		const agent = testServer.publicApiAgentFor(owner);
+		const created = await agent.post('/node-type-policies/policies').send({ rules: [] });
+		const policyId = created.body.policy.id as string;
+
+		const instancePut = await agent.put('/node-type-policies/instance').send(ALLOW_ALL);
+		await agent
+			.put(`/node-type-policies/scopes/${instancePut.body.scopeId}/attachments`)
+			.send({ attachments: [{ policyId, priority: 5, isFloor: false }] });
+
+		const response = await agent.delete(`/node-type-policies/policies/${policyId}`);
+
+		expect(response.statusCode).toBe(409);
+	});
+});
+
+describe('node type policies public API attachments', () => {
+	test('PUT replaces the attachments, bumps the version, and fires an audit event', async () => {
+		const eventService = Container.get(EventService);
+		const emitSpy = vi.spyOn(eventService, 'emit');
+		const agent = testServer.publicApiAgentFor(owner);
+
+		const instancePut = await agent.put('/node-type-policies/instance').send(ALLOW_ALL);
+		const scopeId = instancePut.body.scopeId as string;
+		const created = await agent.post('/node-type-policies/policies').send({ rules: [DENY_RULE] });
+		const policyId = created.body.policy.id as string;
+
+		emitSpy.mockClear();
+		const response = await agent
+			.put(`/node-type-policies/scopes/${scopeId}/attachments`)
+			.send({ attachments: [{ policyId, priority: 1, isFloor: false }] });
+
+		expect(response.statusCode).toBe(200);
+		expect(Object.keys(response.body).sort()).toEqual(['attachments', 'version']);
+		expect(response.body.attachments).toEqual([
+			{ policyId, rules: [DENY_RULE], priority: 1, isFloor: false },
+		]);
+		expect(response.body.version).toBeGreaterThan(instancePut.body.version);
+		expect(emitSpy).toHaveBeenCalledWith(
+			'node-type-policy-attachments-updated',
+			expect.objectContaining({ updatedBy: owner.id, scopeId }),
+		);
+	});
+
+	test('PUT applies the same validation as the internal controller', async () => {
+		const agent = testServer.publicApiAgentFor(owner);
+		const instancePut = await agent.put('/node-type-policies/instance').send(ALLOW_ALL);
+		const scopeId = instancePut.body.scopeId as string;
+
+		const duplicatePolicy = await agent
+			.put(`/node-type-policies/scopes/${scopeId}/attachments`)
+			.send({
+				attachments: [
+					{ policyId: 'p1', priority: 0, isFloor: false },
+					{ policyId: 'p1', priority: 1, isFloor: false },
+				],
+			});
+		expect(duplicatePolicy.statusCode).toBe(400);
+
+		const duplicateSlot = await agent
+			.put(`/node-type-policies/scopes/${scopeId}/attachments`)
+			.send({
+				attachments: [
+					{ policyId: 'p1', priority: 0, isFloor: false },
+					{ policyId: 'p2', priority: 0, isFloor: false },
+				],
+			});
+		expect(duplicateSlot.statusCode).toBe(400);
+	});
+
+	test('PUT on an unknown scope returns 404', async () => {
+		const response = await testServer
+			.publicApiAgentFor(owner)
+			.put('/node-type-policies/scopes/does-not-exist/attachments')
+			.send({ attachments: [] });
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	test('attaching a document with a delegate rule to a project scope is rejected with 400', async () => {
+		const ownerAgent = testServer.publicApiAgentFor(owner);
+		const configured = await testServer
+			.publicApiAgentFor(projectAdmin)
+			.put(projectRoute(project.id))
+			.send(ALLOW_ALL);
+		const scopeId = configured.body.scopeId as string;
+
+		const created = await ownerAgent
+			.post('/node-type-policies/policies')
+			.send({ rules: [DELEGATE_RULE] });
+		expect(created.statusCode).toBe(201);
+
+		const response = await ownerAgent
+			.put(`/node-type-policies/scopes/${scopeId}/attachments`)
+			.send({ attachments: [{ policyId: created.body.policy.id, priority: 0, isFloor: false }] });
+
+		expect(response.statusCode).toBe(400);
 	});
 });

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -450,6 +450,24 @@
 		},
 		"PUT /node-type-policies/projects/{projectId}": {
 			"status": "gap"
+		},
+		"GET /node-type-policies/policies": {
+			"status": "gap"
+		},
+		"POST /node-type-policies/policies": {
+			"status": "gap"
+		},
+		"GET /node-type-policies/policies/{policyId}": {
+			"status": "gap"
+		},
+		"PUT /node-type-policies/policies/{policyId}": {
+			"status": "gap"
+		},
+		"DELETE /node-type-policies/policies/{policyId}": {
+			"status": "gap"
+		},
+		"PUT /node-type-policies/scopes/{scopeId}/attachments": {
+			"status": "gap"
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Second and final part of exposing node type availability policies on
the public API. Adds the remaining `NodeTypePoliciesPublicController`
routes for reusable policy documents and scope attachments:

| Method | Path | RBAC |
|---|---|---|
| GET, POST | `/node-type-policies/policies` | `@GlobalScope('nodeTypePolicy:manage')` |
| GET, PUT, DELETE | `/node-type-policies/policies/{policyId}` | `@GlobalScope('nodeTypePolicy:manage')` |
| PUT | `/node-type-policies/scopes/{scopeId}/attachments` | `@GlobalScope('nodeTypePolicy:manage')` |

Every route calls the same `TypeAvailabilityPolicyService` methods as
the internal `/rest` controllers and reuses their request DTOs.
Validation, RBAC, and audit events are therefore identical on both
surfaces.

Other changes:

- Add public response DTOs (`NodeTypePolicyDocumentPublicDto`,
  `NodeTypePolicyDocumentWriteResultPublicDto`,
  `NodeTypePolicyDocumentListPublicDto`,
  `NodeTypePolicyAttachmentsPublicDto`) and the `policyId`/`scopeId`
  path param schemas.
- Add `listPolicyDocumentsPage` to the service and repository for
  cursor pagination on the document list route.
- Commit the generated OpenAPI fragments and add the routes to the n8n
  node coverage manifest.

Contract differences from `/rest`, on purpose: the document update is
`PUT` instead of `PATCH`, delete answers `204`, the document list
returns `{ data, nextCursor }`, and create answers `201`.

## How to test

The feature is gated. Start an instance with
`N8N_ENABLED_MODULES=type-availability-policies` and a license that
enables the node type policies feature
(`LICENSE_FEATURES.NODE_TYPE_POLICIES`). Requires an API key with the
`nodeTypePolicy:manage` scope (added in #38239).

1. `POST /api/v1/node-type-policies/policies` with `{ "rules": [] }`.
   Expect `201`.
2. `GET /api/v1/node-type-policies/policies`. Expect the created
   document, paginated with `{ data, nextCursor }`.
3. `GET`, `PUT`, and `DELETE` of one document by id — see the
   integration tests for the full matrix (stale version → `409`,
   attached document delete → `409`, etc.).
4. `PUT /api/v1/node-type-policies/scopes/{scopeId}/attachments` with
   a document id from step 1. Expect `200` and the instance/project
   scope's version bumped.

Automated coverage: `packages/cli/test/integration/public-api/node-type-policies.test.ts`
(44 cases total, cumulative across the stack) and
`packages/cli/src/public-api/v1/controllers/__tests__/node-type-policies.public.controller.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1144

Depends on #38239. Depends on #38238.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)