### PR TITLE
fix(Microsoft Excel Node): Show only workbook files in the Workbook picker

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/methods/listSearch.test.ts
@@ -1,0 +1,140 @@
+import type { ILoadOptionsFunctions, INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+import type { MockedFunction } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { searchWorkbooks } from '../../../v2/methods/listSearch';
+import { getExcelCredentialType, microsoftApiRequest } from '../../../v2/transport';
+
+vi.mock('../../../v2/transport', () => ({
+	microsoftApiRequest: vi.fn(),
+	getExcelCredentialType: vi.fn(),
+}));
+
+const WORKBOOK = { id: 'wb1', name: 'Budget.xlsx', webUrl: 'https://c/wb1', file: {} };
+const MACRO_WORKBOOK = { id: 'wb2', name: 'Q4.XLSM', webUrl: 'https://c/wb2', file: {} };
+const DOUBLE_EXTENSION = {
+	id: 'wb3',
+	name: 'Report.xlsx.backup.xlsx',
+	webUrl: 'https://c/wb3',
+	file: {},
+};
+const SHORTCUT = { id: 'url1', name: 'SPBook.xlsx.url', webUrl: 'https://c/url1', file: {} };
+const FOLDER = {
+	id: 'f1',
+	name: 'Archive.xlsx',
+	webUrl: 'https://c/f1',
+	folder: { childCount: 2 },
+};
+
+const DEFAULT_QUERY = "/drive/root/search(q='.xlsx OR .xlsm')";
+const DEFAULT_QS = { select: 'id,name,webUrl,file', $top: 100 };
+
+describe('Microsoft Excel V2 - listSearch', () => {
+	let ctx: ILoadOptionsFunctions;
+	const apiRequest = microsoftApiRequest as MockedFunction<typeof microsoftApiRequest>;
+	const credentialType = getExcelCredentialType as MockedFunction<typeof getExcelCredentialType>;
+
+	beforeEach(() => {
+		apiRequest.mockReset();
+		credentialType.mockReset();
+		credentialType.mockReturnValue('microsoftOAuth2Api');
+		ctx = mock<ILoadOptionsFunctions>({
+			getNode: vi.fn(() => mock<INode>({ typeVersion: 2 })),
+		});
+	});
+
+	describe('searchWorkbooks', () => {
+		it('lists only workbook files when no search text is given', async () => {
+			apiRequest.mockResolvedValue({ value: [WORKBOOK, SHORTCUT, FOLDER] });
+
+			const result = await searchWorkbooks.call(ctx);
+
+			expect(apiRequest).toHaveBeenCalledWith(
+				'GET',
+				DEFAULT_QUERY,
+				undefined,
+				DEFAULT_QS,
+				undefined,
+				undefined,
+				0,
+			);
+			expect(result).toEqual({
+				results: [{ name: 'Budget', value: 'wb1', url: 'https://c/wb1' }],
+				paginationToken: undefined,
+			});
+		});
+
+		it('applies the same workbook check to a user search, ignoring case', async () => {
+			apiRequest.mockResolvedValue({ value: [MACRO_WORKBOOK, SHORTCUT] });
+
+			const result = await searchWorkbooks.call(ctx, 'q4');
+
+			expect(apiRequest).toHaveBeenCalledWith(
+				'GET',
+				"/drive/root/search(q='q4')",
+				undefined,
+				DEFAULT_QS,
+				undefined,
+				undefined,
+				0,
+			);
+			expect(result.results).toEqual([{ name: 'Q4', value: 'wb2', url: 'https://c/wb2' }]);
+		});
+
+		it('treats a blank search as no search text', async () => {
+			apiRequest.mockResolvedValue({ value: [WORKBOOK] });
+
+			await searchWorkbooks.call(ctx, '   ');
+
+			expect(apiRequest).toHaveBeenCalledWith(
+				'GET',
+				DEFAULT_QUERY,
+				undefined,
+				DEFAULT_QS,
+				undefined,
+				undefined,
+				0,
+			);
+		});
+
+		it('strips only the trailing extension from the display name', async () => {
+			apiRequest.mockResolvedValue({ value: [DOUBLE_EXTENSION] });
+
+			const result = await searchWorkbooks.call(ctx);
+
+			expect(result.results).toEqual([
+				{ name: 'Report.xlsx.backup', value: 'wb3', url: 'https://c/wb3' },
+			]);
+		});
+
+		it('follows the pagination token and filters that page too', async () => {
+			const token = 'https://graph.microsoft.com/v1.0/me/drive/root/search?$skiptoken=abc';
+			const nextLink = 'https://graph.microsoft.com/v1.0/me/drive/root/search?$skiptoken=def';
+			apiRequest.mockResolvedValue({ value: [SHORTCUT, WORKBOOK], '@odata.nextLink': nextLink });
+
+			const result = await searchWorkbooks.call(ctx, undefined, token);
+
+			expect(apiRequest).toHaveBeenCalledWith('GET', '', undefined, undefined, token, undefined, 0);
+			expect(result).toEqual({
+				results: [{ name: 'Budget', value: 'wb1', url: 'https://c/wb1' }],
+				paginationToken: nextLink,
+			});
+		});
+
+		it('returns no results when the response has no value collection', async () => {
+			apiRequest.mockResolvedValue({});
+
+			const result = await searchWorkbooks.call(ctx);
+
+			expect(result.results).toEqual([]);
+		});
+
+		it('rejects search with the Service Principal credential', async () => {
+			credentialType.mockReturnValue('microsoftEntraServicePrincipalApi');
+
+			await expect(searchWorkbooks.call(ctx)).rejects.toThrow(NodeOperationError);
+			expect(apiRequest).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/methods/listSearch.ts
@@ -11,6 +11,26 @@ import { getExcelCredentialType, microsoftApiRequest } from '../transport';
 // listSearch context throughout this file: the transport's trailing `0` is its
 // fallback read (getNodeParameter's 2nd arg here is a fallback, not an item index).
 
+const WORKBOOK_EXTENSIONS = ['.xlsx', '.xlsm'];
+
+type DriveItem = {
+	id?: string;
+	name?: string;
+	webUrl?: string;
+	file?: IDataObject;
+};
+
+type DriveSearchResponse = {
+	value?: DriveItem[];
+	'@odata.nextLink'?: string;
+};
+
+function workbookExtension(item: DriveItem): string | undefined {
+	if (item.file === undefined) return undefined;
+	const name = (item.name ?? '').toLowerCase();
+	return WORKBOOK_EXTENSIONS.find((extension) => name.endsWith(extension));
+}
+
 export async function searchWorkbooks(
 	this: ILoadOptionsFunctions,
 	filter?: string,
@@ -27,61 +47,49 @@ export async function searchWorkbooks(
 			},
 		);
 	}
-	const fileExtensions = ['.xlsx', '.xlsm', '.xlst'];
-	const extensionFilter = fileExtensions.join(' OR ');
+	const trimmed = filter?.trim() ?? '';
+	const q = trimmed === '' ? WORKBOOK_EXTENSIONS.join(' OR ') : trimmed;
 
-	const q = filter || extensionFilter;
+	const response: DriveSearchResponse = paginationToken
+		? await microsoftApiRequest.call(
+				this,
+				'GET',
+				'',
+				undefined,
+				undefined,
+				paginationToken, // paginationToken contains the full URL
+				undefined,
+				0,
+			)
+		: await microsoftApiRequest.call(
+				this,
+				'GET',
+				`/drive/root/search(q='${q}')`,
+				undefined,
+				{
+					select: 'id,name,webUrl,file',
+					$top: 100,
+				},
+				undefined,
+				undefined,
+				0,
+			);
 
-	let response: IDataObject = {};
-
-	if (paginationToken) {
-		response = await microsoftApiRequest.call(
-			this,
-			'GET',
-			'',
-			undefined,
-			undefined,
-			paginationToken, // paginationToken contains the full URL
-			undefined,
-			0,
-		);
-	} else {
-		response = await microsoftApiRequest.call(
-			this,
-			'GET',
-			`/drive/root/search(q='${q}')`,
-			undefined,
-			{
-				select: 'id,name,webUrl',
-				$top: 100,
-			},
-			undefined,
-			undefined,
-			0,
-		);
-	}
-
-	if (response.value && filter) {
-		response.value = (response.value as IDataObject[]).filter((workbook: IDataObject) => {
-			return fileExtensions.some((extension) => (workbook.name as string).includes(extension));
+	const results: INodeListSearchItems[] = [];
+	for (const item of response.value ?? []) {
+		const extension = workbookExtension(item);
+		if (extension === undefined) continue;
+		const name = item.name ?? '';
+		results.push({
+			name: name.slice(0, -extension.length),
+			value: item.id ?? '',
+			url: item.webUrl,
 		});
 	}
 
 	return {
-		results: (response.value as IDataObject[]).map((workbook: IDataObject) => {
-			for (const extension of fileExtensions) {
-				if ((workbook.name as string).includes(extension)) {
-					workbook.name = (workbook.name as string).replace(extension, '');
-					break;
-				}
-			}
-			return {
-				name: workbook.name as string,
-				value: workbook.id as string,
-				url: workbook.webUrl as string,
-			};
-		}),
-		paginationToken: response['@odata.nextLink'] as string | undefined,
+		results,
+		paginationToken: response['@odata.nextLink'],
 	};
 }
 


### PR DESCRIPTION
## Summary

The Workbook picker in the Microsoft Excel (OneDrive) node matched file extensions with `includes()`. A OneDrive shortcut such as `SPBook.xlsx.url` contains `.xlsx`, so it passed the check and appeared in the dropdown as a workbook. Every operation on it then failed with a 403 that the UI rendered as "Forbidden - perhaps check your credentials?", which sent users to Azure permissions for a problem that was never about credentials. This is the path that produced the ENT-416 escalation.

The check also ran only when the user had typed search text. The default listing, which is the repro path, was never filtered at all.

This PR makes the picker offer only files it can open:

- An item is kept only when it is a file (the `file` facet is present) and its lowercased name ends with `.xlsx` or `.xlsm`. Shortcuts and folders named like workbooks are dropped.
- The check now runs on the default listing too, not only on a typed search.
- The display name strips only the trailing extension. `Report.xlsx.backup.xlsx` shows as `Report.xlsx.backup` instead of `Report.backup.xlsx`.
- The extension list drops `.xlst`, which is not an Excel format, and now matches the Microsoft Excel (SharePoint) node. The request selects the `file` facet the same way that node already does.
- A blank or whitespace-only search falls back to the default listing.

Out of scope on purpose:

- Workbook > Get Many uses the same unfiltered search and is left alone. Filtering it would shrink execution output for existing workflows.
- The search query string is unchanged. Apostrophe handling in the OData literal stays with ENT-400.

## How to test

Unit tests:

```
cd packages/nodes-base && pnpm test nodes/Microsoft/Excel/test/v2/methods/listSearch.test.ts
```

Manual check against a real tenant:

1. Put a workbook, for example `SPBook.xlsx`, in a SharePoint document library.
2. In the SharePoint web UI, use "Add shortcut to OneDrive" on that file. This creates `SPBook.xlsx.url` in your personal OneDrive.
3. Add a Microsoft Excel (OneDrive) node with a Microsoft OAuth2 credential. Set Resource to Workbook and Operation to Add Sheet.
4. Open the Workbook field in From List mode, with and without search text.

Before: the shortcut appears as a selectable workbook and the operation fails with a 403. After: the shortcut is not listed. Real `.xlsx` and `.xlsm` files are listed with the extension removed from the display name.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-448

Related: #20040 (same 403 signature, already closed), https://linear.app/n8n/issue/ENT-416

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

