### PR TITLE
feat: Allow browser recordings without prior connection

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -104,6 +104,7 @@ export {
 	browserRecordingSchema,
 	browserRecordingScreenshotSchema,
 	browserRecordingTargetSchema,
+	InstanceAiBrowserRecordingRequest,
 	MAX_BROWSER_RECORDING_SCREENSHOT_BASE64_BYTES,
 	MAX_BROWSER_RECORDING_NETWORK_REQUESTS,
 	MAX_BROWSER_RECORDING_SCREENSHOTS,
@@ -117,6 +118,7 @@ export type {
 	BrowserRecordingNetworkRequest,
 	BrowserRecordingScreenshot,
 	BrowserRecordingTarget,
+	InstanceAiBrowserRecordingResponse,
 } from './schemas/browser-recording.schema';
 
 export type {

--- a/packages/@n8n/api-types/src/schemas/browser-recording.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/browser-recording.schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { Z } from '../zod-class';
+
 export const browserRecordingTargetSchema = z
 	.object({
 		tag: z.string().min(1).max(30),
@@ -124,6 +126,14 @@ export const browserRecordingSchema = z
 			});
 		}
 	});
+
+export class InstanceAiBrowserRecordingRequest extends Z.class({
+	recording: browserRecordingSchema,
+}) {}
+
+export interface InstanceAiBrowserRecordingResponse {
+	threadId: string;
+}
 
 export type BrowserRecordingTarget = z.infer<typeof browserRecordingTargetSchema>;
 export type BrowserRecordingAction = z.infer<typeof browserRecordingActionSchema>;

--- a/packages/@n8n/mcp-browser-extension/src/approvedHosts.ts
+++ b/packages/@n8n/mcp-browser-extension/src/approvedHosts.ts
@@ -7,6 +7,20 @@
 import { getRelayHostKey } from './relayAllowlist';
 
 const APPROVED_HOSTS_KEY = 'approvedRelayHosts';
+const APPROVED_ORIGINS_KEY = 'approvedInstanceOrigins';
+
+function getPageOrigin(relayUrl: string | null | undefined): string | null {
+	if (!relayUrl) return null;
+	try {
+		const url = new URL(relayUrl);
+		if (url.protocol === 'wss:') url.protocol = 'https:';
+		else if (url.protocol === 'ws:') url.protocol = 'http:';
+		else return null;
+		return url.origin;
+	} catch {
+		return null;
+	}
+}
 
 export async function listApprovedHosts(): Promise<string[]> {
 	const stored = await chrome.storage.local.get(APPROVED_HOSTS_KEY);
@@ -21,13 +35,32 @@ export async function isHostApproved(relayUrl: string | null | undefined): Promi
 	return (await listApprovedHosts()).includes(host);
 }
 
