### PR TITLE
feat(core): Add observability for the decryption path

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -100,6 +100,10 @@ export class PrometheusMetricsConfig {
 	@Env('N8N_METRICS_INCLUDE_SSRF_METRICS')
 	includeSsrfMetrics: boolean = false;
 
+	/** Whether to include metrics for decryption and key-lookup latency. */
+	@Env('N8N_METRICS_INCLUDE_ENCRYPTION_METRICS')
+	includeEncryptionMetrics: boolean = false;
+
 	/** Whether to include metrics for the DNS cache (currently only used by SSRF protection). */
 	@Env('N8N_METRICS_INCLUDE_DNS_CACHE_METRICS')
 	includeDnsCacheMetrics: boolean = false;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -272,6 +272,7 @@ describe('GlobalConfig', () => {
 				workflowStatisticsInterval: 300,
 				includeExecutionDataMetrics: false,
 				includeSsrfMetrics: false,
+				includeEncryptionMetrics: false,
 				includeDnsCacheMetrics: false,
 				includeWebhookMetrics: false,
 				includeFormMetrics: false,

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -10,6 +10,7 @@ import type { PrometheusCacheMetricsService } from '../prometheus/cache-metrics.
 import type { PrometheusDbPoolMetricsService } from '../prometheus/db-pool-metrics.service';
 import type { PrometheusDefaultMetricsService } from '../prometheus/default-metrics.service';
 import type { PrometheusDnsCacheMetricsService } from '../prometheus/dns-cache-metrics.service';
+import type { PrometheusEncryptionMetricsService } from '../prometheus/encryption-metrics.service';
 import type { PrometheusEventBusMetricsService } from '../prometheus/event-bus-metrics.service';
 import type { PrometheusExecutionDataMetricsService } from '../prometheus/execution-data-metrics.service';
 import type { PrometheusInstanceAiMetricsService } from '../prometheus/instance-ai-metrics.service';
@@ -50,6 +51,7 @@ describe('PrometheusMetricsService', () => {
 	let tokenExchange: Mocked<PrometheusTokenExchangeMetricsService>;
 	let ssrf: Mocked<PrometheusSsrfMetricsService>;
 	let dnsCache: Mocked<PrometheusDnsCacheMetricsService>;
+	let encryption: Mocked<PrometheusEncryptionMetricsService>;
 	let webhook: Mocked<PrometheusWebhookAndFormMetricsService>;
 	let workflowInfo: Mocked<PrometheusWorkflowInfoMetricsService>;
 	let instanceAi: Mocked<PrometheusInstanceAiMetricsService>;
@@ -85,6 +87,7 @@ describe('PrometheusMetricsService', () => {
 			workflowPublication,
 			scheduler,
 			pollTrigger,
+			encryption,
 		);
 
 	beforeEach(() => {
@@ -120,6 +123,7 @@ describe('PrometheusMetricsService', () => {
 		workflowPublication = mock<PrometheusWorkflowPublicationMetricsService>({ enabled: true });
 		scheduler = mock<PrometheusSchedulerMetricsService>({ enabled: true });
 		pollTrigger = mock<PrometheusPollTriggerMetricsService>({ enabled: true });
+		encryption = mock<PrometheusEncryptionMetricsService>({ enabled: true });
 
 		service = buildService();
 	});
@@ -154,6 +158,7 @@ describe('PrometheusMetricsService', () => {
 			expect(workflowPublication.init).toHaveBeenCalledWith(app);
 			expect(scheduler.init).toHaveBeenCalledWith(app);
 			expect(pollTrigger.init).toHaveBeenCalledWith(app);
+			expect(encryption.init).toHaveBeenCalledWith(app);
 		});
 
 		it('should NOT call init on disabled collectors', () => {

--- a/packages/cli/src/metrics/prometheus/__tests__/encryption-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/encryption-metrics.service.test.ts
@@ -1,0 +1,111 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PrometheusMetricsConfig } from '@n8n/config';
+import type { Cipher } from 'n8n-core';
+import promClient from 'prom-client';
+import type { Mock } from 'vitest';
+
+import { PrometheusEncryptionMetricsService } from '../encryption-metrics.service';
+
+vi.mock('prom-client');
+
+describe('PrometheusEncryptionMetricsService', () => {
+	const config = mockInstance(PrometheusMetricsConfig, {
+		prefix: 'n8n_',
+		includeEncryptionMetrics: true,
+	});
+
+	const cipherEvents = { on: vi.fn() };
+	const cipher = { events: cipherEvents } as unknown as Cipher;
+
+	let service: PrometheusEncryptionMetricsService;
+	let mockHistogramObserve: Mock;
+
+	beforeEach(() => {
+		Object.assign(config, { prefix: 'n8n_', includeEncryptionMetrics: true });
+		service = new PrometheusEncryptionMetricsService(cipher, config);
+		mockHistogramObserve = vi.fn();
+		promClient.Histogram.prototype.observe = mockHistogramObserve;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function getEventsHandler(eventName: string) {
+		const calls = cipherEvents.on.mock.calls as Array<[string, (...args: unknown[]) => void]>;
+		return calls.find((c) => c[0] === eventName)?.[1];
+	}
+
+	describe('enabled', () => {
+		it('should reflect includeEncryptionMetrics', () => {
+			config.includeEncryptionMetrics = true;
+			expect(service.enabled).toBe(true);
+
+			config.includeEncryptionMetrics = false;
+			expect(service.enabled).toBe(false);
+		});
+	});
+
+	describe('init', () => {
+		it('should create the decrypt duration histogram with an algorithm label', () => {
+			service.init();
+
+			expect(promClient.Histogram).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'n8n_encryption_decrypt_duration_seconds',
+					help: 'Duration of a full decryptV2 operation (key lookup and decryption) in seconds.',
+					labelNames: ['algorithm'],
+				}),
+			);
+		});
+
+		it('should create the key-lookup duration histogram with a source label', () => {
+			service.init();
+
+			expect(promClient.Histogram).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'n8n_encryption_key_lookup_duration_seconds',
+					help: 'Duration of encryption key lookups in seconds.',
+					labelNames: ['source'],
+				}),
+			);
+		});
+
+		it('should apply a custom prefix to metric names', () => {
+			config.prefix = 'myapp_';
+			service.init();
+
+			expect(promClient.Histogram).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_encryption_decrypt_duration_seconds' }),
+			);
+			expect(promClient.Histogram).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_encryption_key_lookup_duration_seconds' }),
+			);
+		});
+
+		it('should register listeners for decrypt and key-lookup', () => {
+			service.init();
+
+			expect(cipherEvents.on).toHaveBeenCalledWith('decrypt', expect.any(Function));
+			expect(cipherEvents.on).toHaveBeenCalledWith('key-lookup', expect.any(Function));
+		});
+
+		it('should observe the decrypt histogram with duration converted to seconds', () => {
+			service.init();
+			const handler = getEventsHandler('decrypt')!;
+
+			handler({ algorithm: 'aes-256-gcm', durationMs: 250 });
+
+			expect(mockHistogramObserve).toHaveBeenCalledWith({ algorithm: 'aes-256-gcm' }, 0.25);
+		});
+
+		it('should observe the key-lookup histogram with duration converted to seconds', () => {
+			service.init();
+			const handler = getEventsHandler('key-lookup')!;
+
+			handler({ source: 'prefixed', durationMs: 100 });
+
+			expect(mockHistogramObserve).toHaveBeenCalledWith({ source: 'prefixed' }, 0.1);
+		});
+	});
+});

--- a/packages/cli/src/metrics/prometheus/encryption-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/encryption-metrics.service.ts
@@ -1,0 +1,49 @@
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import { Cipher } from 'n8n-core';
+import promClient from 'prom-client';
+
+import type { PrometheusMetricsCollector } from './base';
+import { DURATION_BUCKETS_SECONDS } from './constant';
+
+/**
+ * Tracks decrypt and key-lookup latency on the read path as histograms.
+ * Registers:
+ * - `n8n_encryption_decrypt_duration_seconds`
+ * - `n8n_encryption_key_lookup_duration_seconds`
+ */
+@Service()
+export class PrometheusEncryptionMetricsService implements PrometheusMetricsCollector {
+	constructor(
+		private readonly cipher: Cipher,
+		private readonly config: PrometheusMetricsConfig,
+	) {}
+
+	get enabled(): boolean {
+		return this.config.includeEncryptionMetrics;
+	}
+
+	init() {
+		const decryptHistogram = new promClient.Histogram({
+			name: `${this.config.prefix}encryption_decrypt_duration_seconds`,
+			help: 'Duration of a full decryptV2 operation (key lookup and decryption) in seconds.',
+			labelNames: ['algorithm'],
+			buckets: DURATION_BUCKETS_SECONDS,
+		});
+
+		const keyLookupHistogram = new promClient.Histogram({
+			name: `${this.config.prefix}encryption_key_lookup_duration_seconds`,
+			help: 'Duration of encryption key lookups in seconds.',
+			labelNames: ['source'],
+			buckets: DURATION_BUCKETS_SECONDS,
+		});
+
+		this.cipher.events.on('decrypt', ({ algorithm, durationMs }) => {
+			decryptHistogram.observe({ algorithm }, durationMs / 1000);
+		});
+
+		this.cipher.events.on('key-lookup', ({ source, durationMs }) => {
+			keyLookupHistogram.observe({ source }, durationMs / 1000);
+		});
+	}
+}

--- a/packages/cli/src/metrics/prometheus/prometheus.service.ts
+++ b/packages/cli/src/metrics/prometheus/prometheus.service.ts
@@ -9,6 +9,7 @@ import { PrometheusCacheMetricsService } from './cache-metrics.service';
 import { PrometheusDbPoolMetricsService } from './db-pool-metrics.service';
 import { PrometheusDefaultMetricsService } from './default-metrics.service';
 import { PrometheusDnsCacheMetricsService } from './dns-cache-metrics.service';
+import { PrometheusEncryptionMetricsService } from './encryption-metrics.service';
 import { PrometheusEventBusMetricsService } from './event-bus-metrics.service';
 import { PrometheusExecutionDataMetricsService } from './execution-data-metrics.service';
 import { PrometheusInstanceAiMetricsService } from './instance-ai-metrics.service';
@@ -57,6 +58,7 @@ export class PrometheusMetricsService {
 		workflowPublication: PrometheusWorkflowPublicationMetricsService,
 		scheduler: PrometheusSchedulerMetricsService,
 		pollTrigger: PrometheusPollTriggerMetricsService,
+		encryption: PrometheusEncryptionMetricsService,
 	) {
 		this.logger = logger.scoped('metrics');
 		this.collectors = [
@@ -82,6 +84,7 @@ export class PrometheusMetricsService {
 			workflowPublication,
 			scheduler,
 			pollTrigger,
+			encryption,
 		];
 	}
 

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -437,6 +437,46 @@ describe('Cipher', () => {
 				});
 				expect(emitSpy).not.toHaveBeenCalledWith('decrypt', expect.anything());
 			});
+
+			it('should not let a throwing metrics listener break a successful decrypt', async () => {
+				const keyId = 'test-uuid-listener';
+				const encryptedDataKey = cipher.encryptDEKWithInstanceKey(plaintextDataKey);
+				const ciphertext = cipher.encryptWithKey('safe', plaintextDataKey, 'aes-256-gcm');
+				withProvider({
+					getKeyById: async (id: string) =>
+						id === keyId
+							? { id, value: encryptedDataKey, algorithm: 'aes-256-gcm', format: 'prefixed' }
+							: null,
+				});
+				const boom = () => {
+					throw new Error('listener boom');
+				};
+				cipher.events.on('decrypt', boom);
+
+				try {
+					await expect(cipher.decryptV2(`${keyId}:${ciphertext}`)).resolves.toEqual('safe');
+				} finally {
+					cipher.events.off('decrypt', boom);
+				}
+			});
+
+			it('should preserve the original error when a metrics listener throws', async () => {
+				withProvider({
+					getKeyById: async () => {
+						throw new Error('provider down');
+					},
+				});
+				const boom = () => {
+					throw new Error('listener boom');
+				};
+				cipher.events.on('key-lookup', boom);
+
+				try {
+					await expect(cipher.decryptV2('some-id:abc')).rejects.toThrow('provider down');
+				} finally {
+					cipher.events.off('key-lookup', boom);
+				}
+			});
 		});
 	});
 });

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -341,5 +341,66 @@ describe('Cipher', () => {
 				'Encryption key provider is not configured',
 			);
 		});
