### PR TITLE
feat(API): Let @Body require a body independently of DTO field optionality

### DIFF
--- a/packages/@n8n/decorators/src/controller/args.ts
+++ b/packages/@n8n/decorators/src/controller/args.ts
@@ -15,22 +15,10 @@ const ArgDecorator =
 	};
 
 export interface BodyOptions {
-	/**
-	 * Public API only. Rejects a request with no body/JSON content-type even when every field on
-	 * the DTO is optional (which otherwise makes the body itself optional too). Mirrors the
-	 * independent `requestBody.required` an OpenAPI spec can declare regardless of its schema's
-	 * own property-level `required`.
-	 */
 	required?: boolean;
 }
 
-/**
- * Injects the request body into the handler. Supports both a bare `@Body payload: SomeDto` and a
- * factory form `@Body({ required: true }) payload: SomeDto` for cases where the DTO alone can't
- * express the right default (see `BodyOptions`). The two are told apart by arity: the runtime
- * always calls a parameter decorator with `(target, propertyKey, parameterIndex)` - 3 arguments -
- * so a call missing `parameterIndex` is the factory being invoked by user code instead.
- */
+/** Injects the request body into the handler */
 export function Body(
 	target: object,
 	propertyKey: string | symbol | undefined,
@@ -41,7 +29,8 @@ export function Body(
 	targetOrOptions?: object | BodyOptions,
 	propertyKey?: string | symbol,
 	parameterIndex?: number,
-) {
+): ParameterDecorator | void {
+	// Bare form e.g. `@Body body: MyDto`
 	if (parameterIndex !== undefined) {
 		return ArgDecorator({ type: 'body' })(
 			targetOrOptions as object,
@@ -50,6 +39,7 @@ export function Body(
 		);
 	}
 
+	// Factory form e.g. `@Body() body: MyDto` or `@Body({ required: true }) body: MyDto`
 	const options = targetOrOptions as BodyOptions | undefined;
 	return ArgDecorator({
 		type: 'body',

--- a/packages/@n8n/decorators/src/controller/args.ts
+++ b/packages/@n8n/decorators/src/controller/args.ts
@@ -14,8 +14,48 @@ const ArgDecorator =
 		routeMetadata.args[parameterIndex] = arg;
 	};
 
-/** Injects the request body into the handler */
-export const Body = ArgDecorator({ type: 'body' });
+export interface BodyOptions {
+	/**
+	 * Public API only. Rejects a request with no body/JSON content-type even when every field on
+	 * the DTO is optional (which otherwise makes the body itself optional too). Mirrors the
+	 * independent `requestBody.required` an OpenAPI spec can declare regardless of its schema's
+	 * own property-level `required`.
+	 */
+	required?: boolean;
+}
+
+/**
+ * Injects the request body into the handler. Supports both a bare `@Body payload: SomeDto` and a
+ * factory form `@Body({ required: true }) payload: SomeDto` for cases where the DTO alone can't
+ * express the right default (see `BodyOptions`). The two are told apart by arity: the runtime
+ * always calls a parameter decorator with `(target, propertyKey, parameterIndex)` - 3 arguments -
+ * so a call missing `parameterIndex` is the factory being invoked by user code instead.
+ */
+export function Body(
+	target: object,
+	propertyKey: string | symbol | undefined,
+	parameterIndex: number,
+): void;
+export function Body(options?: BodyOptions): ParameterDecorator;
+export function Body(
+	targetOrOptions?: object | BodyOptions,
+	propertyKey?: string | symbol,
+	parameterIndex?: number,
+) {
+	if (parameterIndex !== undefined) {
+		return ArgDecorator({ type: 'body' })(
+			targetOrOptions as object,
+			propertyKey as string | symbol,
+			parameterIndex,
+		);
+	}
+
+	const options = targetOrOptions as BodyOptions | undefined;
+	return ArgDecorator({
+		type: 'body',
+		...(options?.required !== undefined && { required: options.required }),
+	});
+}
 
 /** Injects the request query into the handler */
 export const Query = ArgDecorator({ type: 'query' });

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -24,7 +24,10 @@ export interface ErrorResponse {
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options';
 
-export type Arg = { type: 'body' | 'query' } | { type: 'param'; key: string; schema?: ZodTypeAny };
+export type Arg =
+	| { type: 'body'; required?: boolean }
+	| { type: 'query' }
+	| { type: 'param'; key: string; schema?: ZodTypeAny };
 
 export interface CorsOptions {
 	allowedOrigins: string[];

--- a/packages/cli/src/public-api/__tests__/public-api-controller.registry.test.ts
+++ b/packages/cli/src/public-api/__tests__/public-api-controller.registry.test.ts
@@ -244,6 +244,22 @@ describe('PublicApiControllerRegistry', () => {
 			markPublicApiController(WidgetsPublicController as Controller, '/widgets');
 		}
 
+		function registerRequiredOptionalBodyRoute() {
+			@Service()
+			class WidgetsPublicController {
+				@Post('/')
+				@ApiResponse(200)
+				method(
+					_req: unknown,
+					_res: unknown,
+					@Body({ required: true }) body: OptionalWidgetBodyDto,
+				) {
+					return body;
+				}
+			}
+			markPublicApiController(WidgetsPublicController as Controller, '/widgets');
+		}
+
 		it('accepts application/json', async () => {
 			registerBodyRoute();
 
@@ -323,6 +339,27 @@ describe('PublicApiControllerRegistry', () => {
 			const response = await postWithContentType(header).expect(415);
 
 			expect(response.body.message).toBe('unsupported media type undefined');
+		});
+
+		it.each(namesNoMediaType)(
+			'rejects %s when @Body({ required: true }) overrides an otherwise-optional DTO',
+			async (_label, header) => {
+				registerRequiredOptionalBodyRoute();
+
+				const response = await postWithContentType(header).expect(415);
+
+				expect(response.body.message).toBe('unsupported media type undefined');
+			},
+		);
+
+		it('accepts application/json with an empty object when @Body({ required: true }) is set', async () => {
+			registerRequiredOptionalBodyRoute();
+
+			await request(activate())
+				.post('/api/v1/widgets')
+				.set('Content-Type', 'application/json')
+				.send({})
+				.expect(200);
 		});
 
 		it('accepts application/json carrying an unrelated parameter', async () => {

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -14,9 +14,9 @@ import { EventService } from '@/events/event.service';
 import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import { assertJsonContentType } from '@/public-api/public-api-media-type';
-import type { ResolvedRouteArg } from '@/public-api/public-api-route-resolver';
 import {
 	apiKeyScopesSatisfy,
+	findBodyArg,
 	isRequestBodyRequired,
 	resolveRouteArgs,
 	resolveSuccessStatus,
@@ -80,9 +80,7 @@ export class PublicApiControllerRegistry {
 				route.successStatus,
 			);
 
-			const bodyArg = resolvedArgs.find(
-				(arg): arg is Extract<ResolvedRouteArg, { type: 'body' }> => arg.type === 'body',
-			);
+			const bodyArg = findBodyArg(resolvedArgs);
 			const bodyDto = bodyArg?.dto;
 			const bodyRequired = bodyDto ? (bodyArg?.required ?? isRequestBodyRequired(bodyDto)) : false;
 

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -14,9 +14,9 @@ import { EventService } from '@/events/event.service';
 import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import { assertJsonContentType } from '@/public-api/public-api-media-type';
+import type { ResolvedRouteArg } from '@/public-api/public-api-route-resolver';
 import {
 	apiKeyScopesSatisfy,
-	isDtoArg,
 	isRequestBodyRequired,
 	resolveRouteArgs,
 	resolveSuccessStatus,
@@ -80,8 +80,11 @@ export class PublicApiControllerRegistry {
 				route.successStatus,
 			);
 
-			const bodyDto = resolvedArgs.find((arg) => isDtoArg(arg, 'body'))?.dto;
-			const bodyRequired = bodyDto ? isRequestBodyRequired(bodyDto) : false;
+			const bodyArg = resolvedArgs.find(
+				(arg): arg is Extract<ResolvedRouteArg, { type: 'body' }> => arg.type === 'body',
+			);
+			const bodyDto = bodyArg?.dto;
+			const bodyRequired = bodyDto ? (bodyArg?.required ?? isRequestBodyRequired(bodyDto)) : false;
 
 			const handler = async (req: Request, res: Response) => {
 				if (bodyDto) assertJsonContentType(req.headers['content-type'], bodyRequired);

--- a/packages/cli/src/public-api/public-api-route-resolver.ts
+++ b/packages/cli/src/public-api/public-api-route-resolver.ts
@@ -40,6 +40,14 @@ export function isDtoArg(
 	return arg.type === type;
 }
 
+export function findBodyArg(
+	args: ResolvedRouteArg[],
+): Extract<ResolvedRouteArg, { type: 'body' }> | undefined {
+	return args.find(
+		(arg): arg is Extract<ResolvedRouteArg, { type: 'body' }> => arg.type === 'body',
+	);
+}
+
 export interface ResolvedPublicApiRoute {
 	controllerClass: Controller;
 	controllerName: string;
@@ -240,9 +248,7 @@ export function resolvePublicApiRoutes(): ResolvedPublicApiRoute[] {
 
 		for (const [handlerName, route] of controllerMetadata.routes) {
 			const args = resolveRouteArgs(controllerClass, handlerName, route.args);
-			const requestBodyArg = args.find(
-				(arg): arg is Extract<ResolvedRouteArg, { type: 'body' }> => arg.type === 'body',
-			);
+			const requestBodyArg = findBodyArg(args);
 			const requestBodyDto = requestBodyArg?.dto;
 			const requestBodyRequired = requestBodyArg?.required;
 			const requestQueryDto = args.find((arg) => isDtoArg(arg, 'query'))?.dto;

--- a/packages/cli/src/public-api/public-api-route-resolver.ts
+++ b/packages/cli/src/public-api/public-api-route-resolver.ts
@@ -30,7 +30,8 @@ export type HttpMethod = (typeof HTTP_METHODS)[number];
 
 export type ResolvedRouteArg =
 	| { type: 'param'; key: string; schema?: ZodTypeAny }
-	| { type: 'body' | 'query'; dto: ZodClass };
+	| { type: 'body'; dto: ZodClass; required?: boolean }
+	| { type: 'query'; dto: ZodClass };
 
 export function isDtoArg(
 	arg: ResolvedRouteArg,
@@ -48,6 +49,8 @@ export interface ResolvedPublicApiRoute {
 	path: string;
 	args: ResolvedRouteArg[];
 	requestBodyDto?: ZodClass;
+	/** Explicit `@Body({ required })` override; falls back to `isRequestBodyRequired` when unset. */
+	requestBodyRequired?: boolean;
 	requestQueryDto?: ZodClass;
 	responseDto?: ResponseDtoClass;
 	/** Success status declared via `@ApiResponse` - always present, see `resolveSuccessStatus`. */
@@ -111,7 +114,16 @@ export function resolveRouteArgs(
 			);
 		}
 
-		resolved.push({ type: arg.type, dto: paramType });
+		if (arg.type === 'body') {
+			resolved.push({
+				type: 'body',
+				dto: paramType,
+				...(arg.required !== undefined && { required: arg.required }),
+			});
+			continue;
+		}
+
+		resolved.push({ type: 'query', dto: paramType });
 	}
 
 	return resolved;
@@ -228,7 +240,11 @@ export function resolvePublicApiRoutes(): ResolvedPublicApiRoute[] {
 
 		for (const [handlerName, route] of controllerMetadata.routes) {
 			const args = resolveRouteArgs(controllerClass, handlerName, route.args);
-			const requestBodyDto = args.find((arg) => isDtoArg(arg, 'body'))?.dto;
+			const requestBodyArg = args.find(
+				(arg): arg is Extract<ResolvedRouteArg, { type: 'body' }> => arg.type === 'body',
+			);
+			const requestBodyDto = requestBodyArg?.dto;
+			const requestBodyRequired = requestBodyArg?.required;
 			const requestQueryDto = args.find((arg) => isDtoArg(arg, 'query'))?.dto;
 
 			const joined = `${prefix}${route.path}`.replace(/\/+/g, '/');
@@ -242,6 +258,7 @@ export function resolvePublicApiRoutes(): ResolvedPublicApiRoute[] {
 				path,
 				args,
 				requestBodyDto,
+				requestBodyRequired,
 				requestQueryDto,
 				responseDto: route.responseDto,
 				successStatus: resolveSuccessStatus(controllerClass.name, handlerName, route.successStatus),

--- a/packages/cli/src/public-api/v1/openapi-gen/decorator-routes.ts
+++ b/packages/cli/src/public-api/v1/openapi-gen/decorator-routes.ts
@@ -158,8 +158,10 @@ function buildRequestBody(
 ): NonNullable<RouteConfig['request']>['body'] {
 	if (!route.requestBodyDto) return undefined;
 
+	const required = route.requestBodyRequired ?? isRequestBodyRequired(route.requestBodyDto);
+
 	return {
-		...(isRequestBodyRequired(route.requestBodyDto) ? { required: true } : {}),
+		...(required ? { required: true } : {}),
 		content: {
 			'application/json': {
 				schema: route.requestBodyDto.schema,


### PR DESCRIPTION
## Summary

- The legacy EOV validator let a route declare `requestBody.required: true` independently of its schema's own property-level `required`, so a DTO where every field is optional could still require *some* body/JSON content-type. The decorator-based `@Body` had no equivalent — requiredness was derived purely from `!dto.safeParse({}).success`.
- `@Body` now accepts an options form, `@Body({ required: true })`, to override that inference. Both request-time enforcement (`PublicApiControllerRegistry`) and the generated OpenAPI spec (`buildRequestBody` in `decorator-routes.ts`) respect the override.
- Every existing bare `@Body payload: X` usage (internal `@RestController`s and public API controllers) is unaffected; the two call shapes are discriminated at runtime, not by a breaking signature change.

Found while migrating `POST /source-control/pull` to the decorator pattern (API-226, #38186): `PullWorkFolderRequestDto`'s fields are all optional, so the migrated route silently accepted a fully bodyless request where the old EOV-validated spec (`requestBody.required: true`) returned 415. That endpoint-specific change is intentionally **not** included here since `pull` isn't migrated on `master` yet — this PR is the standalone framework fix. `api-226` will pick this up once merged and apply `@Body({ required: true })` there.

Linear: https://linear.app/n8n/issue/API-297/body-cant-express-body-required-independently-of-dto-field-optionality

Loom: https://www.loom.com/share/eb10790e5553486482bf59687910b056

## Test plan

- [x] `public-api-controller.registry.test.ts` — 28/28, including 3 new cases covering the `{ required: true }` override (rejects no-Content-Type/no-body, still accepts `{}`)
- [x] Full `openapi-gen` suite — 206/206, including the generated-spec drift check, confirming no other endpoint's spec is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