+export async function listApprovedOrigins(): Promise<string[]> {
+	const stored = await chrome.storage.local.get(APPROVED_ORIGINS_KEY);
+	const value: unknown = stored[APPROVED_ORIGINS_KEY];
+	if (Array.isArray(value))
+		return value.filter((entry): entry is string => typeof entry === 'string');
+
+	return (await listApprovedHosts()).map((host) => {
+		const isLocal = /^(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/.test(host);
+		return `${isLocal ? 'http' : 'https'}://${host}`;
+	});
+}
+
 /** Returns the resulting list, so callers refresh their view without a second read. */
 export async function rememberHost(relayUrl: string | null | undefined): Promise<string[]> {
 	const host = getRelayHostKey(relayUrl);
 	const hosts = await listApprovedHosts();
-	if (!host || hosts.includes(host)) return hosts;
-	const next = [...hosts, host];
-	await chrome.storage.local.set({ [APPROVED_HOSTS_KEY]: next });
+	if (!host) return hosts;
+	const next = hosts.includes(host) ? hosts : [...hosts, host];
+	const origin = getPageOrigin(relayUrl);
+	const origins = await listApprovedOrigins();
+	await chrome.storage.local.set({
+		[APPROVED_HOSTS_KEY]: next,
+		...(origin && !origins.includes(origin)
+			? { [APPROVED_ORIGINS_KEY]: [...origins, origin] }
+			: {}),
+	});
 	return next;
 }
 
@@ -35,6 +68,16 @@ export async function forgetApprovedHost(host: string): Promise<string[]> {
 	const hosts = await listApprovedHosts();
 	if (!hosts.includes(host)) return hosts;
 	const next = hosts.filter((entry) => entry !== host);
-	await chrome.storage.local.set({ [APPROVED_HOSTS_KEY]: next });
+	const origins = (await listApprovedOrigins()).filter((origin) => {
+		try {
+			return new URL(origin).host !== host;
+		} catch {
+			return false;
+		}
+	});
+	await chrome.storage.local.set({
+		[APPROVED_HOSTS_KEY]: next,
+		[APPROVED_ORIGINS_KEY]: origins,
+	});
 	return next;
 }

--- a/packages/@n8n/mcp-browser-extension/src/background.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.ts
@@ -485,12 +485,14 @@ function getRecordingData(current: BrowserRecording) {
 }
 
 async function submitRecording(
-	destinationOrigin: string,
+	destinationOrigin?: string,
 	destinationTabId?: number,
 ): Promise<{ success: boolean; error?: string }> {
 	if (!recording || recording.status !== 'review' || recording.actions.length === 0) {
 		return { success: false, error: 'Record at least one action before sending.' };
 	}
+	if (activeConnection) return submitRecordingThroughRelay();
+	if (!destinationOrigin) return { success: false, error: 'Select an n8n instance.' };
 	let origin: string;
 	try {
 		origin = new URL(destinationOrigin).origin;
@@ -551,18 +553,15 @@ async function submitRecording(
 	return { success: true };
 }
 
-/** Stop and submit in one step, for a recording n8n itself asked to start — skips the
- *  manual review screen, since Instance AI reviews the recording in chat instead. */
-async function stopAndSubmitRecordingNow(): Promise<{ success: boolean; error?: string }> {
-	await stopRecording();
+function submitRecordingThroughRelay(): { success: boolean; error?: string } {
 	if (!recording || recording.status !== 'review' || recording.actions.length === 0) {
 		return { success: false, error: 'Record at least one action before sending.' };
 	}
 	if (!activeConnection) return { success: false, error: 'Reconnect before sending.' };
+
 	recording.status = 'submitting';
 	broadcastRecordingChange();
-	const sent = activeConnection.relay.sendRecording(getRecordingData(recording));
-	if (!sent) {
+	if (!activeConnection.relay.sendRecording(getRecordingData(recording))) {
 		recording.status = 'review';
 		broadcastRecordingChange('The recording could not be sent. Try again.');
 		return { success: false, error: 'The recording could not be sent. Try again.' };
@@ -573,6 +572,13 @@ async function stopAndSubmitRecordingNow(): Promise<{ success: boolean; error?: 
 		broadcastRecordingChange('n8n did not confirm the recording. Try again.');
 	}, RECORDING_SUBMIT_TIMEOUT_MS);
 	return { success: true };
+}
+
+/** Stop and submit in one step, for a recording n8n itself asked to start — skips the
+ *  manual review screen, since Instance AI reviews the recording in chat instead. */
+async function stopAndSubmitRecordingNow(): Promise<{ success: boolean; error?: string }> {
+	await stopRecording();
+	return submitRecordingThroughRelay();
 }
 
 async function discardRecording(): Promise<{ success: boolean }> {
@@ -1349,7 +1355,9 @@ async function connectToRelay(
 			if (recording?.id !== recordingId || recording.status !== 'submitting') return;
 			if (recordingSubmitTimer) clearTimeout(recordingSubmitTimer);
 			recordingSubmitTimer = undefined;
-			recording.status = accepted ? 'submitted' : 'review';
+			recording = accepted
+				? { ...recording, status: 'submitted', actions: [], screenshots: [], networkRequests: [] }
+				: { ...recording, status: 'review' };
 			if (accepted && threadUrl) void openRecordingThread(threadUrl);
 			broadcastRecordingChange(
 				accepted ? undefined : 'The recording could not be processed. Try again.',

--- a/packages/@n8n/mcp-browser-extension/src/background.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.ts
@@ -7,8 +7,9 @@
 
 import type { BrowserRecordingAction } from '@n8n/api-types';
 
-import { isHostApproved } from './approvedHosts';
+import { isHostApproved, listApprovedOrigins } from './approvedHosts';
 import { createLogger } from './logger';
+import { StandaloneRecordingCapture } from './recordingCapture';
 import { getRecordingSettings } from './recordingSettings';
 import { getRelayHostKey, isAllowedPageOrigin, isAllowedRelayUrl } from './relayAllowlist';
 import { RelayConnection, isEligibleTab, type CapturedNetworkRequest } from './relayConnection';
@@ -17,6 +18,7 @@ import type {
 	ExtensionMessage,
 	ExternalConnectResponse,
 	ExternalConnectResultResponse,
+	RecordingDestination,
 } from './types';
 import { isExternalMessage } from './types';
 
@@ -172,8 +174,11 @@ async function handleMessage(
 		case 'getRecording':
 			return getVisibleRecording();
 
+		case 'getRecordingDestinations':
+			return await getRecordingDestinations();
+
 		case 'submitRecording':
-			return submitRecording();
+			return await submitRecording(message.destinationOrigin, message.destinationTabId);
 
 		case 'discardRecording':
 			await discardRecording();
@@ -239,6 +244,9 @@ async function handleMessage(
 			appendRecordingAction(message.action, sender);
 			return { success: true };
 
+		case 'recordingHeartbeat':
+			return { keepAlive: recording !== null };
+
 		default:
 			return { error: 'Unknown message type' };
 	}
@@ -263,7 +271,10 @@ const SECRET_VALUE_PATTERNS = [
 ];
 
 let recording: BrowserRecording | null = null;
+let standaloneRecordingCapture: StandaloneRecordingCapture | null = null;
+let recordingRelay: RelayConnection | null = null;
 let recordingSubmitTimer: ReturnType<typeof setTimeout> | undefined;
+let recordingHandoffTimer: ReturnType<typeof setTimeout> | undefined;
 const pendingRecordingTabIds = new Set<number>();
 const recordingTabIds = new Set<number>();
 const activatingRecordingTabIds = new Set<number>();
@@ -337,22 +348,23 @@ async function injectRecorder(tabId: number, frameId?: number): Promise<void> {
 
 async function startRecording(): Promise<{ success: boolean; error?: string }> {
 	const relay = activeConnection?.relay;
-	if (!relay) return { success: false, error: 'Connect the extension before recording.' };
-
 	const [activeTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 	const pendingTabId =
 		activeTab?.id !== undefined && isBlankTabUrl(activeTab.url) ? activeTab.id : undefined;
 	if (activeTab?.id !== undefined && isEligibleTab(activeTab)) {
-		await relay.addTab(activeTab.id, activeTab.title ?? '', activeTab.url ?? '');
+		if (relay) await relay.addTab(activeTab.id, activeTab.title ?? '', activeTab.url ?? '');
 	}
 
-	const controlledTabs = relay.getControlledIds();
+	const controlledTabs = relay?.getControlledIds() ?? [];
+	const activeTabId =
+		activeTab?.id !== undefined && isEligibleTab(activeTab) ? activeTab.id : undefined;
 	if (controlledTabs.length === 0 && pendingTabId === undefined) {
-		return { success: false, error: 'Open a web page before recording.' };
+		if (activeTabId === undefined)
+			return { success: false, error: 'Open a web page before recording.' };
 	}
 
 	const captureSettings = await getRecordingSettings();
-	if (activeConnection?.relay !== relay) {
+	if (relay && activeConnection?.relay !== relay) {
 		return { success: false, error: 'The browser connection changed. Try again.' };
 	}
 	recording = {
@@ -371,15 +383,24 @@ async function startRecording(): Promise<{ success: boolean; error?: string }> {
 	screenshotCaptureQueue = Promise.resolve();
 	queuedScreenshotCount = 0;
 	screenshotCaptureRecordingId = recording.id;
+	recordingRelay = relay ?? null;
+	standaloneRecordingCapture = relay
+		? null
+		: new StandaloneRecordingCapture(captureSettings.networkRequests, appendNetworkRequest);
+	for (const { chromeTabId } of controlledTabs) recordingTabIds.add(chromeTabId);
+	if (activeTabId !== undefined) recordingTabIds.add(activeTabId);
 	if (pendingTabId !== undefined) {
 		pendingRecordingTabIds.add(pendingTabId);
 		recordingTabIds.add(pendingTabId);
 	}
 	updateRecordingIndicator(true);
-	await Promise.all(
-		controlledTabs.map(async ({ chromeTabId }) => await injectRecorder(chromeTabId)),
-	);
-	await relay.startRecordingCapture(captureSettings.networkRequests);
+	if (standaloneRecordingCapture) {
+		await Promise.all(
+			[...recordingTabIds].map(async (tabId) => await standaloneRecordingCapture?.addTab(tabId)),
+		);
+	}
+	await Promise.all([...recordingTabIds].map(async (tabId) => await injectRecorder(tabId)));
+	await relay?.startRecordingCapture(captureSettings.networkRequests);
 	broadcastStatusChange();
 	broadcastRecordingChange();
 	return { success: true };
@@ -388,7 +409,7 @@ async function startRecording(): Promise<{ success: boolean; error?: string }> {
 async function stopRecording(): Promise<void> {
 	if (!recording || recording.status !== 'recording') return;
 	const tabIds = new Set([
-		...(activeConnection?.relay.getControlledIds().map(({ chromeTabId }) => chromeTabId) ?? []),
+		...(recordingRelay?.getControlledIds().map(({ chromeTabId }) => chromeTabId) ?? []),
 		...recordingTabIds,
 	]);
 	await Promise.all(
@@ -407,7 +428,10 @@ async function stopRecording(): Promise<void> {
 	);
 	await screenshotCaptureQueue;
 	screenshotCaptureRecordingId = undefined;
-	activeConnection?.relay.stopRecordingCapture();
+	recordingRelay?.stopRecordingCapture();
+	await standaloneRecordingCapture?.stop();
+	standaloneRecordingCapture = null;
+	recordingRelay = null;
 	pendingRecordingTabIds.clear();
 	recordingTabIds.clear();
 	activatingRecordingTabIds.clear();
@@ -418,22 +442,127 @@ async function stopRecording(): Promise<void> {
 	broadcastRecordingChange();
 }
 
-function submitRecording(): { success: boolean; error?: string } {
+async function getRecordingDestinations(): Promise<RecordingDestination[]> {
+	const tabs = await chrome.tabs.query({});
+	const destinations = new Map<string, RecordingDestination>();
+	for (const origin of await listApprovedOrigins()) {
+		if (isAllowedPageOrigin(origin)) destinations.set(origin, { origin });
+	}
+	for (const tab of tabs) {
+		if (tab.id === undefined || !tab.url) continue;
+		let origin: string;
+		try {
+			origin = new URL(tab.url).origin;
+		} catch {
+			continue;
+		}
+		if (!isAllowedPageOrigin(origin)) continue;
+		const destination = { tabId: tab.id, origin };
+		const current = destinations.get(origin);
+		if (!current || tab.url.includes('/assistant')) destinations.set(origin, destination);
+	}
+	return [...destinations.values()];
+}
+
+interface PendingRecordingHandoff {
+	id: string;
+	recordingId: string;
+	tabId: number;
+	origin: string;
+}
+
+let pendingRecordingHandoff: PendingRecordingHandoff | null = null;
+
+function getRecordingData(current: BrowserRecording) {
+	return {
+		id: current.id,
+		startedAt: current.startedAt,
+		actions: current.actions,
+		captureSettings: current.captureSettings,
+		networkRequests: current.networkRequests,
+		screenshots: current.screenshots,
+	};
+}
+
+async function submitRecording(
+	destinationOrigin: string,
+	destinationTabId?: number,
+): Promise<{ success: boolean; error?: string }> {
+	if (!recording || recording.status !== 'review' || recording.actions.length === 0) {
+		return { success: false, error: 'Record at least one action before sending.' };
+	}
+	let origin: string;
+	try {
+		origin = new URL(destinationOrigin).origin;
+	} catch {
+		return { success: false, error: 'Enter a valid n8n instance URL.' };
+	}
+	if (!isAllowedPageOrigin(origin)) {
+		return { success: false, error: 'Select a supported n8n instance.' };
+	}
+	const handoffId = crypto.randomUUID();
+	const assistantUrl = new URL('/assistant', origin);
+	assistantUrl.searchParams.set('browserRecordingHandoff', handoffId);
+	let destination: chrome.tabs.Tab | undefined;
+	if (destinationTabId !== undefined) {
+		try {
+			destination = await chrome.tabs.get(destinationTabId);
+		} catch {
+			// The tab closed. Open the remembered instance below.
+		}
+	}
+	if (destination?.url && new URL(destination.url).origin !== origin) destination = undefined;
+	const shouldNavigateExistingTab = destination?.id !== undefined;
+	if (!destination?.id)
+		destination = await chrome.tabs.create({ url: assistantUrl.href, active: true });
+	if (destination.id === undefined) {
+		return { success: false, error: 'The n8n instance could not be opened.' };
+	}
+	pendingRecordingHandoff = {
+		id: handoffId,
+		recordingId: recording.id,
+		tabId: destination.id,
+		origin,
+	};
+	if (recordingHandoffTimer) clearTimeout(recordingHandoffTimer);
+	recordingHandoffTimer = setTimeout(() => {
+		if (recording?.status !== 'submitting' || pendingRecordingHandoff?.id !== handoffId) return;
+		pendingRecordingHandoff = null;
+		recording.status = 'review';
+		broadcastRecordingChange('n8n did not confirm the recording. Try again.');
+	}, 60_000);
+	recording.status = 'submitting';
+	broadcastRecordingChange();
+	try {
+		if (shouldNavigateExistingTab) {
+			await chrome.tabs.update(destination.id, { url: assistantUrl.href, active: true });
+		}
+		if (destination.windowId !== undefined) {
+			await chrome.windows.update(destination.windowId, { focused: true });
+		}
+	} catch {
+		if (recordingHandoffTimer) clearTimeout(recordingHandoffTimer);
+		recordingHandoffTimer = undefined;
+		pendingRecordingHandoff = null;
+		recording.status = 'review';
+		broadcastRecordingChange('The n8n instance could not be opened. Try again.');
+		return { success: false, error: 'The recording could not be sent. Try again.' };
+	}
+	return { success: true };
+}
+
+/** Stop and submit in one step, for a recording n8n itself asked to start — skips the
+ *  manual review screen, since Instance AI reviews the recording in chat instead. */
+async function stopAndSubmitRecordingNow(): Promise<{ success: boolean; error?: string }> {
+	await stopRecording();
 	if (!recording || recording.status !== 'review' || recording.actions.length === 0) {
 		return { success: false, error: 'Record at least one action before sending.' };
 	}
 	if (!activeConnection) return { success: false, error: 'Reconnect before sending.' };
 	recording.status = 'submitting';
 	broadcastRecordingChange();
-	const recordingData = {
-		id: recording.id,
-		startedAt: recording.startedAt,
-		actions: recording.actions,
-		captureSettings: recording.captureSettings,
-		networkRequests: recording.networkRequests,
-		screenshots: recording.screenshots,
-	};
-	if (!activeConnection.relay.sendRecording(recordingData)) {
+	const sent = activeConnection.relay.sendRecording(getRecordingData(recording));
+	if (!sent) {
 		recording.status = 'review';
 		broadcastRecordingChange('The recording could not be sent. Try again.');
 		return { success: false, error: 'The recording could not be sent. Try again.' };
@@ -446,19 +575,15 @@ function submitRecording(): { success: boolean; error?: string } {
 	return { success: true };
 }
 
-/** Stop and submit in one step, for a recording n8n itself asked to start — skips the
- *  manual review screen, since Instance AI reviews the recording in chat instead. */
-async function stopAndSubmitRecordingNow(): Promise<{ success: boolean; error?: string }> {
-	await stopRecording();
-	return submitRecording();
-}
-
 async function discardRecording(): Promise<{ success: boolean }> {
 	if (recordingSubmitTimer) clearTimeout(recordingSubmitTimer);
 	recordingSubmitTimer = undefined;
+	if (recordingHandoffTimer) clearTimeout(recordingHandoffTimer);
+	recordingHandoffTimer = undefined;
 	screenshotCaptureRecordingId = undefined;
 	await stopRecording();
 	recording = null;
+	pendingRecordingHandoff = null;
 	broadcastRecordingChange();
 	return { success: true };
 }
@@ -469,7 +594,7 @@ function pushRecordingAction(action: BrowserRecordingAction, chromeTabId: number
 	recording.actions.push(action);
 	lastRecordingActionByTab.set(chromeTabId, action.id);
 	scheduleScreenshot(action.id, chromeTabId);
-	activeConnection?.relay.sendRecordingAction(recording.id, action);
+	recordingRelay?.sendRecordingAction(recording.id, action);
 	broadcastRecordingChange();
 }
 
@@ -477,8 +602,8 @@ function scheduleScreenshot(actionId: string, chromeTabId: number): void {
 	if (!recording?.captureSettings?.screenshots) return;
 	if (queuedScreenshotCount >= MAX_RECORDING_SCREENSHOTS) return;
 	const recordingId = recording.id;
-	const relay = activeConnection?.relay;
-	if (!relay) return;
+	const capture = standaloneRecordingCapture ?? recordingRelay;
+	if (!capture) return;
 	queuedScreenshotCount++;
 	screenshotCaptureQueue = screenshotCaptureQueue.then(async () => {
 		if (screenshotCaptureRecordingId !== recordingId) return;
@@ -491,7 +616,7 @@ function scheduleScreenshot(actionId: string, chromeTabId: number): void {
 			return;
 		const screenshots = recording.screenshots ?? [];
 		if (screenshots.length >= MAX_RECORDING_SCREENSHOTS) return;
-		const data = await relay.captureScreenshot(chromeTabId);
+		const data = await capture.captureScreenshot(chromeTabId);
 		if (!data || data.length > MAX_RECORDING_SCREENSHOT_BASE64_BYTES) return;
 		const totalBytes = screenshots.reduce((total, screenshot) => total + screenshot.data.length, 0);
 		if (totalBytes + data.length > MAX_RECORDING_SCREENSHOTS_BASE64_BYTES) return;
@@ -538,11 +663,7 @@ function appendRecordingAction(
 	)
 		return;
 	const tabId = sender.tab?.id;
-	if (
-		sender.id !== chrome.runtime.id ||
-		tabId === undefined ||
-		(!activeConnection?.relay.isControlledTab(tabId) && !recordingTabIds.has(tabId))
-	) {
+	if (sender.id !== chrome.runtime.id || tabId === undefined || !recordingTabIds.has(tabId)) {
 		return;
 	}
 	const target = action.target
@@ -631,20 +752,23 @@ async function activatePendingRecordingTab(
 	action: 'navigation' | 'tab_switch' = 'navigation',
 ): Promise<void> {
 	const relay = activeConnection?.relay;
-	if (!relay || recording?.status !== 'recording' || !pendingRecordingTabIds.has(tabId)) return;
+	if (recording?.status !== 'recording' || !pendingRecordingTabIds.has(tabId)) return;
 
 	pendingRecordingTabIds.delete(tabId);
 	activatingRecordingTabIds.add(tabId);
 	try {
 		await injectRecorder(tabId);
-		await relay.addTab(tabId, title, url);
-		if (relay !== activeConnection?.relay || recording?.status !== 'recording') return;
+		if (recordingRelay) await recordingRelay.addTab(tabId, title, url);
+		else await standaloneRecordingCapture?.addTab(tabId);
+		if (recording?.status !== 'recording') return;
 		if (action === 'tab_switch') appendTabSwitch(tabId, url, title);
 		else appendNavigation(tabId, url);
-		broadcastStatusChange();
-		updateBadge(relay.getControlledIds().length);
+		if (relay) {
+			broadcastStatusChange();
+			updateBadge(relay.getControlledIds().length);
+		}
 	} catch (error) {
-		if (relay === activeConnection?.relay && recording?.status === 'recording') {
+		if (recording?.status === 'recording') {
 			pendingRecordingTabIds.add(tabId);
 		}
 		log.warn('Failed to activate pending recording tab', error);
@@ -820,6 +944,42 @@ chrome.runtime.onMessageExternal.addListener(
 		}
 		log.debug('external message received:', message.type, 'from', sender.origin);
 
+		if (message.type === 'getRecording' || message.type === 'acknowledgeRecording') {
+			const handoff = pendingRecordingHandoff;
+			if (
+				!handoff ||
+				handoff.id !== message.handoffId ||
+				sender.tab?.id !== handoff.tabId ||
+				sender.origin !== handoff.origin ||
+				recording?.id !== handoff.recordingId
+			) {
+				sendResponse({ success: false });
+				return false;
+			}
+			if (message.type === 'getRecording') {
+				sendResponse({ success: true, recording: getRecordingData(recording) });
+				return false;
+			}
+			pendingRecordingHandoff = null;
+			if (recordingHandoffTimer) clearTimeout(recordingHandoffTimer);
+			recordingHandoffTimer = undefined;
+			if (message.accepted) {
+				recording = {
+					...recording,
+					status: 'submitted',
+					actions: [],
+					screenshots: [],
+					networkRequests: [],
+				};
+				broadcastRecordingChange();
+			} else {
+				recording.status = 'review';
+				broadcastRecordingChange('The recording could not be sent. Try again.');
+			}
+			sendResponse({ success: true });
+			return false;
+		}
+
 		if (message.type === 'connect') {
 			void handleExternalConnect(message.relayUrl, sender.origin).then(
 				sendResponse,
@@ -916,9 +1076,7 @@ async function openConnectPopup(relayUrl: string): Promise<number | null> {
 
 chrome.tabs.onCreated.addListener((tab) => {
 	log.debug('[onCreated] fired:', JSON.stringify(tab));
-	if (!activeConnection || !tab.id) return;
-
-	const relay = activeConnection.relay;
+	if (!tab.id) return;
 	if (recording?.status === 'recording') {
 		recordingTabIds.add(tab.id);
 		pendingRecordingTabIds.add(tab.id);
@@ -928,6 +1086,9 @@ chrome.tabs.onCreated.addListener((tab) => {
 		}
 		return;
 	}
+	if (!activeConnection) return;
+
+	const relay = activeConnection.relay;
 
 	const isAgentCreated = relay.isAgentCreatedTab(tab.id);
 
@@ -953,16 +1114,16 @@ chrome.tabs.onCreated.addListener((tab) => {
 // This uses sourceTabId which correctly identifies the originating tab,
 // unlike chrome.tabs.onCreated's openerTabId which just reflects the focused tab.
 chrome.webNavigation.onCreatedNavigationTarget.addListener((details) => {
-	if (!activeConnection) return;
-
-	const relay = activeConnection.relay;
 	if (recording?.status === 'recording' && recordingTabIds.has(details.tabId)) {
-		relay.markAsAgentCreated(details.tabId);
+		recordingRelay?.markAsAgentCreated(details.tabId);
 		if (isRecordableUrl(details.url)) {
 			void activatePendingRecordingTab(details.tabId, details.url);
 		}
 		return;
 	}
+	if (!activeConnection) return;
+
+	const relay = activeConnection.relay;
 	const sourceIsControlled = relay.isControlledTab(details.sourceTabId);
 
 	log.debug(
@@ -1008,22 +1169,22 @@ chrome.webNavigation.onCommitted.addListener((details) => {
 		void activatePendingRecordingTab(details.tabId, details.url);
 		return;
 	}
-	if (recording?.status === 'recording' && activeConnection?.relay.isControlledTab(details.tabId)) {
+	if (recording?.status === 'recording' && recordingTabIds.has(details.tabId)) {
 		if (details.frameId === 0) appendNavigation(details.tabId, details.url);
 		void injectRecorder(details.tabId, details.frameId);
 	}
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-	if (!activeConnection) return;
 	if (changeInfo.url && pendingRecordingTabIds.has(tabId) && isRecordableUrl(changeInfo.url)) {
 		void activatePendingRecordingTab(tabId, changeInfo.url, changeInfo.title ?? '');
 		return;
 	}
-	if (recording?.status === 'recording' && activeConnection.relay.isControlledTab(tabId)) {
+	if (recording?.status === 'recording' && recordingTabIds.has(tabId)) {
 		if (changeInfo.url) appendNavigation(tabId, changeInfo.url);
 		if (changeInfo.status === 'complete') void injectRecorder(tabId);
 	}
+	if (!activeConnection) return;
 
 	// Only auto-register tabs created by the AI agent (or marked as spawned)
 	if (!activeConnection.relay.isAgentCreatedTab(tabId)) return;
@@ -1044,12 +1205,11 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 });
 
 chrome.tabs.onActivated.addListener(({ tabId }) => {
-	if (recording?.status !== 'recording' || !activeConnection) return;
-	const relay = activeConnection.relay;
+	if (recording?.status !== 'recording') return;
 	void chrome.tabs
 		.get(tabId)
 		.then((tab) => {
-			if (recording?.status !== 'recording' || relay !== activeConnection?.relay) return;
+			if (recording?.status !== 'recording') return;
 			const url = tab.url ?? tab.pendingUrl;
 			if (!url) return;
 			if (
@@ -1058,7 +1218,7 @@ chrome.tabs.onActivated.addListener(({ tabId }) => {
 			) {
 				return;
 			}
-			if (relay.isControlledTab(tabId)) {
+			if (recordingTabIds.has(tabId)) {
 				appendTabSwitch(tabId, url, tab.title ?? '');
 				return;
 			}
@@ -1079,6 +1239,7 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 	pendingRecordingTabIds.delete(tabId);
 	recordingTabIds.delete(tabId);
 	activatingRecordingTabIds.delete(tabId);
+	standaloneRecordingCapture?.removeTab(tabId);
 	if (pendingConnectFlow?.tabId === tabId && !activeConnection) {
 		settleConnectFlow(false);
 	}
@@ -1222,7 +1383,6 @@ function disconnect(): void {
 		activeConnection = null;
 		updateBadge(0);
 	}
-	void discardRecording();
 }
 
 /** Notify all extension contexts (popup, connect.html tab) about connection state changes. */

--- a/packages/@n8n/mcp-browser-extension/src/recorder.ts
+++ b/packages/@n8n/mcp-browser-extension/src/recorder.ts
@@ -2,6 +2,7 @@ interface RecorderState {
 	active: boolean;
 	inputTimers: Map<Element, ReturnType<typeof setTimeout>>;
 	copyContext?: { target: Element; value?: string; timestamp: number };
+	heartbeatTimer?: ReturnType<typeof setInterval>;
 }
 
 declare global {
@@ -10,13 +11,36 @@ declare global {
 	}
 }
 
+function startHeartbeat(state: RecorderState): void {
+	if (window !== window.top || state.heartbeatTimer) return;
+	state.heartbeatTimer = setInterval(() => {
+		void chrome.runtime
+			.sendMessage({ type: 'recordingHeartbeat' })
+			.then((response: unknown) => {
+				if (
+					response &&
+					typeof response === 'object' &&
+					'keepAlive' in response &&
+					response.keepAlive === false &&
+					state.heartbeatTimer
+				) {
+					clearInterval(state.heartbeatTimer);
+					state.heartbeatTimer = undefined;
+				}
+			})
+			.catch(() => {});
+	}, 20_000);
+}
+
 const existing = window.__n8nBrowserRecorder;
 if (existing) {
 	existing.active = true;
+	startHeartbeat(existing);
 } else {
 	const state: RecorderState = { active: true, inputTimers: new Map() };
 	window.__n8nBrowserRecorder = state;
 	const inFlightMessages = new Set<Promise<unknown>>();
+	startHeartbeat(state);
 
 	const normalized = (value: string | null | undefined, limit = 160) => {
 		const result = value?.replace(/\s+/g, ' ').trim().slice(0, limit);

--- a/packages/@n8n/mcp-browser-extension/src/recordingCapture.ts
+++ b/packages/@n8n/mcp-browser-extension/src/recordingCapture.ts
@@ -1,0 +1,149 @@
+import { createLogger } from './logger';
+import type { CapturedNetworkRequest } from './relayConnection';
+
+const log = createLogger('recording-capture');
+const SCREENSHOT_TIMEOUT_MS = 5_000;
+const MAX_PENDING_NETWORK_REQUESTS = 1_000;
+
+interface PendingNetworkRequest {
+	url: string;
+	method: string;
+	timestamp: number;
+}
+
+interface RequestWillBeSentEvent {
+	requestId?: string;
+	request?: { url?: string; method?: string };
+}
+
+interface ResponseReceivedEvent {
+	requestId?: string;
+	response?: { url?: string; status?: number; mimeType?: string };
+}
+
+export class StandaloneRecordingCapture {
+	private readonly tabIds = new Set<number>();
+
+	private readonly attachedTabIds = new Set<number>();
+
+	private readonly pendingNetworkRequests = new Map<string, PendingNetworkRequest>();
+
+	private readonly eventListener: (
+		source: chrome.debugger.Debuggee,
+		method: string,
+		params?: object,
+	) => void;
+
+	constructor(
+		private readonly captureNetworkRequests: boolean,
+		private readonly onNetworkRequest: (request: CapturedNetworkRequest) => void,
+	) {
+		this.eventListener = this.onDebuggerEvent.bind(this);
+		chrome.debugger.onEvent.addListener(this.eventListener);
+	}
+
+	async addTab(tabId: number): Promise<void> {
+		this.tabIds.add(tabId);
+		if (this.captureNetworkRequests) await this.enableNetworkCapture(tabId);
+	}
+
+	removeTab(tabId: number): void {
+		this.tabIds.delete(tabId);
+		if (this.attachedTabIds.delete(tabId)) {
+			void chrome.debugger.detach({ tabId }).catch(() => {});
+		}
+	}
+
+	async captureScreenshot(tabId: number): Promise<string | undefined> {
+		if (!this.tabIds.has(tabId)) return undefined;
+		try {
+			await this.attach(tabId);
+			const result: unknown = await Promise.race([
+				chrome.debugger.sendCommand({ tabId }, 'Page.captureScreenshot', {
+					format: 'jpeg',
+					quality: 60,
+					captureBeyondViewport: false,
+					optimizeForSpeed: true,
+				}),
+				new Promise<never>((_resolve, reject) => {
+					setTimeout(() => reject(new Error('Screenshot timed out')), SCREENSHOT_TIMEOUT_MS);
+				}),
+			]);
+			if (!result || typeof result !== 'object' || !('data' in result)) return undefined;
+			return typeof result.data === 'string' ? result.data : undefined;
+		} catch (error) {
+			log.warn(`Failed to capture screenshot for tab ${tabId}`, error);
+			return undefined;
+		}
+	}
+
+	async stop(): Promise<void> {
+		chrome.debugger.onEvent.removeListener(this.eventListener);
+		this.pendingNetworkRequests.clear();
+		await Promise.all(
+			[...this.attachedTabIds].map(async (tabId) => {
+				await chrome.debugger.detach({ tabId }).catch(() => {});
+			}),
+		);
+		this.attachedTabIds.clear();
+		this.tabIds.clear();
+	}
+
+	private async attach(tabId: number): Promise<void> {
+		if (this.attachedTabIds.has(tabId)) return;
+		await chrome.debugger.attach({ tabId }, '1.3');
+		this.attachedTabIds.add(tabId);
+	}
+
+	private async enableNetworkCapture(tabId: number): Promise<void> {
+		try {
+			await this.attach(tabId);
+			await chrome.debugger.sendCommand({ tabId }, 'Network.enable');
+		} catch (error) {
+			log.warn(`Failed to enable network capture for tab ${tabId}`, error);
+		}
+	}
+
+	private onDebuggerEvent(source: chrome.debugger.Debuggee, method: string, params?: object): void {
+		const tabId = source.tabId;
+		if (!tabId || !this.tabIds.has(tabId) || !this.captureNetworkRequests) return;
+
+		if (method === 'Network.requestWillBeSent') {
+			const event: RequestWillBeSentEvent | undefined = params;
+			if (
+				typeof event?.requestId !== 'string' ||
+				typeof event.request?.url !== 'string' ||
+				typeof event.request.method !== 'string'
+			) {
+				return;
+			}
+			this.pendingNetworkRequests.set(`${tabId}:${event.requestId}`, {
+				url: event.request.url,
+				method: event.request.method,
+				timestamp: Date.now(),
+			});
+			if (this.pendingNetworkRequests.size > MAX_PENDING_NETWORK_REQUESTS) {
+				const oldestKey = this.pendingNetworkRequests.keys().next().value;
+				if (typeof oldestKey === 'string') this.pendingNetworkRequests.delete(oldestKey);
+			}
+			return;
+		}
+
+		if (method !== 'Network.responseReceived') return;
+		const event: ResponseReceivedEvent | undefined = params;
+		if (typeof event?.requestId !== 'string' || typeof event.response?.status !== 'number') return;
+		const key = `${tabId}:${event.requestId}`;
+		const request = this.pendingNetworkRequests.get(key);
+		this.pendingNetworkRequests.delete(key);
+		if (!request) return;
+		this.onNetworkRequest({
+			chromeTabId: tabId,
+			url: typeof event.response.url === 'string' ? event.response.url : request.url,
+			method: request.method,
+			status: event.response.status,
+			contentType:
+				typeof event.response.mimeType === 'string' ? event.response.mimeType : undefined,
+			timestamp: request.timestamp,
+		});
+	}
+}

--- a/packages/@n8n/mcp-browser-extension/src/types.ts
+++ b/packages/@n8n/mcp-browser-extension/src/types.ts
@@ -75,7 +75,7 @@ export interface GetRecordingMessage {
 
 export interface SubmitRecordingMessage {
 	type: 'submitRecording';
-	destinationOrigin: string;
+	destinationOrigin?: string;
 	destinationTabId?: number;
 }
 

--- a/packages/@n8n/mcp-browser-extension/src/types.ts
+++ b/packages/@n8n/mcp-browser-extension/src/types.ts
@@ -75,6 +75,17 @@ export interface GetRecordingMessage {
 
 export interface SubmitRecordingMessage {
 	type: 'submitRecording';
+	destinationOrigin: string;
+	destinationTabId?: number;
+}
+
+export interface GetRecordingDestinationsMessage {
+	type: 'getRecordingDestinations';
+}
+
+export interface RecordingDestination {
+	tabId?: number;
+	origin: string;
 }
 
 export interface DiscardRecordingMessage {
@@ -112,6 +123,10 @@ export interface RecordingActionMessage {
 	};
 }
 
+export interface RecordingHeartbeatMessage {
+	type: 'recordingHeartbeat';
+}
+
 export type ExtensionMessage =
 	| GetTabsMessage
 	| ConnectMessage
@@ -122,12 +137,14 @@ export type ExtensionMessage =
 	| StartRecordingMessage
 	| StopRecordingMessage
 	| GetRecordingMessage
+	| GetRecordingDestinationsMessage
 	| SubmitRecordingMessage
 	| DiscardRecordingMessage
 	| RemoveRecordingActionMessage
 	| MaskRecordingActionMessage
 	| RemoveRecordingScreenshotMessage
 	| RemoveRecordingNetworkRequestMessage
+	| RecordingHeartbeatMessage
 	| RecordingActionMessage;
 
 // ---------------------------------------------------------------------------
@@ -144,7 +161,22 @@ export interface ExternalConnectResultMessage {
 	relayUrl: string;
 }
 
-export type ExternalMessage = ExternalConnectMessage | ExternalConnectResultMessage;
+export interface ExternalGetRecordingMessage {
+	type: 'getRecording';
+	handoffId: string;
+}
+
+export interface ExternalAcknowledgeRecordingMessage {
+	type: 'acknowledgeRecording';
+	handoffId: string;
+	accepted: boolean;
+}
+
+export type ExternalMessage =
+	| ExternalConnectMessage
+	| ExternalConnectResultMessage
+	| ExternalGetRecordingMessage
+	| ExternalAcknowledgeRecordingMessage;
 
 export interface ExternalConnectResponse {
 	accepted: boolean;
@@ -194,8 +226,17 @@ export type BackgroundPushMessage =
 export function isExternalMessage(raw: unknown): raw is ExternalMessage {
 	if (raw === null || typeof raw !== 'object') return false;
 	const obj = raw as Record<string, unknown>;
+	if (
+		(obj.type === 'connect' || obj.type === 'connectResult') &&
+		typeof obj.relayUrl === 'string'
+	) {
+		return true;
+	}
+	if (obj.type === 'getRecording') return typeof obj.handoffId === 'string';
 	return (
-		(obj.type === 'connect' || obj.type === 'connectResult') && typeof obj.relayUrl === 'string'
+		obj.type === 'acknowledgeRecording' &&
+		typeof obj.handoffId === 'string' &&
+		typeof obj.accepted === 'boolean'
 	);
 }
 

--- a/packages/@n8n/mcp-browser-extension/src/ui/App.vue
+++ b/packages/@n8n/mcp-browser-extension/src/ui/App.vue
@@ -85,6 +85,10 @@ async function disconnectFromInstance() {
 }
 
 async function prepareSubmission() {
+	if (isConnected.value) {
+		await submitRecording();
+		return;
+	}
 	await loadDestinations();
 	if (destinations.value.length === 1) {
 		const destination = destinations.value[0];

--- a/packages/@n8n/mcp-browser-extension/src/ui/App.vue
+++ b/packages/@n8n/mcp-browser-extension/src/ui/App.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { N8nButton, N8nCheckbox, N8nIcon, N8nIconButton, N8nLogo } from '@n8n/design-system';
+import {
+	N8nButton,
+	N8nCheckbox,
+	N8nIcon,
+	N8nIconButton,
+	N8nInput,
+	N8nLogo,
+} from '@n8n/design-system';
 import { useConnection } from './composables/useConnection';
 import { useRecording } from './composables/useRecording';
 import InfoRow from './components/InfoRow.vue';
@@ -32,10 +39,12 @@ const {
 
 const {
 	recording,
+	destinations,
 	errorMessage: recordingError,
 	start: startRecording,
 	stop: stopRecording,
 	submit: submitRecording,
+	loadDestinations,
 	discard: discardRecording,
 	recordAgain,
 	removeAction,
@@ -47,6 +56,8 @@ const {
 const showTabSelection = ref(false);
 const showRecordingSettings = ref(false);
 const showSettings = ref(false);
+const showDestinations = ref(false);
+const instanceUrl = ref('');
 
 const isConnected = computed(() => status.value === 'connected');
 const showConnectPrompt = computed(() => hasRelayUrl.value && isRelayAllowed.value);
@@ -71,6 +82,27 @@ const recordingTitle = computed(() => {
 async function disconnectFromInstance() {
 	await disconnect();
 	showSettings.value = false;
+}
+
+async function prepareSubmission() {
+	await loadDestinations();
+	if (destinations.value.length === 1) {
+		const destination = destinations.value[0];
+		await submitRecording(destination.origin, destination.tabId);
+	} else {
+		showDestinations.value = true;
+	}
+}
+
+async function submitTo(origin: string, tabId?: number) {
+	showDestinations.value = false;
+	await submitRecording(origin, tabId);
+}
+
+async function submitToInstanceUrl() {
+	const origin = instanceUrl.value.trim();
+	if (!origin) return;
+	await submitTo(origin);
 }
 </script>
 
@@ -131,9 +163,32 @@ async function disconnectFromInstance() {
 				<RememberedHosts show-empty :hosts="approvedHosts" @forget="forgetHost" />
 			</template>
 
-			<template v-else-if="isConnected && recording?.status === 'review'">
-				<h1 class="title">Review recording</h1>
+			<template v-else-if="recording?.status === 'review'">
+				<h1 class="title">{{ showDestinations ? 'Send to AI Assistant' : 'Review recording' }}</h1>
+				<div v-if="showDestinations && destinations.length" class="panel">
+					<InfoRow
+						v-for="destination in destinations"
+						:key="destination.origin"
+						icon="sparkles"
+						:title="destination.origin"
+					>
+						<div class="destination-action">
+							<N8nButton size="small" @click="submitTo(destination.origin, destination.tabId)">
+								Send here
+							</N8nButton>
+						</div>
+					</InfoRow>
+				</div>
+				<div v-else-if="showDestinations" class="panel">
+					<InfoRow
+						icon="link"
+						title="Enter your n8n instance URL"
+						description="Open AI Assistant at this address"
+					/>
+					<N8nInput v-model="instanceUrl" placeholder="https://example.app.n8n.cloud" />
+				</div>
 				<RecordingReview
+					v-else
 					:actions="recording.actions"
 					:screenshots="recording.screenshots ?? []"
 					:network-requests="recording.networkRequests ?? []"
@@ -144,7 +199,7 @@ async function disconnectFromInstance() {
 				/>
 			</template>
 
-			<template v-else-if="isConnected">
+			<template v-else-if="(isConnected || !hasRelayUrl) && !showSettings">
 				<h1 v-if="recording" class="title">
 					<span class="status-dot" />
 					{{ recordingTitle }}
@@ -152,8 +207,8 @@ async function disconnectFromInstance() {
 				<template v-if="!recording">
 					<h1 class="title">Record a browser task</h1>
 					<p class="subtitle">
-						Show AI Assistant how you complete a task. Browser Use records your clicks, typing, and
-						navigation so AI Assistant can build a workflow.
+						Show AI Assistant how you complete a task. The extension records your clicks, typing,
+						and navigation so AI Assistant can build a workflow.
 					</p>
 				</template>
 				<div v-if="!recording" class="panel">
@@ -176,7 +231,7 @@ async function disconnectFromInstance() {
 					AI Assistant is processing your recording in a new conversation.
 				</p>
 				<p v-else-if="recording.status === 'submitting'" class="subtitle">
-					Keep this extension open while n8n starts the conversation.
+					n8n is starting a new conversation from your recording.
 				</p>
 			</template>
 
@@ -313,15 +368,34 @@ async function disconnectFromInstance() {
 				Disconnect
 			</N8nButton>
 		</div>
-		<div v-else-if="isConnected" class="footer">
+		<div v-else-if="(isConnected || !hasRelayUrl) && !showSettings" class="footer">
 			<template v-if="recording?.status === 'recording'">
 				<N8nButton variant="outline" size="large" @click="discardRecording">Cancel</N8nButton>
 				<N8nButton size="large" @click="stopRecording">Stop recording</N8nButton>
 			</template>
 			<template v-else-if="recording?.status === 'review'">
-				<N8nButton variant="outline" size="large" @click="recordAgain">Record again</N8nButton>
-				<N8nButton size="large" :disabled="recording.actions.length === 0" @click="submitRecording">
-					Send to n8n
+				<N8nButton
+					variant="outline"
+					size="large"
+					@click="showDestinations ? (showDestinations = false) : recordAgain()"
+				>
+					{{ showDestinations ? 'Back' : 'Record again' }}
+				</N8nButton>
+				<N8nButton
+					v-if="!showDestinations"
+					size="large"
+					:disabled="recording.actions.length === 0"
+					@click="prepareSubmission"
+				>
+					Send to AI Assistant
+				</N8nButton>
+				<N8nButton
+					v-else-if="destinations.length === 0"
+					size="large"
+					:disabled="instanceUrl.trim().length === 0"
+					@click="submitToInstanceUrl"
+				>
+					Continue
 				</N8nButton>
 			</template>
 			<template v-else-if="recording?.status === 'submitted'">
@@ -451,6 +525,10 @@ async function disconnectFromInstance() {
 
 .remember {
 	--checkbox--label--font-size: var(--font-size--xs);
+	margin-top: var(--spacing--sm);
+}
+
+.destination-action {
 	margin-top: var(--spacing--sm);
 }
 

--- a/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecording.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecording.ts
@@ -56,7 +56,7 @@ export function useRecording() {
 		}
 	}
 
-	async function submit(destinationOrigin: string, destinationTabId?: number): Promise<void> {
+	async function submit(destinationOrigin?: string, destinationTabId?: number): Promise<void> {
 		await send({ type: 'submitRecording', destinationOrigin, destinationTabId });
 	}
 

--- a/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecording.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecording.ts
@@ -1,6 +1,6 @@
 import { onMounted, onUnmounted, ref } from 'vue';
 
-import type { BackgroundPushMessage, BrowserRecording } from '../../types';
+import type { BackgroundPushMessage, BrowserRecording, RecordingDestination } from '../../types';
 
 interface ActionResponse {
 	success: boolean;
@@ -17,6 +17,7 @@ function isActionResponse(value: unknown): value is ActionResponse {
 
 export function useRecording() {
 	const recording = ref<BrowserRecording | null>(null);
+	const destinations = ref<RecordingDestination[]>([]);
 	const errorMessage = ref('');
 
 	async function send(message: Record<string, unknown>): Promise<boolean> {
@@ -42,8 +43,21 @@ export function useRecording() {
 		await send({ type: 'stopRecording' });
 	}
 
-	async function submit(): Promise<void> {
-		await send({ type: 'submitRecording' });
+	async function loadDestinations(): Promise<void> {
+		errorMessage.value = '';
+		try {
+			const response: unknown = await chrome.runtime.sendMessage({
+				type: 'getRecordingDestinations',
+			});
+			destinations.value = Array.isArray(response) ? (response as RecordingDestination[]) : [];
+		} catch {
+			destinations.value = [];
+			errorMessage.value = 'n8n instances could not be loaded. Try again.';
+		}
+	}
+
+	async function submit(destinationOrigin: string, destinationTabId?: number): Promise<void> {
+		await send({ type: 'submitRecording', destinationOrigin, destinationTabId });
 	}
 
 	async function discard(): Promise<void> {
@@ -87,10 +101,12 @@ export function useRecording() {
 
 	return {
 		recording,
+		destinations,
 		errorMessage,
 		start,
 		stop,
 		submit,
+		loadDestinations,
 		discard,
 		recordAgain,
 		removeAction,

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -21,9 +21,14 @@ import {
 	InstanceAiEvalCredentialAllowlistRequest,
 	InstanceAiEvalRestoreThreadRequest,
 	InstanceAiEvalSeedDataTableRowsRequest,
+	InstanceAiBrowserRecordingRequest,
 	findUnbackedSeedWorkflowTools,
 } from '@n8n/api-types';
-import type { InstanceAiAdminSettingsResponse, InstanceAiEvent } from '@n8n/api-types';
+import type {
+	InstanceAiAdminSettingsResponse,
+	InstanceAiBrowserRecordingResponse,
+	InstanceAiEvent,
+} from '@n8n/api-types';
 import { ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
@@ -1367,6 +1372,25 @@ export class InstanceAiController {
 		this.requireInstanceAiEnabled();
 		this.assertBrowserChannelEnabled();
 		return await this.browserSessionService.createLink(req.user.id);
+	}
+
+	@Post('/browser/recording')
+	@GlobalScope('instanceAi:message')
+	async createBrowserRecordingThread(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Body payload: InstanceAiBrowserRecordingRequest,
+	): Promise<InstanceAiBrowserRecordingResponse> {
+		this.requireInstanceAiEnabled();
+		this.assertBrowserChannelEnabled();
+		await this.requireModelConfigured();
+		const project = await this.projectService.getPersonalProject(req.user);
+		if (!project) throw new NotFoundError('Personal project not found');
+		return await this.instanceAiService.launchManualBrowserRecording({
+			userId: req.user.id,
+			projectId: project.id,
+			recording: payload.recording,
+		});
 	}
 
 	@Get('/browser/status')

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1477,6 +1477,14 @@ export class InstanceAiService {
 		return runId;
 	}
 
+	async launchManualBrowserRecording(input: {
+		userId: string;
+		projectId: string;
+		recording: BrowserRecording;
+	}): Promise<{ threadId: string }> {
+		return await this.launchBrowserRecording(input);
+	}
+
 	private async launchBrowserRecording(input: {
 		userId: string;
 		projectId: string;

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7166,6 +7166,8 @@
 	"instanceAi.recordingPreview.stopError.message": "Try again.",
 	"instanceAi.recordingPreview.discardError.title": "Could not discard the recording",
 	"instanceAi.recordingPreview.discardError.message": "Try again.",
+	"instanceAi.browserRecordingImport.error.title": "Recording couldn't be sent",
+	"instanceAi.browserRecordingImport.error.message": "Return to the extension and try again.",
 	"instanceAi.dataTableCard.title": "Managing data table",
 	"instanceAi.dataTableCard.phase.checking": "Checking tables",
 	"instanceAi.dataTableCard.phase.schema": "Modifying schema",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -804,7 +804,7 @@ async function syncRouteToStore() {
 	// submit cannot race past it while the thread list is still loading.
 	pendingComposerContext.value = getPendingHandoffContext(requestedThreadId);
 	pendingComposerDraft.value = getPendingComposerDraft(requestedThreadId);
-	if (!store.threads.length) {
+	if (!store.threads.some((thread) => thread.id === requestedThreadId)) {
 		await store.loadThreads();
 	}
 	// User may have navigated elsewhere while we awaited

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -17,6 +17,7 @@ import InstanceAiThreadList from './components/InstanceAiThreadList.vue';
 import { INSTANCE_AI_VIEW, isInstanceAiChatRoute } from './constants';
 import { SidebarStateKey } from './instanceAiLayout';
 import InstanceAiOnboardingView from './onboarding/InstanceAiOnboardingView.vue';
+import { useBrowserRecordingHandoff } from './composables/useBrowserRecordingHandoff';
 
 const store = useInstanceAiStore();
 const settingsStore = useInstanceAiSettingsStore();
@@ -30,6 +31,7 @@ const rootStore = useRootStore();
 const usersStore = useUsersStore();
 const telemetry = useTelemetry();
 const { isCtrlKeyPressed } = useDeviceSupport();
+const { importRecording } = useBrowserRecordingHandoff();
 const setupCompletionState = computed(
 	() => appSettingsStore.moduleSettings['instance-ai']?.setupCompleted,
 );
@@ -125,6 +127,7 @@ useEventListener(document, 'keydown', (event: KeyboardEvent) => {
 // These run once when the user enters the InstanceAi feature. Route changes
 // (empty ↔ thread) don't remount the layout, so the listeners persist.
 onMounted(() => {
+	void importRecording();
 	if (showOnboarding.value && route.name !== INSTANCE_AI_VIEW) {
 		void router.replace({ name: INSTANCE_AI_VIEW });
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useBrowserRecordingHandoff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useBrowserRecordingHandoff.ts
@@ -1,0 +1,89 @@
+import { browserRecordingSchema } from '@n8n/api-types';
+import { useToast } from '@n8n/composables/useToast';
+import { useI18n } from '@n8n/i18n';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { useRoute, useRouter } from 'vue-router';
+
+import { BROWSER_USE_EXTENSION_ID, INSTANCE_AI_THREAD_VIEW } from '../constants';
+import { createThreadFromBrowserRecording } from '../instanceAi.api';
+
+const HANDOFF_QUERY = 'browserRecordingHandoff';
+
+interface ExtensionRuntime {
+	sendMessage: (
+		extensionId: string,
+		message: unknown,
+		callback: (response: unknown) => void,
+	) => void;
+	lastError?: { message?: string };
+}
+
+function getExtensionRuntime(): ExtensionRuntime | null {
+	const runtime = (globalThis as { chrome?: { runtime?: ExtensionRuntime } }).chrome?.runtime;
+	return typeof runtime?.sendMessage === 'function' ? runtime : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object';
+}
+
+async function sendToExtension(runtime: ExtensionRuntime, message: unknown): Promise<unknown> {
+	return await new Promise((resolve, reject) => {
+		runtime.sendMessage(BROWSER_USE_EXTENSION_ID, message, (response) => {
+			const error = runtime.lastError;
+			if (error) reject(new Error(error.message ?? 'Extension messaging failed'));
+			else resolve(response);
+		});
+	});
+}
+
+export function useBrowserRecordingHandoff() {
+	const route = useRoute();
+	const router = useRouter();
+	const rootStore = useRootStore();
+	const toast = useToast();
+	const i18n = useI18n();
+
+	async function importRecording(): Promise<void> {
+		const handoffId = route.query[HANDOFF_QUERY];
+		if (typeof handoffId !== 'string') return;
+
+		const query = { ...route.query };
+		delete query[HANDOFF_QUERY];
+		await router.replace({ query });
+
+		const runtime = getExtensionRuntime();
+		try {
+			if (!runtime) throw new Error('The Browser Use extension is not available');
+			const response = await sendToExtension(runtime, { type: 'getRecording', handoffId });
+			if (!isRecord(response) || response.success !== true)
+				throw new Error('Recording unavailable');
+			const parsed = browserRecordingSchema.safeParse(response.recording);
+			if (!parsed.success) throw new Error('Recording is invalid');
+
+			const result = await createThreadFromBrowserRecording(rootStore.restApiContext, parsed.data);
+			await sendToExtension(runtime, {
+				type: 'acknowledgeRecording',
+				handoffId,
+				accepted: true,
+			}).catch(() => {});
+			await router.replace({
+				name: INSTANCE_AI_THREAD_VIEW,
+				params: { threadId: result.threadId },
+			});
+		} catch (error) {
+			if (runtime) {
+				await sendToExtension(runtime, {
+					type: 'acknowledgeRecording',
+					handoffId,
+					accepted: false,
+				}).catch(() => {});
+			}
+			toast.showError(error, i18n.baseText('instanceAi.browserRecordingImport.error.title'), {
+				message: i18n.baseText('instanceAi.browserRecordingImport.error.message'),
+			});
+		}
+	}
+
+	return { importRecording };
+}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.api.ts
@@ -12,6 +12,8 @@ import type {
 	InstanceAiHandoffContext,
 	InstanceAiThreadOrigin,
 	InstanceAiThreadSource,
+	BrowserRecording,
+	InstanceAiBrowserRecordingResponse,
 } from '@n8n/api-types';
 
 export interface InstanceAiThreadLaunchInput {
@@ -206,6 +208,18 @@ export async function stopBrowserRecording(context: IRestApiContext): Promise<{ 
  */
 export async function discardBrowserRecording(context: IRestApiContext): Promise<{ ok: boolean }> {
 	return await makeRestApiRequest(context, 'POST', '/instance-ai/browser/recording/discard');
+}
+
+export async function createThreadFromBrowserRecording(
+	context: IRestApiContext,
+	recording: BrowserRecording,
+): Promise<InstanceAiBrowserRecordingResponse> {
+	return await makeRestApiRequest<InstanceAiBrowserRecordingResponse>(
+		context,
+		'POST',
+		'/instance-ai/browser/recording',
+		{ recording },
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

Allow users to record and review a browser task before they connect Browser Use.

Use the existing relay when Browser Use is connected. When it is disconnected, send the reviewed recording through an authenticated AI Assistant page handoff. Reuse open or remembered n8n instances, and ask for an instance URL when none is available.

Keep screenshots and network request capture available for disconnected recordings. Fix navigation to newly created recording threads when the frontend thread list is stale.

## How to test

1. Enable AI Assistant and Browser Use.
2. Load the unpacked Browser Use extension.
3. Disconnect Browser Use.
4. Start and stop a recording from the extension.
5. Review the recording and select **Send to AI Assistant**.
6. Verify that the extension reuses an open or remembered n8n instance.
7. Verify that the extension asks for an instance URL when no destination is known.
8. Verify that n8n opens the newly created assistant thread.
9. Connect Browser Use and repeat the recording flow.
10. Verify that the connected flow sends through the existing relay.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## 🤖 PR Summary generated by AI

- Record browser tasks without an active Browser Use connection.
- Send disconnected recordings through the authenticated AI Assistant frontend.
- Preserve direct relay submission for connected sessions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