+
+		describe('latency events', () => {
+			it('should emit key-lookup (prefixed) and decrypt events for prefixed data', async () => {
+				const keyId = 'test-uuid-9012';
+				const encryptedDataKey = cipher.encryptDEKWithInstanceKey(plaintextDataKey);
+				const ciphertext = cipher.encryptWithKey('metric', plaintextDataKey, 'aes-256-gcm');
+				withProvider({
+					getKeyById: async (id: string) =>
+						id === keyId
+							? { id, value: encryptedDataKey, algorithm: 'aes-256-gcm', format: 'prefixed' }
+							: null,
+				});
+				const emitSpy = vi.spyOn(cipher.events, 'emit');
+
+				await cipher.decryptV2(`${keyId}:${ciphertext}`);
+
+				expect(emitSpy).toHaveBeenCalledWith('key-lookup', {
+					source: 'prefixed',
+					durationMs: expect.any(Number),
+				});
+				expect(emitSpy).toHaveBeenCalledWith('decrypt', {
+					algorithm: 'aes-256-gcm',
+					durationMs: expect.any(Number),
+				});
+			});
+
+			it('should emit key-lookup (legacy) and decrypt events for unprefixed data', async () => {
+				withProvider({
+					getKeyById: vi.fn(),
+					getLegacyKey: async () => ({
+						id: 'legacy',
+						value: cipher.encryptDEKWithInstanceKey(instanceKey),
+						algorithm: 'aes-256-cbc',
+						format: 'no-prefix',
+					}),
+				});
+				const legacyCiphertext = cipher.encryptWithKey('legacy-metric', instanceKey, 'aes-256-cbc');
+				const emitSpy = vi.spyOn(cipher.events, 'emit');
+
+				await cipher.decryptV2(legacyCiphertext);
+
+				expect(emitSpy).toHaveBeenCalledWith('key-lookup', {
+					source: 'legacy',
+					durationMs: expect.any(Number),
+				});
+				expect(emitSpy).toHaveBeenCalledWith('decrypt', {
+					algorithm: 'aes-256-cbc',
+					durationMs: expect.any(Number),
+				});
+			});
+
+			it('should not emit events when customEncryptionKey is provided', async () => {
+				withProvider({ getActiveKey: vi.fn() });
+				const encrypted = await cipher.encryptV2('bypass', 'custom-key');
+				const emitSpy = vi.spyOn(cipher.events, 'emit');
+
+				await cipher.decryptV2(encrypted, 'custom-key');
+
+				expect(emitSpy).not.toHaveBeenCalled();
+			});
+		});
 	});
 });

