### PR TITLE
fix(MCP Client Tool Node): Label tools with their MCP title in tool pickers

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/__test__/McpClient.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/__test__/McpClient.node.test.ts
@@ -471,6 +471,73 @@ describe('McpClient', () => {
 			expect(client.close).toHaveBeenCalledTimes(1);
 		});
 
+		it('should label results with the tool title and match the filter against it', async () => {
+			client.listTools.mockResolvedValue({
+				tools: [
+					{
+						name: 'list_limetypes',
+						title: 'List object types',
+						description: 'A tool',
+						inputSchema: { type: 'object' },
+					},
+					{
+						name: 'query_limeobjects',
+						annotations: { title: 'Query CRM data' },
+						description: 'Another tool',
+						inputSchema: { type: 'object' },
+					},
+					{
+						name: 'search',
+						description: 'Untitled tool',
+						inputSchema: { type: 'object' },
+					},
+				],
+			});
+
+			const loadOptionsFunctions = mock<ILoadOptionsFunctions>({
+				getNode: vi.fn().mockReturnValue({
+					id: '123',
+					name: 'MCP Client',
+					type: '@n8n/n8n-nodes-langchain.mcpClient',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				}),
+				getNodeParameter: vi.fn().mockImplementation((key: string) => {
+					const params: Record<string, unknown> = {
+						authentication: 'none',
+						serverTransport: 'httpStreamable',
+						endpointUrl: 'https://test.com/mcp',
+					};
+					return params[key];
+				}),
+			});
+
+			const all = await getTools.call(loadOptionsFunctions);
+			expect(all.results.map((option) => option.name)).toEqual([
+				'List object types',
+				'Query CRM data',
+				'search',
+			]);
+			expect(all.results.map((option) => option.value)).toEqual([
+				'list_limetypes',
+				'query_limeobjects',
+				'search',
+			]);
+
+			const byTitle = await getTools.call(loadOptionsFunctions, 'crm');
+			expect(byTitle.results.map(({ value }) => value)).toEqual(['query_limeobjects']);
+
+			const byName = await getTools.call(loadOptionsFunctions, 'limeobjects');
+			expect(byName.results.map(({ value }) => value)).toEqual(['query_limeobjects']);
+
+			const byEither = await getTools.call(loadOptionsFunctions, 'object');
+			expect(byEither.results.map(({ value }) => value)).toEqual([
+				'list_limetypes',
+				'query_limeobjects',
+			]);
+		});
+
 		it('should close client when listTools throws', async () => {
 			client.listTools.mockRejectedValue(new Error('listTools failed'));
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/listSearch.ts
@@ -1,7 +1,11 @@
 import type { ILoadOptionsFunctions, INodeListSearchResult } from 'n8n-workflow';
 
 import type { McpAuthenticationOption, McpServerTransport } from '../shared/types';
-import { connectMcpClientForCredential, mapToNodeOperationError } from '../shared/utils';
+import {
+	connectMcpClientForCredential,
+	getMcpToolDisplayName,
+	mapToNodeOperationError,
+} from '../shared/utils';
 
 export async function getTools(
 	this: ILoadOptionsFunctions,
@@ -25,13 +29,18 @@ export async function getTools(
 
 	try {
 		const result = await client.result.listTools({ cursor: paginationToken });
-		const tools = filter
-			? result.tools.filter((tool) => tool.name.toLowerCase().includes(filter.toLowerCase()))
-			: result.tools;
+		const matchesFilter = (tool: (typeof result.tools)[number]) => {
+			if (!filter) return true;
+			const needle = filter.toLowerCase();
+			return (
+				tool.name.toLowerCase().includes(needle) ||
+				getMcpToolDisplayName(tool).toLowerCase().includes(needle)
+			);
+		};
 
 		return {
-			results: tools.map((tool) => ({
-				name: tool.name,
+			results: result.tools.filter(matchesFilter).map((tool) => ({
+				name: getMcpToolDisplayName(tool),
 				value: tool.name,
 				description: tool.description,
 				inputSchema: tool.inputSchema,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
@@ -569,6 +569,37 @@ describe('runtime', () => {
 			]);
 		});
 
+		it('labels options with the tool title when the server provides one', async () => {
+			const titledTool = { ...sampleTool, name: 'list_limetypes', title: 'List object types' };
+			const annotatedTool = {
+				...sampleTool,
+				name: 'query_limeobjects',
+				annotations: { title: 'Query CRM data' },
+			};
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [titledTool, annotatedTool, sampleTool],
+			});
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+			const ctx = mock<ILoadOptionsFunctions>({
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP' })),
+				...egressHelpers<ILoadOptionsFunctions>(),
+			});
+
+			const result = await loadMcpToolOptions(ctx, baseConnectionConfig);
+
+			expect(result.map((option) => option.name)).toEqual([
+				'List object types',
+				'Query CRM data',
+				'search',
+			]);
+			expect(result.map((option) => option.value)).toEqual([
+				'list_limetypes',
+				'query_limeobjects',
+				'search',
+			]);
+		});
+
 		it('throws NodeOperationError when connect fails', async () => {
 			vi.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('boom'));
 			const ctx = mock<ILoadOptionsFunctions>({

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
@@ -27,6 +27,7 @@ import type { McpAuthenticationOption, McpServerTransport, McpTool } from './typ
 import {
 	connectMcpClientForCredential,
 	getAllTools,
+	getMcpToolDisplayName,
 	isStructuredContent,
 	mapToNodeOperationError,
 } from './utils';
@@ -400,7 +401,7 @@ export async function loadMcpToolOptions(
 	try {
 		const tools = await getAllTools(client.result);
 		return tools.map((tool) => ({
-			name: tool.name,
+			name: getMcpToolDisplayName(tool),
 			value: tool.name,
 			description: tool.description,
 			inputSchema: tool.inputSchema,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/types.ts
@@ -1,7 +1,13 @@
 import type { JSONSchema7 } from 'json-schema';
 import { isMcpOAuth2Authentication, type McpOAuth2CredentialType } from 'n8n-workflow';
 
-export type McpTool = { name: string; description?: string; inputSchema: JSONSchema7 };
+export type McpTool = {
+	name: string;
+	title?: string;
+	description?: string;
+	inputSchema: JSONSchema7;
+	annotations?: { title?: string };
+};
 
 export type McpServerTransport = 'sse' | 'httpStreamable';
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
@@ -31,6 +31,16 @@ import {
 	type McpTool,
 } from './types';
 
+/**
+ * Human-readable label for a tool, following the MCP spec's precedence:
+ * `title`, then `annotations.title`, then `name`.
+ */
+export function getMcpToolDisplayName(
+	tool: Pick<McpTool, 'name' | 'title' | 'annotations'>,
+): string {
+	return tool.title ?? tool.annotations?.title ?? tool.name;
+}
+
 export async function getAllTools(client: Client, cursor?: string): Promise<McpTool[]> {
 	const { tools, nextCursor } = await client.listTools({ cursor });
 


### PR DESCRIPTION
## Summary

The MCP tool pickers label every tool with its machine `name` (for example `list_limetypes`) even when the server sends a human-readable `title` ("List object types"). The MCP spec defines `title` as the display name and says clients should fall back to `annotations.title`, then `name`, when it is absent.

This PR applies that fallback chain in the two places that build a tool dropdown:

- `loadMcpToolOptions` in `nodes/mcp/shared/runtime.ts`, used by the MCP Client Tool and MCP Registry Client Tool nodes.
- `getTools` in `nodes/mcp/McpClient/listSearch.ts`, used by the MCP Client node. Its search filter now matches the label as well as the name, so typing what you see in the list still finds the tool.

The option `value` is unchanged and remains `name`, so stored `includeTools` / `excludeTools` selections and `tools/call` requests are unaffected. Servers that don't send a title see no difference.

The `McpTool` type in `nodes/mcp/shared/types.ts` gains the optional `title` and `annotations.title` fields that the SDK's `Tool` type already has. The display-name logic lives in one helper in `shared/utils.ts` so the two callers can't drift apart.

## How to test

1. Point an MCP Client Tool node at any MCP server whose `tools/list` includes `title` on its tools.
2. Set "Tools to Include" to "Selected" and open the dropdown.
3. Before this change every entry is the snake_case name. After it, entries show the title, and untitled tools still show their name.
4. Repeat with the MCP Client node's "Tool" picker; also type part of a title into its search box.

Regression tests: `labels options with the tool title when the server provides one` in `nodes/mcp/shared/runtime.test.ts` and `should label results with the tool title and match the filter against it` in `nodes/mcp/McpClient/__test__/McpClient.node.test.ts`. Both fail on `master` with the old labels, and pass with this change.

```
pnpm --filter @n8n/n8n-nodes-langchain test nodes/mcp
```

## Related Linear tickets, Github issues, and Community forum posts

fixes #38232

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

AI disclosure: written with Claude Code; I reviewed and ran the change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

