### PR TITLE
feat(core): Refuse an ungrouped Instance AI build over the top-level ceiling (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -994,10 +994,11 @@ store its own public endpoint.
 Do not report a build as done until you have made the grouping decision described in
 [Node Groups](#node-groups) and checked what the build did with it. A dropped-group warning
 names what was invalid — a duplicate name, a member that does not exist, a boundary the rules
-reject: fix what the warning reports and build again. A `GROUPING_DECISION_MISSING` or
-`ALL_GROUPS_DROPPED` error means the build was refused: fix the source, or pass the opt-out
-with a reason. If the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items
-with groups in place, name each remaining item and why it cannot join a group.
+reject: fix what the warning reports and build again. A `GROUPING_DECISION_MISSING` error means
+the build was refused: fix the source, or pass the opt-out with a reason. An `ALL_GROUPS_DROPPED`
+error also refuses the build: fix the boundaries the dropped-group warnings name — the opt-out
+does not apply. If the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items with groups in place, name each
+remaining item and why it cannot join a group.
 
 For a successful build, finish with one concise sentence naming the workflow and
 what changed. Include the workflow ID when it is available. If setup is

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -219,7 +219,9 @@ follow its build → publish → assign steps.
    Decide grouping now, while writing the source: `.group(...)` lives in the code, so
    it cannot be added after the build. See [Node Groups](#node-groups) for the
    criteria, and reach a decision either way — groups declared, or this workflow does
-   not warrant them.
+   not warrant them. When the canvas will be over the ceiling and no valid group can hold
+   the remaining nodes, pass `groupingDecision: 'not_warranted'` with a `groupingReason`
+   to `build-workflow`; without groups or that reason the build is refused.
 7. Before the first `build-workflow` (and again after substantive edits), run
    SDK validation on the workspace source file via
    `workspace_execute_command`:
@@ -992,9 +994,10 @@ store its own public endpoint.
 Do not report a build as done until you have made the grouping decision described in
 [Node Groups](#node-groups) and checked what the build did with it. A dropped-group warning
 names what was invalid — a duplicate name, a member that does not exist, a boundary the rules
-reject: fix what the warning reports and build again. If the top level is still above
-{{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items, name each remaining item and why it cannot join
-a group — if you cannot, group it and build again.
+reject: fix what the warning reports and build again. A `GROUPING_DECISION_MISSING` or
+`ALL_GROUPS_DROPPED` error means the build was refused: fix the source, or pass the opt-out
+with a reason. If the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items
+with groups in place, name each remaining item and why it cannot join a group.
 
 For a successful build, finish with one concise sentence naming the workflow and
 what changed. Include the workflow ID when it is available. If setup is

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -995,10 +995,11 @@ Do not report a build as done until you have made the grouping decision describe
 [Node Groups](#node-groups) and checked what the build did with it. A dropped-group warning
 names what was invalid — a duplicate name, a member that does not exist, a boundary the rules
 reject: fix what the warning reports and build again. A `GROUPING_DECISION_MISSING` error means
-the build was refused: fix the source, or pass the opt-out with a reason. An `ALL_GROUPS_DROPPED`
-error also refuses the build: fix the boundaries the dropped-group warnings name — the opt-out
-does not apply. If the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items with groups in place, name each
-remaining item and why it cannot join a group.
+the build was refused: fix the source, or pass the opt-out with a reason. A
+`GROUP_DROPPED_OVER_CEILING` error also refuses the build: a declared group was invalid and the
+canvas is still too wide. Fix the boundary the message names — the opt-out does not apply. If
+the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items with groups in place, name each remaining item and why
+it cannot join a group.
 
 For a successful build, finish with one concise sentence naming the workflow and
 what changed. Include the workflow ID when it is available. If setup is

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -998,8 +998,9 @@ reject: fix what the warning reports and build again. A `GROUPING_DECISION_MISSI
 the build was refused: fix the source, or pass the opt-out with a reason. A
 `GROUP_DROPPED_OVER_CEILING` error also refuses the build: a declared group was invalid and the
 canvas is still over the ceiling. Fix the boundary the message names — the opt-out does not
-apply. If the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items with groups in place, name each remaining
-item and why it cannot join a group.
+apply. If the top level is still above
+{{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items with groups in place, name each remaining item and
+why it cannot join a group.
 
 For a successful build, finish with one concise sentence naming the workflow and
 what changed. Include the workflow ID when it is available. If setup is

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -997,9 +997,9 @@ names what was invalid — a duplicate name, a member that does not exist, a bou
 reject: fix what the warning reports and build again. A `GROUPING_DECISION_MISSING` error means
 the build was refused: fix the source, or pass the opt-out with a reason. A
 `GROUP_DROPPED_OVER_CEILING` error also refuses the build: a declared group was invalid and the
-canvas is still too wide. Fix the boundary the message names — the opt-out does not apply. If
-the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items with groups in place, name each remaining item and why
-it cannot join a group.
+canvas is still over the ceiling. Fix the boundary the message names — the opt-out does not
+apply. If the top level is still above {{TOP_LEVEL_ITEM_CEILING_PLACEHOLDER}} items with groups in place, name each remaining
+item and why it cannot join a group.
 
 For a successful build, finish with one concise sentence naming the workflow and
 what changed. Include the workflow ID when it is available. If setup is

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -103,6 +103,14 @@ vi.mock('../generate-simulation-fixtures.service', async (importOriginal) => ({
 type BuildToolOutput = {
 	success: boolean;
 	filePath: string;
+	grouping?: {
+		topLevelItemCount: number;
+		ceiling: number;
+		groupCount: number;
+		droppedGroupCount: number;
+		decision: string;
+		reason?: string;
+	};
 	sourceHash?: string;
 	workflowId?: string;
 	workflowName?: string;
@@ -563,6 +571,139 @@ describe('createBuildWorkflowTool', () => {
 				warning_count: 1,
 			}),
 		);
+	});
+
+	describe('grouping decision check', () => {
+		const wideWorkflow = (nodeGroups?: Array<{ id: string; name: string; nodeIds: string[] }>) => ({
+			name: 'Wide workflow',
+			nodes: Array.from({ length: 8 }, (_, i) => ({
+				id: `node-${i}`,
+				name: `Step ${i}`,
+				type: 'n8n-nodes-base.set',
+				typeVersion: 1,
+				position: [0, 0] as [number, number],
+				parameters: {},
+			})),
+			connections: {},
+			...(nodeGroups ? { nodeGroups } : {}),
+		});
+		const compileTo = (workflow: ReturnType<typeof wideWorkflow>) =>
+			vi.mocked(compileWorkflowSource).mockResolvedValueOnce({
+				success: true,
+				workflow,
+				warnings: [],
+				compiler: 'sandbox-tsx',
+			});
+
+		it('refuses a new canvas over the ceiling that declares no group', async () => {
+			const { context, filePath, trackTelemetry } = makeContext({ source: 'src' });
+			compileTo(wideWorkflow());
+
+			const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+				filePath,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors?.join('\n')).toContain('[GROUPING_DECISION_MISSING]');
+			expect(result.errors?.join('\n')).toContain('Step 0, Step 1');
+			expect(result.remediation?.reason).toBe('workflow_grouping_decision_missing');
+			expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();
+			expect(trackTelemetry).toHaveBeenCalledWith(
+				'instance_ai_workflow_source_build',
+				expect.objectContaining({
+					result: 'failure',
+					stage: 'grouping',
+					top_level_item_count: 8,
+					group_count: 0,
+				}),
+			);
+		});
+
+		it('saves the same canvas when the agent opts out with a reason, and records it', async () => {
+			const { context, filePath } = makeContext({ source: 'src' });
+			compileTo(wideWorkflow());
+
+			const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+				filePath,
+				groupingDecision: 'not_warranted',
+				groupingReason: 'every step fans out to its own branch',
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.grouping).toMatchObject({
+				topLevelItemCount: 8,
+				groupCount: 0,
+				decision: 'not_warranted',
+				reason: 'every step fans out to its own branch',
+			});
+			expect(result.warnings?.join('\n')).toContain(
+				'(accepted: every step fans out to its own branch)',
+			);
+		});
+
+		it('rejects the opt-out without a reason before compiling', async () => {
+			const { context, filePath } = makeContext({ source: 'src' });
+
+			const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+				filePath,
+				groupingDecision: 'not_warranted',
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.remediation?.reason).toBe('grouping_reason_missing');
+			expect(compileWorkflowSource).not.toHaveBeenCalled();
+		});
+
+		it('saves a canvas over the ceiling when a valid group survived', async () => {
+			const { context, filePath } = makeContext({ source: 'src' });
+			compileTo(
+				wideWorkflow([{ id: 'g1', name: 'Stage', nodeIds: ['node-0', 'node-1', 'node-2'] }]),
+			);
+
+			const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+				filePath,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.grouping).toMatchObject({
+				topLevelItemCount: 6,
+				groupCount: 1,
+				decision: 'grouped',
+			});
+			expect(result.warnings).toBeUndefined();
+		});
+
+		it('refuses when every declared group was dropped, even with the opt-out', async () => {
+			const { context, filePath } = makeContext({ source: 'src' });
+			compileTo(wideWorkflow([{ id: 'g1', name: 'Stage', nodeIds: ['missing-a', 'missing-b'] }]));
+
+			const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+				filePath,
+				groupingDecision: 'not_warranted',
+				groupingReason: 'does not matter here',
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors?.join('\n')).toContain('[ALL_GROUPS_DROPPED]');
+			expect(result.errors?.join('\n')).toContain('Stage');
+			expect(result.remediation?.reason).toBe('workflow_groups_all_dropped');
+			expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();
+		});
+
+		it('leaves a canvas at the ceiling alone', async () => {
+			const { context, filePath } = makeContext({ source: 'src' });
+			const atCeiling = wideWorkflow();
+			atCeiling.nodes = atCeiling.nodes.slice(0, 7);
+			compileTo(atCeiling);
+
+			const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+				filePath,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.grouping).toMatchObject({ topLevelItemCount: 7, decision: 'under_ceiling' });
+			expect(result.warnings).toBeUndefined();
+		});
 	});
 
 	it('falls back to the post-build-flow handoff for a triggerless one-off build', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -688,6 +688,7 @@ describe('createBuildWorkflowTool', () => {
 			expect(result.errors?.join('\n')).toContain('[ALL_GROUPS_DROPPED]');
 			expect(result.errors?.join('\n')).toContain('Stage');
 			expect(result.remediation?.reason).toBe('workflow_groups_all_dropped');
+			expect(result.grouping).toMatchObject({ groupCount: 0, decision: 'grouped' });
 			expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();
 		});
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -687,6 +687,8 @@ describe('createBuildWorkflowTool', () => {
 			expect(result.success).toBe(false);
 			expect(result.errors?.join('\n')).toContain('[GROUP_DROPPED_OVER_CEILING]');
 			expect(result.errors?.join('\n')).toContain('Stage');
+			// The error carries the drop reason; the matching warning is not repeated.
+			expect(result.warnings?.join('\n') ?? '').not.toContain('[NODE_GROUP_DROPPED]');
 			expect(result.remediation?.reason).toBe('workflow_group_dropped_over_ceiling');
 			expect(result.grouping).toMatchObject({ groupCount: 0, decision: 'grouped' });
 			expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -607,6 +607,7 @@ describe('createBuildWorkflowTool', () => {
 			expect(result.errors?.join('\n')).toContain('[GROUPING_DECISION_MISSING]');
 			expect(result.errors?.join('\n')).toContain('Step 0, Step 1');
 			expect(result.remediation?.reason).toBe('workflow_grouping_decision_missing');
+			expect(result.grouping).toMatchObject({ groupCount: 0, decision: 'missing' });
 			expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();
 			expect(trackTelemetry).toHaveBeenCalledWith(
 				'instance_ai_workflow_source_build',

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -742,6 +742,96 @@ describe('createBuildWorkflowTool', () => {
 			expect(result.grouping).toMatchObject({ topLevelItemCount: 7, decision: 'under_ceiling' });
 			expect(result.warnings).toBeUndefined();
 		});
+
+		describe('on an existing workflow', () => {
+			const snapshotWith = (count: number) => ({
+				name: 'Target workflow',
+				nodes: Array.from({ length: count }, (_, i) => ({
+					id: `old-${i}`,
+					name: `Old ${i}`,
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+				})),
+				connections: {},
+			});
+
+			it("saves the user's workflow that was already over the ceiling, with a warning only", async () => {
+				const { context, filePath } = makeContext({ source: 'src' });
+				vi.mocked(context.workflowService.getAsWorkflowJSON).mockResolvedValueOnce(
+					snapshotWith(9) as never,
+				);
+				compileTo(wideWorkflow());
+
+				const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+					filePath,
+					workflowId: 'wf-user',
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.warnings?.join('\n')).toContain('[TOP_LEVEL_ITEMS_OVER_CEILING]');
+				expect(result.warnings?.join('\n')).not.toContain('GROUPING_DECISION_MISSING');
+				expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledTimes(1);
+			});
+
+			it("refuses a dropped group even on the user's workflow that was already over the ceiling", async () => {
+				const { context, filePath } = makeContext({ source: 'src' });
+				vi.mocked(context.workflowService.getAsWorkflowJSON).mockResolvedValueOnce(
+					snapshotWith(9) as never,
+				);
+				compileTo(
+					wideWorkflow([{ id: 'g1', name: 'Broken', nodeIds: ['missing-a', 'missing-b'] }]),
+				);
+
+				const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+					filePath,
+					workflowId: 'wf-user',
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors?.join('\n')).toContain('[GROUP_DROPPED_OVER_CEILING]');
+				expect(result.errors?.join('\n')).toContain('Broken');
+				expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+			});
+
+			it('refuses when the edit pushes a workflow that was under the ceiling over it with no groups', async () => {
+				const { context, filePath } = makeContext({ source: 'src' });
+				vi.mocked(context.workflowService.getAsWorkflowJSON).mockResolvedValueOnce(
+					snapshotWith(6) as never,
+				);
+				compileTo(wideWorkflow());
+
+				const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+					filePath,
+					workflowId: 'wf-user',
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors?.join('\n')).toContain('[GROUPING_DECISION_MISSING]');
+				expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+			});
+
+			it('refuses on a workflow this run created, even when it was already over the ceiling', async () => {
+				const { context, filePath } = makeContext({
+					source: 'src',
+					overrides: { aiCreatedWorkflowIds: new Set(['wf-created']) },
+				});
+				vi.mocked(context.workflowService.getAsWorkflowJSON).mockResolvedValueOnce(
+					snapshotWith(9) as never,
+				);
+				compileTo(wideWorkflow());
+
+				const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+					filePath,
+					workflowId: 'wf-created',
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors?.join('\n')).toContain('[GROUPING_DECISION_MISSING]');
+				expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+			});
+		});
 	});
 
 	it('falls back to the post-build-flow handoff for a triggerless one-off build', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -685,10 +685,46 @@ describe('createBuildWorkflowTool', () => {
 			});
 
 			expect(result.success).toBe(false);
-			expect(result.errors?.join('\n')).toContain('[ALL_GROUPS_DROPPED]');
+			expect(result.errors?.join('\n')).toContain('[GROUP_DROPPED_OVER_CEILING]');
 			expect(result.errors?.join('\n')).toContain('Stage');
-			expect(result.remediation?.reason).toBe('workflow_groups_all_dropped');
+			expect(result.remediation?.reason).toBe('workflow_group_dropped_over_ceiling');
 			expect(result.grouping).toMatchObject({ groupCount: 0, decision: 'grouped' });
+			expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();
+		});
+
+		it('refuses when one declared group was dropped and the canvas is still over the ceiling', async () => {
+			const { context, filePath } = makeContext({ source: 'src' });
+			const wide = wideWorkflow([
+				{ id: 'g1', name: 'Kept', nodeIds: ['node-0', 'node-1'] },
+				{ id: 'g2', name: 'Broken', nodeIds: ['missing-a', 'missing-b'] },
+			]);
+			// 10 nodes: 2 in the kept group + 8 loose = 9 boxes, still over the ceiling.
+			wide.nodes.push(
+				...[8, 9].map((i) => ({
+					id: `node-${i}`,
+					name: `Step ${i}`,
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+				})),
+			);
+			compileTo(wide);
+
+			const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+				filePath,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors?.join('\n')).toContain('[GROUP_DROPPED_OVER_CEILING]');
+			expect(result.errors?.join('\n')).toContain('Broken');
+			expect(result.remediation?.reason).toBe('workflow_group_dropped_over_ceiling');
+			expect(result.grouping).toMatchObject({
+				topLevelItemCount: 9,
+				groupCount: 1,
+				droppedGroupCount: 1,
+				decision: 'grouped',
+			});
 			expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();
 		});
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-validation-warnings.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-validation-warnings.test.ts
@@ -2,7 +2,9 @@ import type { WorkflowJSON } from '@n8n/workflow-sdk';
 import type { IConnections } from 'n8n-workflow';
 
 import {
+	groupingDecisionBlocker,
 	partitionWarnings,
+	summarizeWorkflowTopLevelItems,
 	topLevelItemsWarning,
 	type ValidationWarning,
 } from '../workflow-validation-warnings';
@@ -118,5 +120,91 @@ describe('topLevelItemsWarning', () => {
 		};
 
 		expect(topLevelItemsWarning(withSticky)).toBeUndefined();
+	});
+});
+
+describe('groupingDecisionBlocker', () => {
+	const node = (name: string) => ({
+		id: name,
+		name,
+		type: 'n8n-nodes-base.noOp',
+		typeVersion: 1,
+		position: [0, 0] as [number, number],
+	});
+	const names = (count: number) => Array.from({ length: count }, (_, i) => `n${i}`);
+	const workflow = (count: number, extra: Partial<WorkflowJSON> = {}): WorkflowJSON => ({
+		name: 'wf',
+		nodes: names(count).map(node),
+		connections: {},
+		...extra,
+	});
+	const dropped = [
+		{
+			code: 'NODE_GROUP_DROPPED',
+			severity: 'informational' as const,
+			message: 'Node group "Body" was removed: reason.',
+		},
+	];
+
+	it('says nothing under the ceiling', () => {
+		const summary = summarizeWorkflowTopLevelItems(workflow(7));
+
+		expect(
+			groupingDecisionBlocker({ summary, declaredGroupCount: 0, droppedGroupWarnings: [] }),
+		).toBeUndefined();
+	});
+
+	it('says nothing when a group survived, even over the ceiling', () => {
+		const summary = summarizeWorkflowTopLevelItems(
+			workflow(9, { nodeGroups: [{ id: 'g', name: 'Stage', nodeIds: ['n0', 'n1'] }] }),
+		);
+
+		expect(
+			groupingDecisionBlocker({ summary, declaredGroupCount: 1, droppedGroupWarnings: [] }),
+		).toBeUndefined();
+	});
+
+	it('blocks an over-ceiling canvas with no group declared, naming the groupable nodes', () => {
+		const summary = summarizeWorkflowTopLevelItems(workflow(8));
+
+		const blocker = groupingDecisionBlocker({
+			summary,
+			declaredGroupCount: 0,
+			droppedGroupWarnings: [],
+		});
+
+		expect(blocker?.code).toBe('GROUPING_DECISION_MISSING');
+		expect(blocker?.severity).toBe('warning');
+		expect(blocker?.message).toContain('8 boxes');
+		expect(blocker?.message).toContain('n0, n1');
+		expect(blocker?.message).toContain("groupingDecision: 'not_warranted'");
+	});
+
+	it('lets the explicit opt-out through', () => {
+		const summary = summarizeWorkflowTopLevelItems(workflow(8));
+
+		expect(
+			groupingDecisionBlocker({
+				summary,
+				declaredGroupCount: 0,
+				droppedGroupWarnings: [],
+				groupingDecision: 'not_warranted',
+			}),
+		).toBeUndefined();
+	});
+
+	it('blocks when every declared group was dropped, and the opt-out does not excuse it', () => {
+		const summary = summarizeWorkflowTopLevelItems(workflow(8));
+
+		const blocker = groupingDecisionBlocker({
+			summary,
+			declaredGroupCount: 1,
+			droppedGroupWarnings: dropped,
+			groupingDecision: 'not_warranted',
+		});
+
+		expect(blocker?.code).toBe('ALL_GROUPS_DROPPED');
+		expect(blocker?.severity).toBe('warning');
+		expect(blocker?.message).toContain('Node group "Body" was removed: reason.');
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-validation-warnings.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-validation-warnings.test.ts
@@ -203,8 +203,31 @@ describe('groupingDecisionBlocker', () => {
 			groupingDecision: 'not_warranted',
 		});
 
-		expect(blocker?.code).toBe('ALL_GROUPS_DROPPED');
+		expect(blocker?.code).toBe('GROUP_DROPPED_OVER_CEILING');
 		expect(blocker?.severity).toBe('warning');
 		expect(blocker?.message).toContain('Node group "Body" was removed: reason.');
+	});
+
+	it('blocks when one declared group was dropped and another survived, while still over the ceiling', () => {
+		const summary = summarizeWorkflowTopLevelItems(
+			workflow(10, { nodeGroups: [{ id: 'g1', name: 'Kept', nodeIds: ['n0', 'n1'] }] }),
+		);
+
+		const blocker = groupingDecisionBlocker({
+			summary,
+			declaredGroupCount: 2,
+			droppedGroupWarnings: dropped,
+		});
+
+		expect(blocker?.code).toBe('GROUP_DROPPED_OVER_CEILING');
+		expect(blocker?.message).toContain('1 of 2 declared node group(s) were removed');
+	});
+
+	it('does not block a dropped group when the canvas is within the ceiling', () => {
+		const summary = summarizeWorkflowTopLevelItems(workflow(6));
+
+		expect(
+			groupingDecisionBlocker({ summary, declaredGroupCount: 1, droppedGroupWarnings: dropped }),
+		).toBeUndefined();
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -81,6 +81,7 @@ import { compileWorkflowSource } from './workflow-source-compiler';
 import {
 	GROUP_DROPPED_OVER_CEILING_CODE,
 	groupingDecisionBlocker,
+	NODE_GROUP_DROPPED_CODE,
 	nodeGroupDroppedWarnings,
 	partitionWarnings,
 	summarizeWorkflowTopLevelItems,
@@ -1272,10 +1273,16 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 							? 'Fix the boundary each dropped-group message names; the opt-out does not apply here.'
 							: "If no valid group can hold the remaining nodes, call it again with groupingDecision: 'not_warranted' and a groupingReason.");
 
+					// The dropped-group error already carries each drop reason, so the matching
+					// warnings would only repeat it.
+					const informationalWithoutDrops = groupWasDropped
+						? informational.filter((warning) => warning.code !== NODE_GROUP_DROPPED_CODE)
+						: informational;
+
 					return await handleValidationFailure({
 						context,
 						blocking: [blocker],
-						informational,
+						informational: informationalWithoutDrops,
 						reason,
 						guidance,
 						summary:

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -55,6 +55,7 @@ import { withDeterministicRouting } from './workflow-build-routing';
 import {
 	trackWaitGateVerificationPlan,
 	trackWorkflowSourceBuild,
+	type BuildTelemetryStage,
 } from './workflow-build-telemetry';
 import {
 	bindSourceFileToExistingWorkflow,
@@ -78,8 +79,10 @@ import {
 import { computeChangedNodeNames, downgradeUnchangedNodeBlockers } from './workflow-node-diff';
 import { compileWorkflowSource } from './workflow-source-compiler';
 import {
+	groupingDecisionBlocker,
 	nodeGroupDroppedWarnings,
 	partitionWarnings,
+	summarizeWorkflowTopLevelItems,
 	topLevelItemsWarning,
 	type ValidationWarning,
 } from './workflow-validation-warnings';
@@ -91,8 +94,10 @@ import type { FolderResolutionFailure, InstanceAiContext, WorkflowFolderRef } fr
 import { BuildFailureTracker } from '../../workflow-builder/build-failure-tracker';
 import { createRemediation } from '../../workflow-loop/remediation';
 import {
+	groupingOutcomeSchema,
 	remediationMetadataSchema,
 	workflowVerificationReadinessSchema,
+	type GroupingOutcome,
 	type WorkflowBuildOutcome,
 } from '../../workflow-loop/workflow-loop-state';
 import { writeWorkspaceFile } from '../../workspace/workspace-files';
@@ -203,6 +208,20 @@ export const buildWorkflowInputSchema = z
 					'vehicle — verification becomes an optional pre-flight and completion is a live run whose ' +
 					'output was read back (see the one-off-operations skill). Omit or pass `reusable` for ' +
 					'anything the user may run again.',
+			),
+		groupingDecision: z
+			.enum(['grouped', 'not_warranted'])
+			.optional()
+			.describe(
+				'Only for a canvas that will exceed the top-level ceiling with no node group: pass `not_warranted` ' +
+					'together with `groupingReason` to say why no valid group can hold the remaining nodes. ' +
+					'Never pass it to skip the grouping decision.',
+			),
+		groupingReason: z
+			.string()
+			.optional()
+			.describe(
+				'Required with `groupingDecision: not_warranted`: why these nodes cannot form a valid group.',
 			),
 	})
 	.strict();
@@ -412,6 +431,8 @@ interface ValidationFailureArgs {
 	isSupportingWorkflow?: boolean;
 	isAuxiliarySupportingWorkflow?: boolean;
 	withEscalation: (errors: string[]) => string[];
+	stage?: BuildTelemetryStage;
+	grouping?: GroupingOutcome;
 }
 
 async function handleValidationFailure(args: ValidationFailureArgs) {
@@ -433,6 +454,8 @@ async function handleValidationFailure(args: ValidationFailureArgs) {
 		isSupportingWorkflow = false,
 		isAuxiliarySupportingWorkflow = false,
 		withEscalation,
+		stage = 'validation',
+		grouping,
 	} = args;
 
 	const formattedErrors = withEscalation(
@@ -451,10 +474,11 @@ async function handleValidationFailure(args: ValidationFailureArgs) {
 		errors: formattedErrors,
 		summary,
 		storeOnRunContext: !isAuxiliarySupportingWorkflow,
+		grouping,
 	});
 	trackWorkflowSourceBuild(context, {
 		result: 'failure',
-		stage: 'validation',
+		stage,
 		binding,
 		targetWorkflowId,
 		isSupportingWorkflow,
@@ -462,6 +486,15 @@ async function handleValidationFailure(args: ValidationFailureArgs) {
 		remediation,
 		errorCount: formattedErrors.length,
 		warningCount: informational.length,
+		...(grouping
+			? {
+					topLevelItemCount: grouping.topLevelItemCount,
+					groupCount: grouping.groupCount,
+					droppedGroupCount: grouping.droppedGroupCount,
+					groupingDecision: grouping.decision,
+					groupingReasonProvided: grouping.reason !== undefined,
+				}
+			: {}),
 	});
 	return {
 		success: false as const,
@@ -496,6 +529,7 @@ const buildWorkflowOutputSchema = z.object({
 	credentialResolutionNote: z.string().optional(),
 	referencedWorkflowIds: z.array(z.string()).optional(),
 	hasUnresolvedPlaceholders: z.boolean().optional(),
+	grouping: groupingOutcomeSchema.optional(),
 	denied: z.boolean().optional(),
 	reason: z.string().optional(),
 	remediation: remediationMetadataSchema.optional(),
@@ -530,6 +564,23 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 		.suspend(confirmationSuspendSchema)
 		.resume(confirmationResumeSchema)
 		.handler(async (input, ctx: BuildCtx) => {
+			const { groupingDecision, groupingReason } = input;
+			if (groupingDecision === 'not_warranted' && !groupingReason?.trim()) {
+				const guidance =
+					"Pass `groupingReason` with `groupingDecision: 'not_warranted'`: say why no valid node group can hold the remaining nodes.";
+				return {
+					success: false,
+					filePath: input.filePath,
+					errors: ['groupingDecision is not_warranted but groupingReason is missing.'],
+					remediation: createRemediation({
+						category: 'code_fixable',
+						shouldEdit: false,
+						reason: 'grouping_reason_missing',
+						guidance,
+					}),
+				};
+			}
+
 			let filePath: string;
 			try {
 				// Accepts absolute paths under the workspace root (models often echo
@@ -1128,9 +1179,73 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				);
 				droppedGroupCount = groupCountBeforeDrop - (json.nodeGroups?.length ?? 0);
 				informational.push(...droppedGroupWarnings);
-				const overCeiling = topLevelItemsWarning(json);
+
+				const topLevel = summarizeWorkflowTopLevelItems(json);
+				const grouping: GroupingOutcome = {
+					topLevelItemCount: topLevel.total,
+					ceiling: topLevel.ceiling,
+					groupCount: topLevel.groupCount,
+					droppedGroupCount,
+					decision: topLevel.groupCount > 0 ? 'grouped' : (groupingDecision ?? 'under_ceiling'),
+					...(groupingReason ? { reason: groupingReason } : {}),
+				};
+				// The check applies to canvases this run is responsible for: a new
+				// workflow, a rebuild of one it created, or an edit that pushed a small
+				// workflow over the ceiling. A small edit to a wide user workflow only warns.
+				const snapshotWasUnderCeiling =
+					savedWorkflowSnapshot !== undefined &&
+					!summarizeWorkflowTopLevelItems(savedWorkflowSnapshot).overCeiling;
+				const isOwnCanvas =
+					!targetWorkflowId ||
+					context.aiCreatedWorkflowIds?.has(targetWorkflowId) === true ||
+					snapshotWasUnderCeiling;
+				const blocker = isOwnCanvas
+					? groupingDecisionBlocker({
+							summary: topLevel,
+							declaredGroupCount: groupCountBeforeDrop,
+							droppedGroupWarnings,
+							groupingDecision,
+						})
+					: undefined;
+
+				if (blocker) {
+					return await handleValidationFailure({
+						context,
+						blocking: [blocker],
+						informational,
+						reason:
+							blocker.code === 'ALL_GROUPS_DROPPED'
+								? 'workflow_groups_all_dropped'
+								: 'workflow_grouping_decision_missing',
+						guidance:
+							'Edit the workspace source file so the stages form valid node groups, then call build-workflow again with the same filePath. ' +
+							"If no valid group can hold the remaining nodes, call it again with groupingDecision: 'not_warranted' and a groupingReason.",
+						summary:
+							'Workflow build stopped: the canvas is over the top-level ceiling with no node group.',
+						binding,
+						sourceHash,
+						targetWorkflowId,
+						filePath,
+						resolvedWorkItemId,
+						resolvedTaskId,
+						plannedTaskId,
+						owner,
+						isSupportingWorkflow,
+						isAuxiliarySupportingWorkflow,
+						withEscalation,
+						stage: 'grouping',
+						grouping,
+					});
+				}
+
+				const overCeiling = topLevelItemsWarning(json, topLevel);
 				if (overCeiling) {
-					informational.push(overCeiling);
+					const accepted = groupingDecision === 'not_warranted' && groupingReason;
+					informational.push(
+						accepted
+							? { ...overCeiling, message: `${overCeiling.message} (accepted: ${groupingReason})` }
+							: overCeiling,
+					);
 				}
 
 				if (await hasLostAllSavedNodeIds(json, targetWorkflowId, context)) {
@@ -1301,6 +1416,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						hasUnresolvedPlaceholders: hasPlaceholders || undefined,
 						changedNodeNames,
 						executionIntent,
+						grouping,
 						summary,
 					});
 					const postBuildFlow = await directPostBuildFlowHandoff(
@@ -1330,6 +1446,14 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						isAuxiliarySupportingWorkflow,
 						warningCount: informational.length,
 						droppedGroupCount,
+						...(grouping
+							? {
+									topLevelItemCount: grouping.topLevelItemCount,
+									groupCount: grouping.groupCount,
+									groupingDecision: grouping.decision,
+									groupingReasonProvided: grouping.reason !== undefined,
+								}
+							: {}),
 					});
 
 					return {
@@ -1371,6 +1495,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						referencedWorkflowIds:
 							referencedWorkflowIds.length > 0 ? referencedWorkflowIds : undefined,
 						hasUnresolvedPlaceholders: hasPlaceholders || undefined,
+						grouping,
 						warnings: combineWarnings(informational.map((w) => formatWarning(w.code, w.message))),
 					};
 				};

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -438,7 +438,7 @@ interface ValidationFailureArgs {
 /**
  * The grouping decision this build ends with, for the result and telemetry.
  *
- * - `grouped`: the agent made groups.
+ * - `grouped`: the agent made groups, even if the save dropped all of them.
  * - `not_warranted`: the agent made no groups and gave a reason.
  * - `under_ceiling`: the canvas has `TOP_LEVEL_ITEM_CEILING` boxes or fewer, so
  *   groups are not needed.
@@ -1221,7 +1221,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					groupCount: topLevel.groupCount,
 					droppedGroupCount,
 					decision: resolveGroupingDecision({
-						groupCount: topLevel.groupCount,
+						groupCount: groupCountBeforeDrop,
 						overCeiling: topLevel.overCeiling,
 						groupingDecision,
 					}),

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -435,6 +435,39 @@ interface ValidationFailureArgs {
 	grouping?: GroupingOutcome;
 }
 
+/**
+ * The grouping decision this build ends with, for the result and telemetry.
+ *
+ * - `grouped`: the agent made groups.
+ * - `not_warranted`: the agent made no groups and gave a reason.
+ * - `under_ceiling`: the canvas has `TOP_LEVEL_ITEM_CEILING` boxes or fewer, so
+ *   groups are not needed.
+ * - `missing`: the canvas has more than `TOP_LEVEL_ITEM_CEILING` boxes, and the
+ *   agent made no groups and gave no reason. It skipped the decision. The build
+ *   is refused.
+ */
+function resolveGroupingDecision(input: {
+	groupCount: number;
+	overCeiling: boolean;
+	groupingDecision: 'grouped' | 'not_warranted' | undefined;
+}): GroupingOutcome['decision'] {
+	if (input.groupCount > 0) {
+		return 'grouped';
+	}
+
+	if (input.groupingDecision !== undefined) {
+		return input.groupingDecision;
+	}
+
+	// No groups and no reason given. With more than `TOP_LEVEL_ITEM_CEILING` boxes on
+	// the canvas, the agent had to make groups or give a reason. It did neither.
+	if (input.overCeiling) {
+		return 'missing';
+	}
+
+	return 'under_ceiling';
+}
+
 async function handleValidationFailure(args: ValidationFailureArgs) {
 	const {
 		context,
@@ -1187,7 +1220,11 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					ceiling: topLevel.ceiling,
 					groupCount: topLevel.groupCount,
 					droppedGroupCount,
-					decision: topLevel.groupCount > 0 ? 'grouped' : (groupingDecision ?? 'under_ceiling'),
+					decision: resolveGroupingDecision({
+						groupCount: topLevel.groupCount,
+						overCeiling: topLevel.overCeiling,
+						groupingDecision,
+					}),
 					...(groupingReason ? { reason: groupingReason } : {}),
 				};
 				// The check applies to canvases this run is responsible for: a new

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -1236,22 +1236,28 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					savedWorkflowSnapshot !== undefined &&
 					!summarizeWorkflowTopLevelItems(savedWorkflowSnapshot).overCeiling;
 
-				// agentExceededCeiling is true when the agent's build made the canvas exceed TOP_LEVEL_ITEM_CEILING boxes,
-				// so the agent must fix it; false when the user's workflow already exceeded it, so we only warn.
+				// agentExceededCeiling is true when the agent's build made the canvas exceed TOP_LEVEL_ITEM_CEILING boxes;
+				// false when the user's workflow already exceeded it. It gates only the "no groups" refusal.
 				const agentExceededCeiling =
 					!targetWorkflowId ||
 					context.aiCreatedWorkflowIds?.has(targetWorkflowId) === true ||
 					snapshotWasUnderCeiling;
 
+				const refusalReason = groupingDecisionBlocker({
+					summary: topLevel,
+					declaredGroupCount: groupCountBeforeDrop,
+					droppedGroupWarnings,
+					groupingDecision,
+				});
+
 				// The one reason to refuse this build because of grouping, or undefined when the canvas is fine.
-				const blocker = agentExceededCeiling
-					? groupingDecisionBlocker({
-							summary: topLevel,
-							declaredGroupCount: groupCountBeforeDrop,
-							droppedGroupWarnings,
-							groupingDecision,
-						})
-					: undefined;
+				// A dropped group is the agent's own declaration, so it is refused on any canvas. "No groups"
+				// is refused only when the agent made the canvas exceed the ceiling; on the user's
+				// pre-existing layout it stays a warning.
+				const blocker =
+					agentExceededCeiling || refusalReason?.code === GROUP_DROPPED_OVER_CEILING_CODE
+						? refusalReason
+						: undefined;
 
 				if (blocker) {
 					const groupWasDropped = blocker.code === GROUP_DROPPED_OVER_CEILING_CODE;

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -504,6 +504,7 @@ async function handleValidationFailure(args: ValidationFailureArgs) {
 		errors: formattedErrors,
 		remediation,
 		warnings: combineWarnings(informational.map((w) => formatWarning(w.code, w.message))),
+		...(grouping ? { grouping } : {}),
 	};
 }
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -79,6 +79,7 @@ import {
 import { computeChangedNodeNames, downgradeUnchangedNodeBlockers } from './workflow-node-diff';
 import { compileWorkflowSource } from './workflow-source-compiler';
 import {
+	GROUP_DROPPED_OVER_CEILING_CODE,
 	groupingDecisionBlocker,
 	nodeGroupDroppedWarnings,
 	partitionWarnings,
@@ -1227,17 +1228,23 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					}),
 					...(groupingReason ? { reason: groupingReason } : {}),
 				};
+
 				// The check applies to canvases this run is responsible for: a new
 				// workflow, a rebuild of one it created, or an edit that pushed a small
 				// workflow over the ceiling. A small edit to a wide user workflow only warns.
 				const snapshotWasUnderCeiling =
 					savedWorkflowSnapshot !== undefined &&
 					!summarizeWorkflowTopLevelItems(savedWorkflowSnapshot).overCeiling;
-				const isOwnCanvas =
+
+				// agentExceededCeiling is true when the agent's build made the canvas exceed TOP_LEVEL_ITEM_CEILING boxes,
+				// so the agent must fix it; false when the user's workflow already exceeded it, so we only warn.
+				const agentExceededCeiling =
 					!targetWorkflowId ||
 					context.aiCreatedWorkflowIds?.has(targetWorkflowId) === true ||
 					snapshotWasUnderCeiling;
-				const blocker = isOwnCanvas
+
+				// The one reason to refuse this build because of grouping, or undefined when the canvas is fine.
+				const blocker = agentExceededCeiling
 					? groupingDecisionBlocker({
 							summary: topLevel,
 							declaredGroupCount: groupCountBeforeDrop,
@@ -1247,19 +1254,26 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					: undefined;
 
 				if (blocker) {
+					const groupWasDropped = blocker.code === GROUP_DROPPED_OVER_CEILING_CODE;
+
+					const reason = groupWasDropped
+						? 'workflow_group_dropped_over_ceiling'
+						: 'workflow_grouping_decision_missing';
+
+					const guidance =
+						'Edit the workspace source file so the stages form valid node groups, then call build-workflow again with the same filePath. ' +
+						(groupWasDropped
+							? 'Fix the boundary each dropped-group message names; the opt-out does not apply here.'
+							: "If no valid group can hold the remaining nodes, call it again with groupingDecision: 'not_warranted' and a groupingReason.");
+
 					return await handleValidationFailure({
 						context,
 						blocking: [blocker],
 						informational,
-						reason:
-							blocker.code === 'ALL_GROUPS_DROPPED'
-								? 'workflow_groups_all_dropped'
-								: 'workflow_grouping_decision_missing',
-						guidance:
-							'Edit the workspace source file so the stages form valid node groups, then call build-workflow again with the same filePath. ' +
-							"If no valid group can hold the remaining nodes, call it again with groupingDecision: 'not_warranted' and a groupingReason.",
+						reason,
+						guidance,
 						summary:
-							'Workflow build stopped: the canvas is over the top-level ceiling with no node group.',
+							'Workflow build stopped: the canvas is over the top-level ceiling and the node groups do not cover it.',
 						binding,
 						sourceHash,
 						targetWorkflowId,

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-reporting.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-reporting.ts
@@ -79,6 +79,7 @@ export async function reportFailedWorkflowBuildOutcome(
 		errors: string[];
 		summary: string;
 		storeOnRunContext: boolean;
+		grouping?: WorkflowBuildOutcome['grouping'];
 	},
 ): Promise<void> {
 	const buildContext = context.workflowBuildContext;
@@ -98,6 +99,7 @@ export async function reportFailedWorkflowBuildOutcome(
 		blockingReason: input.remediation.guidance,
 		failureSignature: input.errors.join('\n').slice(0, 500),
 		remediation: input.remediation,
+		...(input.grouping ? { grouping: input.grouping } : {}),
 		summary: input.summary,
 	});
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-telemetry.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-telemetry.ts
@@ -9,6 +9,7 @@ export type BuildTelemetryStage =
 	| 'hitl'
 	| 'parse'
 	| 'validation'
+	| 'grouping'
 	| 'name'
 	| 'save'
 	| 'conflict'
@@ -29,6 +30,10 @@ export function trackWorkflowSourceBuild(
 		errorCount?: number;
 		warningCount?: number;
 		droppedGroupCount?: number;
+		topLevelItemCount?: number;
+		groupCount?: number;
+		groupingDecision?: 'grouped' | 'not_warranted' | 'under_ceiling';
+		groupingReasonProvided?: boolean;
 	},
 ): void {
 	const buildContext = context.workflowBuildContext;
@@ -47,6 +52,14 @@ export function trackWorkflowSourceBuild(
 		error_count: input.errorCount ?? 0,
 		warning_count: input.warningCount ?? 0,
 		dropped_group_count: input.droppedGroupCount ?? 0,
+		...(input.topLevelItemCount !== undefined
+			? {
+					top_level_item_count: input.topLevelItemCount,
+					group_count: input.groupCount ?? 0,
+					grouping_decision: input.groupingDecision ?? 'under_ceiling',
+					grouping_reason_provided: input.groupingReasonProvided === true,
+				}
+			: {}),
 		...(input.targetWorkflowId ? { target_workflow_id: input.targetWorkflowId } : {}),
 		...(input.savedWorkflowId ? { workflow_id: input.savedWorkflowId } : {}),
 		...(input.binding.sourceHash ? { source_hash: input.binding.sourceHash } : {}),

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-telemetry.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-telemetry.ts
@@ -32,7 +32,7 @@ export function trackWorkflowSourceBuild(
 		droppedGroupCount?: number;
 		topLevelItemCount?: number;
 		groupCount?: number;
-		groupingDecision?: 'grouped' | 'not_warranted' | 'under_ceiling';
+		groupingDecision?: 'grouped' | 'not_warranted' | 'under_ceiling' | 'missing';
 		groupingReasonProvided?: boolean;
 	},
 ): void {

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
@@ -12,10 +12,18 @@ import {
 	type WorkflowGroupViolation,
 } from 'n8n-workflow';
 
+/** Informational: a declared group was invalid and the save removed it. */
 export const NODE_GROUP_DROPPED_CODE = 'NODE_GROUP_DROPPED';
+/** Refusal: the canvas is over the ceiling, has no group, and the agent gave no reason. */
 export const GROUPING_DECISION_MISSING_CODE = 'GROUPING_DECISION_MISSING';
+/** Refusal: the canvas is over the ceiling and the save dropped a group the agent declared. */
 export const GROUP_DROPPED_OVER_CEILING_CODE = 'GROUP_DROPPED_OVER_CEILING';
 
+/**
+ * What the agent tells build-workflow about groups.
+ * `grouped`: the source declares groups.
+ * `not_warranted`: no group is needed, and a reason is given.
+ */
 export type GroupingDecision = 'grouped' | 'not_warranted';
 
 export interface ValidationWarning {

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
@@ -1,17 +1,22 @@
 import {
 	partitionValidationIssues,
+	toEngineConnections,
 	type IssueSeverity,
 	type WorkflowJSON,
 } from '@n8n/workflow-sdk';
 import {
-	isTriggerNodeType,
-	STICKY_NODE_TYPE,
-	TOP_LEVEL_ITEM_CEILING,
+	formatTopLevelItemsMessage,
+	summarizeTopLevelItems,
+	TOP_LEVEL_ITEMS_OVER_CEILING_CODE,
+	type TopLevelItemsSummary,
 	type WorkflowGroupViolation,
 } from 'n8n-workflow';
 
 export const NODE_GROUP_DROPPED_CODE = 'NODE_GROUP_DROPPED';
-export const TOP_LEVEL_ITEMS_CODE = 'TOP_LEVEL_ITEMS_OVER_CEILING';
+export const GROUPING_DECISION_MISSING_CODE = 'GROUPING_DECISION_MISSING';
+export const ALL_GROUPS_DROPPED_CODE = 'ALL_GROUPS_DROPPED';
+
+export type GroupingDecision = 'grouped' | 'not_warranted';
 
 export interface ValidationWarning {
 	code: string;
@@ -50,44 +55,75 @@ export function partitionWarnings(warnings: ValidationWarning[]): {
 	return partitionValidationIssues(warnings);
 }
 
+/** Boxes on the canvas with every group collapsed, for the saved shape of a build. */
+export function summarizeWorkflowTopLevelItems(json: WorkflowJSON): TopLevelItemsSummary {
+	return summarizeTopLevelItems({
+		nodes: json.nodes ?? [],
+		nodeGroups: json.nodeGroups,
+		connectionsBySourceNode: toEngineConnections(json.connections),
+	});
+}
+
 /**
- * Counts the boxes on the canvas with every group collapsed, and warns when there are
- * more than the TOP_LEVEL_ITEM_CEILING ceiling. Sub-nodes and sticky notes don't count:
- * a sub-node rides with its parent, and a sticky belongs to the user.
+ * Warns when the collapsed canvas has more boxes than TOP_LEVEL_ITEM_CEILING. The
+ * count lives in n8n-workflow so the MCP tools report the same number.
  */
-export function topLevelItemsWarning(json: WorkflowJSON): ValidationWarning | undefined {
-	const groups = json.nodeGroups ?? [];
-	const groupedNodeIds = new Set(groups.flatMap((group) => group.nodeIds));
-	const subNodeNames = new Set(
-		Object.entries(json.connections ?? {}).flatMap(([nodeName, connectionsByType]) => {
-			const types = Object.keys(connectionsByType);
-			return types.length > 0 && types.every((type) => type !== 'main') ? [nodeName] : [];
-		}),
-	);
-
-	const ungrouped = (json.nodes ?? []).filter(
-		(node) =>
-			!groupedNodeIds.has(node.id) &&
-			node.type !== STICKY_NODE_TYPE &&
-			!(node.name !== undefined && subNodeNames.has(node.name)),
-	);
-
-	const total = groups.length + ungrouped.length;
-	if (total <= TOP_LEVEL_ITEM_CEILING) {
+export function topLevelItemsWarning(
+	json: WorkflowJSON,
+	summary: TopLevelItemsSummary = summarizeWorkflowTopLevelItems(json),
+): ValidationWarning | undefined {
+	if (!summary.overCeiling) {
 		return;
 	}
 
-	const groupable = ungrouped
-		.filter((node) => !isTriggerNodeType(node.type))
-		.map((node) => node.name ?? node.id);
+	return {
+		code: TOP_LEVEL_ITEMS_OVER_CEILING_CODE,
+		severity: 'informational',
+		message: formatTopLevelItemsMessage(summary),
+	};
+}
+
+/**
+ * The check that blocks a save: over the ceiling with no surviving group, the build
+ * is refused until the agent groups or states why it cannot. A group the save
+ * dropped does not count, and an opt-out never excuses a dropped group — the agent
+ * had already decided to group, so the boundary is what needs fixing.
+ */
+export function groupingDecisionBlocker(input: {
+	summary: TopLevelItemsSummary;
+	declaredGroupCount: number;
+	droppedGroupWarnings: ValidationWarning[];
+	groupingDecision?: GroupingDecision;
+}): ValidationWarning | undefined {
+	const { summary, declaredGroupCount, droppedGroupWarnings, groupingDecision } = input;
+	if (!summary.overCeiling || summary.groupCount > 0) {
+		return;
+	}
+
+	if (declaredGroupCount > 0) {
+		const reasons = droppedGroupWarnings.map((warning) => warning.message).join(' ');
+		return {
+			code: ALL_GROUPS_DROPPED_CODE,
+			severity: 'warning',
+			message:
+				`Every declared node group was removed, so the canvas would have ${summary.total} boxes and no group. ` +
+				`${reasons} Fix the boundary each message names and build again; do not remove the groups.`,
+		};
+	}
+
+	if (groupingDecision === 'not_warranted') {
+		return;
+	}
 
 	return {
-		code: TOP_LEVEL_ITEMS_CODE,
-		severity: 'informational',
+		code: GROUPING_DECISION_MISSING_CODE,
+		severity: 'warning',
 		message:
-			`The canvas top level has ${total} boxes with every group collapsed, over the ${TOP_LEVEL_ITEM_CEILING} you should aim for` +
-			(groupable.length > 0 ? `. Still ungrouped: ${groupable.join(', ')}` : '') +
-			'. Group any stage that can form a valid group and build again, or say why each of them cannot join one.',
+			`The canvas would have ${summary.total} boxes with every group collapsed and no node group. ` +
+			`Ungrouped: ${summary.groupableNodeNames.join(', ')}. ` +
+			'Wrap each stage in `.group(name, members, { description })` and build again. ' +
+			"If no valid group can hold these nodes, call build-workflow again with `groupingDecision: 'not_warranted'` " +
+			'and a `groupingReason` that says why.',
 	};
 }
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
@@ -84,10 +84,10 @@ export function topLevelItemsWarning(
 }
 
 /**
- * The check that blocks a save: over the ceiling with no surviving group, the build
- * is refused until the agent groups or states why it cannot. A group the save
- * dropped does not count, and an opt-out never excuses a dropped group — the agent
- * had already decided to group, so the boundary is what needs fixing.
+ * The check that blocks a save. Over the ceiling, a dropped group refuses the build
+ * until its boundary is fixed — the agent had already decided to group, and an opt-out
+ * never excuses that. A canvas with no group refuses it until the agent groups or
+ * states why it cannot.
  */
 export function groupingDecisionBlocker(input: {
 	summary: TopLevelItemsSummary;

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-validation-warnings.ts
@@ -14,7 +14,7 @@ import {
 
 export const NODE_GROUP_DROPPED_CODE = 'NODE_GROUP_DROPPED';
 export const GROUPING_DECISION_MISSING_CODE = 'GROUPING_DECISION_MISSING';
-export const ALL_GROUPS_DROPPED_CODE = 'ALL_GROUPS_DROPPED';
+export const GROUP_DROPPED_OVER_CEILING_CODE = 'GROUP_DROPPED_OVER_CEILING';
 
 export type GroupingDecision = 'grouped' | 'not_warranted';
 
@@ -96,19 +96,26 @@ export function groupingDecisionBlocker(input: {
 	groupingDecision?: GroupingDecision;
 }): ValidationWarning | undefined {
 	const { summary, declaredGroupCount, droppedGroupWarnings, groupingDecision } = input;
-	if (!summary.overCeiling || summary.groupCount > 0) {
+
+	if (!summary.overCeiling) {
 		return;
 	}
 
-	if (declaredGroupCount > 0) {
+	// Over the ceiling and the save dropped a group: the agent must repair it, not ship past it.
+	if (droppedGroupWarnings.length > 0) {
 		const reasons = droppedGroupWarnings.map((warning) => warning.message).join(' ');
 		return {
-			code: ALL_GROUPS_DROPPED_CODE,
+			code: GROUP_DROPPED_OVER_CEILING_CODE,
 			severity: 'warning',
 			message:
-				`Every declared node group was removed, so the canvas would have ${summary.total} boxes and no group. ` +
+				`${droppedGroupWarnings.length} of ${declaredGroupCount} declared node group(s) were removed, ` +
+				`so the canvas would have ${summary.total} boxes. ` +
 				`${reasons} Fix the boundary each message names and build again; do not remove the groups.`,
 		};
+	}
+
+	if (summary.groupCount > 0) {
+		return;
 	}
 
 	if (groupingDecision === 'not_warranted') {

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -334,6 +334,21 @@ export const waitGateScriptSchema = z.object({
 
 export type WaitGateScript = z.infer<typeof waitGateScriptSchema>;
 
+/**
+ * What the build did about node groups, on the saved (post-drop) shape. A NEW
+ * OPTIONAL FIELD for the same rollback reason as `executionIntent`.
+ */
+export const groupingOutcomeSchema = z.object({
+	topLevelItemCount: z.number().int().min(0),
+	ceiling: z.number().int().min(1),
+	groupCount: z.number().int().min(0),
+	droppedGroupCount: z.number().int().min(0),
+	decision: z.enum(['grouped', 'not_warranted', 'under_ceiling']),
+	reason: z.string().optional(),
+});
+
+export type GroupingOutcome = z.infer<typeof groupingOutcomeSchema>;
+
 export const workflowBuildOutcomeSchema = z.object({
 	workItemId: z.string(),
 	runId: z.string().optional(),
@@ -422,6 +437,8 @@ export const workflowBuildOutcomeSchema = z.object({
 	/** Deterministic setup handoff verdict for post-verification workflow setup. */
 	setupRequirement: workflowSetupRequirementSchema.optional(),
 	remediation: remediationMetadataSchema.optional(),
+	/** Node-group result of this build; absent on outcomes stored before the field existed. */
+	grouping: groupingOutcomeSchema.optional(),
 	/** Count of verify-built-workflow runs for this build; capped by MAX_VERIFY_ATTEMPTS. */
 	verifyAttempts: z.number().int().min(0).optional(),
 	/** Successful verification runs by trigger. A failed rerun removes that trigger's entry. */

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -343,7 +343,7 @@ export const groupingOutcomeSchema = z.object({
 	ceiling: z.number().int().min(1),
 	groupCount: z.number().int().min(0),
 	droppedGroupCount: z.number().int().min(0),
-	decision: z.enum(['grouped', 'not_warranted', 'under_ceiling']),
+	decision: z.enum(['grouped', 'not_warranted', 'under_ceiling', 'missing']),
 	reason: z.string().optional(),
 });
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -120,6 +120,13 @@ describe('NODE_GROUPS_REFERENCE', () => {
 		expect(NODE_GROUPS_REFERENCE).toMatch(/keep the .+ and their descriptions\s+intact/is);
 	});
 
+	it('names the two shapes that are cut wrong most often', () => {
+		// Case 8 (gates in a row) and case 3 (two-node stages) failed on every eval run
+		// while the abstract rule was present, so the guidance names the shape.
+		expect(GROUPING_GUIDANCE).toMatch(/first node of the next group, never loose/i);
+		expect(GROUPING_GUIDANCE).toMatch(/merge the small stage into its neighbour/i);
+	});
+
 	it('tells agents to fix what a dropped-group warning reports, not the boundary', () => {
 		// A build took two dropped-group warnings as licence to publish the stage
 		// ungrouped instead of fixing the group.

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -127,13 +127,13 @@ Every workflow needs an explicit grouping decision, taken while you write the co
 
 - **When:** count top-level items with no groups (trigger + every node or existing group). More than ${TOP_LEVEL_ITEM_CEILING} → you must group. A linear pipeline is the normal case for grouping, not an exemption: stages run in sequence (ingest → transform → deliver). ${TOP_LEVEL_ITEM_CEILING} or fewer serving one objective → leave it ungrouped.
 - **How many:** one per stage or high-level objective, typically 3-5, aiming for at most ${TOP_LEVEL_ITEM_CEILING} top-level items after grouping. Staying above ${TOP_LEVEL_ITEM_CEILING} is only acceptable when every item still at the top level is either a group already, or a node that cannot join one without breaking a validity rule — check each one before you settle. Never split one objective to hit the number. When in doubt, fewer and larger.
-- **What belongs together:** one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Cut where the objective changes; merge groups serving the same outcome. Stages of one or two nodes mean the boundaries are too fine — widen them.
+- **What belongs together:** one business outcome ("Fetch new recordings"), never a technical category ("HTTP requests", "Database operations"). Cut where the objective changes; merge groups serving the same outcome. Stages of one or two nodes mean the boundaries are too fine — widen them: merge the small stage into its neighbour rather than keeping three groups.
 - **Groups vs sub-workflows:** a group organises one canvas; a sub-workflow is separately executed and reusable. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
 
 **Boundaries:** a group takes one member receiving from outside and one member sending outside; any number of connections may reach those two members.
 
 - A branch that stops one way and continues the other: keep the branch node inside with both its paths outside, end the group before it, or leave it and its stop path outside.
-- Work that fans out into parallel branches: the node they fan out from and the node they reconverge on both belong inside, or every branch faces outward on its own.
+- Work that fans out into parallel branches: the node they fan out from and the node they reconverge on both belong inside, or every branch faces outward on its own. Several IF nodes in a row: each IF sits inside a stage; the node where their paths join is inside that stage or the first node of the next group, never loose.
 - When the node at either end cannot be a member — the trigger, or a node already in another group — the stage needs its own step there to serve as the single entry or exit. Use a step the stage already has; add a plain pass-through only when the stage would otherwise stay ungrouped.
 - A rejected group never closes the stage: try a smaller slice that is valid — one branch, or the linear run before or after the split — before leaving anything ungrouped.
 

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -17,7 +17,7 @@ import {
 	type IWorkflowGroup,
 	type NodeConnectionType,
 } from './interfaces';
-import { isTriggerNode } from './node-helpers';
+import { isTriggerNode, isTriggerNodeType } from './node-helpers';
 
 type NodeIo = NodeConnectionType | INodeInputConfiguration | INodeOutputConfiguration;
 type IODirection = 'inputs' | 'outputs';
@@ -39,6 +39,92 @@ export function normalizeGroupDescription(description: unknown): string | undefi
 	if (typeof description !== 'string') return undefined;
 	const capped = description.slice(0, GROUP_DESCRIPTION_MAX_LENGTH);
 	return capped.length > 0 ? capped : undefined;
+}
+
+/** Issue code shared by every surface that reports the collapsed box count. */
+export const TOP_LEVEL_ITEMS_OVER_CEILING_CODE = 'TOP_LEVEL_ITEMS_OVER_CEILING';
+
+export type TopLevelItemsSummary = {
+	/** Boxes on the canvas with every group collapsed: groups plus ungrouped nodes. */
+	total: number;
+	groupCount: number;
+	ceiling: number;
+	overCeiling: boolean;
+	/** Ungrouped nodes that draw a box, the trigger included. */
+	ungroupedNodeNames: string[];
+	/** Ungrouped nodes a group could still hold; a trigger cannot join one. */
+	groupableNodeNames: string[];
+};
+
+type TopLevelItemsNode = Pick<INode, 'type'> & { id?: string; name?: string };
+
+/**
+ * Names of the nodes that reach their parent over non-main connections only. A
+ * sub-node rides with its parent on the canvas, so it is not a box of its own.
+ */
+export function collectSubNodeNames(
+	connectionsBySourceNode: IConnections | undefined,
+): Set<string> {
+	const subNodeNames = new Set<string>();
+
+	for (const [nodeName, connectionsByType] of Object.entries(connectionsBySourceNode ?? {})) {
+		const types = Object.keys(connectionsByType);
+		if (types.length > 0 && types.every((type) => type !== NodeConnectionTypes.Main)) {
+			subNodeNames.add(nodeName);
+		}
+	}
+
+	return subNodeNames;
+}
+
+/**
+ * Counts the boxes a reader sees with every group collapsed. Sticky notes and
+ * sub-nodes do not count: a sticky belongs to the user, a sub-node rides with its
+ * parent. Shared by the Instance AI build and the MCP save tools so both report
+ * the same number the grouping guidance states.
+ */
+export function summarizeTopLevelItems(input: {
+	nodes: TopLevelItemsNode[];
+	nodeGroups?: Array<Pick<IWorkflowGroup, 'nodeIds'>>;
+	connectionsBySourceNode?: IConnections;
+}): TopLevelItemsSummary {
+	const groups = input.nodeGroups ?? [];
+	const groupedNodeIds = new Set(groups.flatMap((group) => group.nodeIds));
+	const subNodeNames = collectSubNodeNames(input.connectionsBySourceNode);
+
+	const ungrouped = input.nodes.filter((node) => {
+		const isSticky = node.type === STICKY_NODE_TYPE;
+		const isGrouped = node.id !== undefined && groupedNodeIds.has(node.id);
+		const isSubNode = node.name !== undefined && subNodeNames.has(node.name);
+
+		return !isSticky && !isGrouped && !isSubNode;
+	});
+
+	const labelOf = (node: TopLevelItemsNode) => node.name ?? node.id ?? node.type;
+	const total = groups.length + ungrouped.length;
+
+	return {
+		total,
+		groupCount: groups.length,
+		ceiling: TOP_LEVEL_ITEM_CEILING,
+		overCeiling: total > TOP_LEVEL_ITEM_CEILING,
+		ungroupedNodeNames: ungrouped.map(labelOf),
+		groupableNodeNames: ungrouped.filter((node) => !isTriggerNodeType(node.type)).map(labelOf),
+	};
+}
+
+/** The over-ceiling message, worded once so every surface tells the agent the same thing. */
+export function formatTopLevelItemsMessage(summary: TopLevelItemsSummary): string {
+	const stillUngrouped =
+		summary.groupableNodeNames.length > 0
+			? `. Still ungrouped: ${summary.groupableNodeNames.join(', ')}`
+			: '';
+
+	return (
+		`The canvas top level has ${summary.total} boxes with every group collapsed, over the ${summary.ceiling} you should aim for` +
+		stillUngrouped +
+		'. Group any stage that can form a valid group and build again, or say why each of them cannot join one.'
+	);
 }
 
 export type NodeGroupingValidationInput<TNode extends INode = INode> = {

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -68,8 +68,15 @@ export function collectSubNodeNames(
 	const subNodeNames = new Set<string>();
 
 	for (const [nodeName, connectionsByType] of Object.entries(connectionsBySourceNode ?? {})) {
-		const types = Object.keys(connectionsByType);
-		if (types.length > 0 && types.every((type) => type !== NodeConnectionTypes.Main)) {
+		// An empty slot (`ai_tool: [[]]`) is not a connection, so it must not make a sub-node.
+		const connectedTypes = Object.entries(connectionsByType)
+			.filter(([, outputs]) => outputs.some((targets) => (targets?.length ?? 0) > 0))
+			.map(([type]) => type);
+
+		if (
+			connectedTypes.length > 0 &&
+			connectedTypes.every((type) => type !== NodeConnectionTypes.Main)
+		) {
 			subNodeNames.add(nodeName);
 		}
 	}

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -1226,4 +1226,14 @@ describe('collectSubNodeNames', () => {
 		expect([...collectSubNodeNames(connections)]).toEqual(['Model']);
 		expect(collectSubNodeNames(undefined).size).toBe(0);
 	});
+
+	it('does not treat a node with only empty non-main slots as a sub-node', () => {
+		const connections: IConnections = {
+			'Loose Tool': { ai_tool: [[]] },
+			'Wired Tool': { ai_tool: [[{ node: 'Agent', type: 'ai_tool', index: 0 }]] },
+			Agent: { main: [[]], ai_tool: [[{ node: 'Other Agent', type: 'ai_tool', index: 0 }]] },
+		};
+
+		expect([...collectSubNodeNames(connections)].sort()).toEqual(['Agent', 'Wired Tool']);
+	});
 });

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -1,8 +1,12 @@
 import {
+	collectSubNodeNames,
 	dropInvalidWorkflowGroups,
+	formatTopLevelItemsMessage,
 	GROUP_DESCRIPTION_MAX_LENGTH,
 	makeGetNodeTypeForGrouping,
 	normalizeGroupDescription,
+	summarizeTopLevelItems,
+	TOP_LEVEL_ITEM_CEILING,
 	validateNodeSelectionForExtraction,
 	validateNodeSelectionForGrouping,
 	validateWorkflowGroups,
@@ -1115,5 +1119,111 @@ describe('dropInvalidWorkflowGroups', () => {
 			).toEqual([]);
 			expect(workflow.nodeGroups).toHaveLength(2);
 		});
+	});
+});
+
+describe('summarizeTopLevelItems', () => {
+	const plainNodes = (count: number) =>
+		Array.from({ length: count }, (_, i) => makeNode({ id: `n${i}`, name: `N${i}` }));
+
+	it('stays under the ceiling with exactly TOP_LEVEL_ITEM_CEILING boxes', () => {
+		const summary = summarizeTopLevelItems({ nodes: plainNodes(TOP_LEVEL_ITEM_CEILING) });
+
+		expect(summary.total).toBe(TOP_LEVEL_ITEM_CEILING);
+		expect(summary.overCeiling).toBe(false);
+	});
+
+	it('counts the trigger as a box but leaves it out of the groupable list', () => {
+		const nodes = [
+			makeNode({ id: 't', name: 'When chat message received', type: 'n8n-nodes-base.chatTrigger' }),
+			...plainNodes(TOP_LEVEL_ITEM_CEILING),
+		];
+
+		const summary = summarizeTopLevelItems({ nodes });
+
+		expect(summary.total).toBe(TOP_LEVEL_ITEM_CEILING + 1);
+		expect(summary.overCeiling).toBe(true);
+		expect(summary.ungroupedNodeNames).toContain('When chat message received');
+		expect(summary.groupableNodeNames).not.toContain('When chat message received');
+		expect(summary.groupableNodeNames).toHaveLength(TOP_LEVEL_ITEM_CEILING);
+	});
+
+	it('counts a group as one box and its members as none', () => {
+		const summary = summarizeTopLevelItems({
+			nodes: plainNodes(8),
+			nodeGroups: [{ nodeIds: ['n0', 'n1', 'n2'] }],
+		});
+
+		// 1 group + 5 ungrouped nodes.
+		expect(summary.total).toBe(6);
+		expect(summary.groupCount).toBe(1);
+		expect(summary.groupableNodeNames).toEqual(['N3', 'N4', 'N5', 'N6', 'N7']);
+	});
+
+	it('counts an agent and its sub-nodes as one box', () => {
+		const connections: IConnections = {
+			Model: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+			Memory: { ai_memory: [[{ node: 'Agent', type: 'ai_memory', index: 0 }]] },
+			Tool: { ai_tool: [[{ node: 'Agent', type: 'ai_tool', index: 0 }]] },
+			Agent: { main: [[{ node: 'N0', type: NodeConnectionTypes.Main, index: 0 }]] },
+		};
+		const nodes = [
+			makeNode({ id: 'agent', name: 'Agent' }),
+			makeNode({ id: 'model', name: 'Model' }),
+			makeNode({ id: 'memory', name: 'Memory' }),
+			makeNode({ id: 'tool', name: 'Tool' }),
+			...plainNodes(6),
+		];
+
+		const summary = summarizeTopLevelItems({ nodes, connectionsBySourceNode: connections });
+
+		// Agent + 6 plain nodes; the three sub-nodes do not count.
+		expect(summary.total).toBe(7);
+		expect(summary.overCeiling).toBe(false);
+	});
+
+	it('does not count sticky notes', () => {
+		const summary = summarizeTopLevelItems({
+			nodes: [...plainNodes(TOP_LEVEL_ITEM_CEILING), makeStickyNode()],
+		});
+
+		expect(summary.total).toBe(TOP_LEVEL_ITEM_CEILING);
+	});
+
+	it('treats a node without an id as ungrouped', () => {
+		const nodes = [
+			{ type: 'n8n-nodes-base.set', name: 'Anonymous' },
+			...plainNodes(TOP_LEVEL_ITEM_CEILING),
+		];
+
+		const summary = summarizeTopLevelItems({ nodes, nodeGroups: [{ nodeIds: ['n0'] }] });
+
+		expect(summary.total).toBe(TOP_LEVEL_ITEM_CEILING + 1);
+		expect(summary.groupableNodeNames).toContain('Anonymous');
+	});
+
+	it('lists the groupable nodes in the message and leaves the trigger out', () => {
+		const nodes = [
+			makeNode({ id: 't', name: 'Start', type: 'n8n-nodes-base.manualTrigger' }),
+			...plainNodes(TOP_LEVEL_ITEM_CEILING),
+		];
+
+		const message = formatTopLevelItemsMessage(summarizeTopLevelItems({ nodes }));
+
+		expect(message).toContain(`${TOP_LEVEL_ITEM_CEILING + 1} boxes`);
+		expect(message).toContain('Still ungrouped: N0, N1');
+		expect(message).not.toContain('Start');
+	});
+});
+
+describe('collectSubNodeNames', () => {
+	it('keeps a node with a main output out of the sub-node set', () => {
+		const connections: IConnections = {
+			Model: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+			Agent: { main: [[{ node: 'Next', type: NodeConnectionTypes.Main, index: 0 }]] },
+		};
+
+		expect([...collectSubNodeNames(connections)]).toEqual(['Model']);
+		expect(collectSubNodeNames(undefined).size).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

Two changes on top of #37729.

**Guidance text.** `GROUPING_GUIDANCE` gets two clauses. One says to merge a small stage into its neighbour instead of keeping three groups. One says that when several IF nodes follow each other, the node where their paths join sits inside the stage or starts the next group, never loose.

**A blocking check in `build-workflow`.** The check runs after the save drops invalid groups. When the canvas has more than 7 top-level boxes and no group survived, the build is refused with `GROUPING_DECISION_MISSING`. The agent must add groups, or pass `groupingDecision: 'not_warranted'` with a `groupingReason`. When the agent declared groups, the save dropped any of them, and the canvas is still over 7 boxes, the build is refused with `GROUP_DROPPED_OVER_CEILING`. The opt-out does not bypass this case. The check applies to new workflows, to workflows this thread created, and to edits that push a workflow over the ceiling. An edit to an existing wide user workflow keeps the informational warning. The counting logic moves to `n8n-workflow` (`summarizeTopLevelItems`) so the SDK and Instance AI share it. The build result and the `instance_ai_workflow_source_build` telemetry event gain the group count, the top-level item count and the grouping decision.

## How to test

1. Run n8n with `N8N_INSTANCE_AI_SANDBOX_LINK_SDK=1`.
2. Ask the AI Assistant to build a workflow with 9 or more nodes and no groups in the prompt.
3. Check the saved workflow has groups. Check the transcript shows a `GROUPING_DECISION_MISSING` refusal when the first draft had no groups.
4. Unit tests: `pnpm test` in `packages/workflow`, `packages/@n8n/workflow-sdk` and `packages/@n8n/instance-ai`.

Eval run on this branch (suite `node-groups`, 5 cases, 3 iterations): https://github.com/n8n-io/n8n/actions/runs/34359344771 — 137/150 expectations, 15/15 builds saved, every workflow over 7 boxes has groups. The check fired in 5 of 15 runs; in each one the agent added groups and built again.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5802

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