--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -401,6 +401,42 @@ describe('Cipher', () => {
 
 				expect(emitSpy).not.toHaveBeenCalled();
 			});
+
+			it('should emit the decrypt event even when decryption fails', async () => {
+				const keyId = 'test-uuid-fail';
+				const encryptedDataKey = cipher.encryptDEKWithInstanceKey(plaintextDataKey);
+				withProvider({
+					getKeyById: async (id: string) =>
+						id === keyId
+							? { id, value: encryptedDataKey, algorithm: 'aes-256-gcm', format: 'prefixed' }
+							: null,
+				});
+				const emitSpy = vi.spyOn(cipher.events, 'emit');
+
+				await expect(cipher.decryptV2(`${keyId}:not-valid-ciphertext`)).rejects.toThrow();
+
+				expect(emitSpy).toHaveBeenCalledWith('decrypt', {
+					algorithm: 'aes-256-gcm',
+					durationMs: expect.any(Number),
+				});
+			});
+
+			it('should emit the key-lookup event even when the provider rejects', async () => {
+				withProvider({
+					getKeyById: async () => {
+						throw new Error('provider down');
+					},
+				});
+				const emitSpy = vi.spyOn(cipher.events, 'emit');
+
+				await expect(cipher.decryptV2('some-id:abc')).rejects.toThrow('provider down');
+
+				expect(emitSpy).toHaveBeenCalledWith('key-lookup', {
+					source: 'prefixed',
+					durationMs: expect.any(Number),
+				});
+				expect(emitSpy).not.toHaveBeenCalledWith('decrypt', expect.anything());
+			});
 		});
 	});
 });

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -143,7 +143,7 @@ export class Cipher {
 			return this.decryptWithKey(ciphertext, plaintextKey, algorithm);
 		} finally {
 			// Emit even on failure so the metric also captures slow or failing decryptions.
-			this.events.emit('decrypt', { algorithm, durationMs: performance.now() - start });
+			this.emitMetric('decrypt', { algorithm, durationMs: performance.now() - start });
 		}
 	}
 
