### PR TITLE
fix(ai-builder): Enhance guidance UX for agents with no sessions on builder session tab

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1453,6 +1453,7 @@
 	"agentSessions.langsmithExport.error": "Session couldn't be sent to LangSmith. Try again.",
 	"agentSessions.actions": "Actions",
 	"agentSessions.empty": "No agent sessions",
+	"agentSessions.emptyDescription": "Sessions will appear here after you preview your agent.",
 	"agentSessions.emptyWithFilters": "No sessions match these filters",
 	"agentSessions.filters.status": "Status",
 	"agentSessions.filters.anyStatus": "Any status",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSessionsListView.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSessionsListView.spec.ts
@@ -52,6 +52,8 @@ vi.mock('@n8n/i18n', () => ({
 					'agentSessions.origin.schedule': 'Schedule',
 					'agentSessions.origin.workflow': 'Workflow',
 					'agentSessions.empty': 'No agent sessions',
+					'agentSessions.emptyDescription':
+						'Sessions will appear here after you preview your agent.',
 					'agentSessions.emptyWithFilters': 'No sessions match these filters',
 					'agentSessions.status.running': 'Running',
 					'agentSessions.status.succeeded': 'Succeeded',
@@ -297,6 +299,17 @@ describe('AgentSessionsListView', () => {
 		});
 	});
 
+	it('shows guidance in the empty state when there are no sessions', async () => {
+		const wrapper = await mountView({
+			threads: [],
+		});
+
+		expect(wrapper.get('[data-test-id="agent-sessions-empty"]').text()).toBe('No agent sessions');
+		expect(wrapper.get('[data-test-id="agent-sessions-empty-description"]').text()).toBe(
+			'Sessions will appear here after you preview your agent.',
+		);
+	});
+
 	it('shows the filtered empty state when no sessions match', async () => {
 		const wrapper = await mountView({
 			threads: [],
@@ -306,6 +319,7 @@ describe('AgentSessionsListView', () => {
 		expect(wrapper.get('[data-test-id="agent-sessions-empty"]').text()).toBe(
 			'No sessions match these filters',
 		);
+		expect(wrapper.find('[data-test-id="agent-sessions-empty-description"]').exists()).toBe(false);
 	});
 
 	it('opens the parent trace in the current tab by default', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionsListView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionsListView.vue
@@ -346,13 +346,22 @@ async function onFiltersChange(value: AgentSessionFilters) {
 					>
 						<td :colspan="5" style="text-align: center; padding: var(--spacing--lg)">
 							<template v-if="!sessionsStore.threads.length && !sessionsStore.loading">
-								<span data-test-id="agent-sessions-empty">
-									{{
-										i18n.baseText(
-											hasActiveFilters ? 'agentSessions.emptyWithFilters' : 'agentSessions.empty',
-										)
-									}}
-								</span>
+								<div :class="$style.emptyState">
+									<span data-test-id="agent-sessions-empty">
+										{{
+											i18n.baseText(
+												hasActiveFilters ? 'agentSessions.emptyWithFilters' : 'agentSessions.empty',
+											)
+										}}
+									</span>
+									<span
+										v-if="!hasActiveFilters"
+										:class="$style.emptyStateDescription"
+										data-test-id="agent-sessions-empty-description"
+									>
+										{{ i18n.baseText('agentSessions.emptyDescription') }}
+									</span>
+								</div>
 							</template>
 						</td>
 					</tr>
@@ -576,5 +585,19 @@ async function onFiltersChange(value: AgentSessionFilters) {
 	&:hover {
 		background-color: transparent;
 	}
+}
+
+.emptyState {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--spacing--4xs);
+	text-align: center;
+}
+
+.emptyStateDescription {
+	max-width: 100%;
+	color: var(--text-color--subtler);
+	white-space: normal;
 }
 </style>


### PR DESCRIPTION
## Summary

Sessions empty state now explains what fills it: "Sessions will appear here after you preview your agent," instead of a bare "No agent sessions" with no next step. Names the actual action ("preview your agent") to match the Preview agent button

Snap: 
<img width="724" height="647" alt="image" src="https://github.com/user-attachments/assets/2c21e2e7-007a-4a7c-bcb0-343bf202cf3d" />

## How to test
1. Create an agent
2. Go to Sessions tab
3. See the new label is there below the "No agent sessions".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-768/explain-what-fills-the-sessions-empty-state


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