@@ -157,7 +157,22 @@ export class Cipher {
 			return await lookup();
 		} finally {
 			// Emit even on failure so the metric also captures slow or failing lookups.
-			this.events.emit('key-lookup', { source, durationMs: performance.now() - start });
+			this.emitMetric('key-lookup', { source, durationMs: performance.now() - start });
+		}
+	}
+
+	/**
+	 * Best-effort metrics emit. A misbehaving listener must never break or mask a
+	 * decrypt, so listener errors are swallowed.
+	 */
+	private emitMetric<E extends keyof CipherMetricsEventMap>(
+		event: E,
+		payload: CipherMetricsEventMap[E],
+	): void {
+		try {
+			this.events.emit(event, payload);
+		} catch {
+			// Telemetry is best-effort; ignore listener failures.
 		}
 	}
 

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -1,3 +1,4 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { createHash } from 'crypto';
 import { UnexpectedError } from 'n8n-workflow';
@@ -18,8 +19,17 @@ import { CipherAlgorithm } from './interface';
  */
 const KEY_ID_PATTERN = /^[A-Za-z0-9_-]{1,36}$/;
 
+/** Latency signals emitted by the read path for observability. */
+export type CipherMetricsEventMap = {
+	decrypt: { algorithm: CipherAlgorithm; durationMs: number };
+	'key-lookup': { source: 'prefixed' | 'legacy'; durationMs: number };
+};
+
 @Service()
 export class Cipher {
+	/** Latency events for the decrypt path. A cli-side collector turns these into metrics. */
+	readonly events = new TypedEmitter<CipherMetricsEventMap>();
+
 	/**
 	 * No-prefix descriptors whose key material was already verified to unwrap
 	 * to the instance key. The module memoizes its descriptor, so verifying
@@ -101,6 +111,9 @@ export class Cipher {
 			return this.decryptWithKey(data, customEncryptionKey, 'aes-256-cbc');
 		}
 
+		// Decrypt latency covers the whole read: key lookup, DEK unwrap, and the AES step.
+		const start = performance.now();
+
 		let keyInfo: KeyInfo | null = null;
 		let ciphertext = data;
 
@@ -109,17 +122,37 @@ export class Cipher {
 			const keyId = data.slice(0, colonIdx);
 			if (KEY_ID_PATTERN.test(keyId)) {
 				ciphertext = data.slice(colonIdx + 1);
-				keyInfo = await this.encryptionKeyProxy.getKeyById(keyId);
+				keyInfo = await this.lookupKey(
+					'prefixed',
+					async () => await this.encryptionKeyProxy.getKeyById(keyId),
+				);
 				if (!keyInfo) throw new UnexpectedError(`Encryption key not found: ${keyId}`);
 			}
 		} else {
-			keyInfo = await this.encryptionKeyProxy.getLegacyKey();
+			keyInfo = await this.lookupKey(
+				'legacy',
+				async () => await this.encryptionKeyProxy.getLegacyKey(),
+			);
 		}
 
 		if (!keyInfo) throw new UnexpectedError('Encryption key not found!');
 
+		const algorithm = keyInfo.algorithm as CipherAlgorithm;
 		const plaintextKey = this.decryptDEKWithInstanceKey(keyInfo.value);
-		return this.decryptWithKey(ciphertext, plaintextKey, keyInfo.algorithm as CipherAlgorithm);
+		const plaintext = this.decryptWithKey(ciphertext, plaintextKey, algorithm);
+		this.events.emit('decrypt', { algorithm, durationMs: performance.now() - start });
+		return plaintext;
+	}
+
+	/** Times a key lookup and emits its latency before returning the descriptor. */
+	private async lookupKey(
+		source: 'prefixed' | 'legacy',
+		lookup: () => Promise<KeyInfo | null>,
+	): Promise<KeyInfo | null> {
+		const start = performance.now();
+		const keyInfo = await lookup();
+		this.events.emit('key-lookup', { source, durationMs: performance.now() - start });
+		return keyInfo;
 	}
 
 	/**

--- a/packages/core/src/encryption/cipher.ts
+++ b/packages/core/src/encryption/cipher.ts
@@ -138,21 +138,27 @@ export class Cipher {
 		if (!keyInfo) throw new UnexpectedError('Encryption key not found!');
 
 		const algorithm = keyInfo.algorithm as CipherAlgorithm;
-		const plaintextKey = this.decryptDEKWithInstanceKey(keyInfo.value);
-		const plaintext = this.decryptWithKey(ciphertext, plaintextKey, algorithm);
-		this.events.emit('decrypt', { algorithm, durationMs: performance.now() - start });
-		return plaintext;
+		try {
+			const plaintextKey = this.decryptDEKWithInstanceKey(keyInfo.value);
+			return this.decryptWithKey(ciphertext, plaintextKey, algorithm);
+		} finally {
+			// Emit even on failure so the metric also captures slow or failing decryptions.
+			this.events.emit('decrypt', { algorithm, durationMs: performance.now() - start });
+		}
 	}
 
-	/** Times a key lookup and emits its latency before returning the descriptor. */
+	/** Times a key lookup and emits its latency, whether the lookup succeeds or fails. */
 	private async lookupKey(
 		source: 'prefixed' | 'legacy',
 		lookup: () => Promise<KeyInfo | null>,
 	): Promise<KeyInfo | null> {
 		const start = performance.now();
-		const keyInfo = await lookup();
-		this.events.emit('key-lookup', { source, durationMs: performance.now() - start });
-		return keyInfo;
+		try {
+			return await lookup();
+		} finally {
+			// Emit even on failure so the metric also captures slow or failing lookups.
+			this.events.emit('key-lookup', { source, durationMs: performance.now() - start });
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR adds two Prometheus histograms for the decrypt read path:

- `n8n_encryption_decrypt_duration_seconds` — the full `decryptV2` operation (key lookup, DEK unwrap, and the AES step), labelled by `algorithm`.
- `n8n_encryption_key_lookup_duration_seconds` — the key-lookup sub-step, labelled by `source` (`prefixed` or `legacy`).

Both are opt-in behind a new flag and appear on the existing `/metrics` endpoint.

### Why

This is part of the Encryption Key Rotation V2 project (milestone "Release A — Read-support"). Read-support routes every decryption through the real key-lookup path. These metrics let us watch the health and latency of that path before the product depends on it. A histogram exposes `_sum` and `_count`, so `rate(sum) / rate(count)` gives the average latency the ticket asks for. The `decrypt` histogram is the full read latency; subtract `key-lookup` to get the crypto-only time.

### How to test manually

Prerequisites: build the repo, then start n8n with metrics on:

```
N8N_METRICS=true N8N_METRICS_INCLUDE_ENCRYPTION_METRICS=true pnpm dev:be
```

1. Open or create a credential in the UI, or run a workflow that uses a credential. This calls `decryptV2`.
2. Read the metrics endpoint:

```
curl -s localhost:5678/metrics | grep encryption_
```

3. Confirm `n8n_encryption_decrypt_duration_seconds_*` and `n8n_encryption_key_lookup_duration_seconds_*` appear with a non-zero `_count`.

Edge cases:

- Data written before key rotation (no key-id prefix) yields `source="legacy"`.
- Data written by the rotation write path (a `keyId:` prefix) yields `source="prefixed"`.
- With the include flag off (the default), the two `encryption_*` metrics must not appear.

Automated coverage: `cipher.test.ts` (the emitted events and their labels), `encryption-metrics.service.test.ts` (the collector), and `prometheus-metrics.service.test.ts` (collector registration).

### Key implementation decisions

- `Cipher` (in `packages/core`) exposes a `TypedEmitter` and emits latency events. A cli-side collector subscribes and records the histograms. `packages/core` must not import the cli metrics stack, so the event bridge crosses the package boundary the same way the SSRF metrics do.
- The `decrypt` histogram times the whole `decryptV2` body, not just the AES call, so it equals the read latency a caller sees. The `key-lookup` histogram is a nested sub-span.
- The key-lookup histogram has no cache-hit label. `Cipher` cannot see whether the key manager served from cache or the database. The duration distribution already separates the two.
- Only `decryptV2` is instrumented. The deprecated `decrypt()` and the custom-key short-circuit stay untouched.


## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-1287

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

