### PR TITLE
refactor(core): Expose the credential access check by id and narrow the global credential query (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -29,6 +29,24 @@ describe('CredentialsRepository', () => {
 		});
 	});
 
+	it('filters ids down to global project credentials', async () => {
+		entityManager.find.mockResolvedValueOnce([mock<CredentialsEntity>({ id: 'global-id' })]);
+
+		const ids = await credentialsRepository.findGlobalProjectCredentialIds(['global-id', 'other']);
+
+		expect(ids).toEqual(['global-id']);
+		expect(entityManager.find).toHaveBeenCalledWith(CredentialsEntity, {
+			where: { id: In(['global-id', 'other']), isGlobal: true, usageScope: 'project' },
+			select: ['id'],
+		});
+	});
+
+	it('does not query for an empty id list', async () => {
+		await expect(credentialsRepository.findGlobalProjectCredentialIds([])).resolves.toEqual([]);
+
+		expect(entityManager.find).not.toHaveBeenCalled();
+	});
+
 	it('finds only dangling project credentials', async () => {
 		const queryBuilder = mock<SelectQueryBuilder<CredentialsEntity>>();
 		queryBuilder.leftJoinAndSelect.mockReturnValue(queryBuilder);

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -59,6 +59,18 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 		});
 	}
 
+	/** Filters `ids` down to the global credentials, which every project can use. */
+	async findGlobalProjectCredentialIds(ids: string[]): Promise<string[]> {
+		if (ids.length === 0) return [];
+
+		const rows = await this.find({
+			where: { id: In(ids), isGlobal: true, usageScope: 'project' },
+			select: ['id'],
+		});
+
+		return rows.map((row) => row.id);
+	}
+
 	async findDanglingProjectCredentials(): Promise<CredentialsEntity[]> {
 		return await this.createQueryBuilder('credentials')
 			.leftJoinAndSelect('credentials.shared', 'shared')

--- a/packages/cli/src/executions/pre-execution-checks/__tests__/credentials-permission-checker.test.ts
+++ b/packages/cli/src/executions/pre-execution-checks/__tests__/credentials-permission-checker.test.ts
@@ -1,9 +1,9 @@
 import {
 	type Project,
 	type User,
+	type CredentialsEntity,
 	type SharedCredentialsRepository,
 	type CredentialsRepository,
-	type CredentialsEntity,
 	type UserRepository,
 	GLOBAL_OWNER_ROLE,
 	GLOBAL_MEMBER_ROLE,
@@ -61,7 +61,7 @@ describe('CredentialsPermissionChecker', () => {
 		node.credentials!.someCredential.id = credentialId;
 		ownershipService.getWorkflowProjectCached.mockResolvedValueOnce(personalProject);
 		projectService.findProjectsWorkflowIsIn.mockResolvedValueOnce([personalProject.id]);
-		credentialsRepository.find.mockResolvedValue([]);
+		credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValue([]);
 		credentialsRepository.findNonProjectCredentialsByIds.mockResolvedValue([]);
 	});
 
@@ -80,7 +80,7 @@ describe('CredentialsPermissionChecker', () => {
 		// AI Gateway managed credentials intentionally have id: null and must be skipped.
 		ownershipService.getPersonalProjectOwnerCached.mockResolvedValueOnce(null);
 		sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValueOnce([]);
-		credentialsRepository.find.mockResolvedValueOnce([]);
+		credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValueOnce([]);
 
 		const managedNode = mock<INode>({
 			name: 'AI Node',
@@ -94,7 +94,7 @@ describe('CredentialsPermissionChecker', () => {
 	it('should throw if a credential is not accessible', async () => {
 		ownershipService.getPersonalProjectOwnerCached.mockResolvedValueOnce(null);
 		sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValueOnce([]);
-		credentialsRepository.find.mockResolvedValueOnce([]);
+		credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValueOnce([]);
 
 		await expect(permissionChecker.check(workflowId, [node])).rejects.toThrow(
 			'Node "Test Node" does not have access to the credential',
@@ -118,7 +118,7 @@ describe('CredentialsPermissionChecker', () => {
 		sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValueOnce([
 			credentialId,
 		]);
-		credentialsRepository.find.mockResolvedValueOnce([]);
+		credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValueOnce([]);
 
 		await expect(permissionChecker.check(workflowId, [node])).resolves.not.toThrow();
 
@@ -127,6 +127,36 @@ describe('CredentialsPermissionChecker', () => {
 			[personalProject.id],
 			[credentialId],
 		);
+	});
+
+	describe('findInaccessible', () => {
+		it('returns every inaccessible id in the order given', async () => {
+			ownershipService.getPersonalProjectOwnerCached.mockResolvedValueOnce(null);
+			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValueOnce(['b']);
+			credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValueOnce(['d']);
+
+			const result = await permissionChecker.findInaccessible(workflowId, ['a', 'b', 'c', 'd']);
+
+			expect(result).toEqual({ homeProject: personalProject, inaccessibleIds: ['a', 'c'] });
+			expect(credentialsRepository.findGlobalProjectCredentialIds).toHaveBeenCalledWith([
+				'a',
+				'b',
+				'c',
+				'd',
+			]);
+		});
+
+		it('returns only the non-project credentials when there are any', async () => {
+			credentialsRepository.findNonProjectCredentialsByIds.mockResolvedValue([
+				mock<CredentialsEntity>({ id: 'b' }),
+			]);
+
+			const result = await permissionChecker.findInaccessible(workflowId, ['a', 'b']);
+
+			expect(result.inaccessibleIds).toEqual(['b']);
+			// Decided before any sharing is read.
+			expect(sharedCredentialsRepository.getFilteredAccessibleCredentials).not.toHaveBeenCalled();
+		});
 	});
 
 	it('should skip credential checks if the home project owner has global scope', async () => {
@@ -178,11 +208,7 @@ describe('CredentialsPermissionChecker', () => {
 	it('should allow global credentials for any project', async () => {
 		ownershipService.getPersonalProjectOwnerCached.mockResolvedValueOnce(null);
 		sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValueOnce([]);
-		const globalCredential = mock<CredentialsEntity>({
-			id: credentialId,
-			isGlobal: true,
-		});
-		credentialsRepository.find.mockResolvedValueOnce([globalCredential]);
+		credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValueOnce([credentialId]);
 
 		await expect(permissionChecker.check(workflowId, [node])).resolves.not.toThrow();
 
@@ -191,13 +217,9 @@ describe('CredentialsPermissionChecker', () => {
 			[personalProject.id],
 			[credentialId],
 		);
-		expect(credentialsRepository.find).toHaveBeenCalledWith({
-			select: ['id'],
-			where: {
-				isGlobal: true,
-				usageScope: 'project',
-			},
-		});
+		expect(credentialsRepository.findGlobalProjectCredentialIds).toHaveBeenCalledWith([
+			credentialId,
+		]);
 	});
 
 	it('should allow global credentials for team projects', async () => {
@@ -213,11 +235,7 @@ describe('CredentialsPermissionChecker', () => {
 		ownershipService.getPersonalProjectOwnerCached.mockResolvedValue(null);
 		sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([]);
 		credentialsRepository.findNonProjectCredentialsByIds.mockResolvedValue([]);
-		const globalCredential = mock<CredentialsEntity>({
-			id: credentialId,
-			isGlobal: true,
-		});
-		credentialsRepository.find.mockResolvedValueOnce([globalCredential]);
+		credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValueOnce([credentialId]);
 
 		await expect(permissionChecker.check(workflowId, [node])).resolves.not.toThrow();
 
@@ -226,13 +244,9 @@ describe('CredentialsPermissionChecker', () => {
 			[teamProject.id],
 			[credentialId],
 		);
-		expect(credentialsRepository.find).toHaveBeenCalledWith({
-			select: ['id'],
-			where: {
-				isGlobal: true,
-				usageScope: 'project',
-			},
-		});
+		expect(credentialsRepository.findGlobalProjectCredentialIds).toHaveBeenCalledWith([
+			credentialId,
+		]);
 	});
 
 	describe('credential type filtering', () => {
@@ -292,7 +306,7 @@ describe('CredentialsPermissionChecker', () => {
 			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([
 				activeCredentialId,
 			]);
-			credentialsRepository.find.mockResolvedValue([]);
+			credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValue([]);
 
 			await expect(permissionChecker.check(workflowId, [httpRequestNode])).resolves.not.toThrow();
 
@@ -336,7 +350,7 @@ describe('CredentialsPermissionChecker', () => {
 			} as never);
 
 			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([]);
-			credentialsRepository.find.mockResolvedValue([]);
+			credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValue([]);
 
 			await expect(
 				permissionChecker.check(workflowId, [httpRequestNodeWithGenericAuth]),
@@ -375,7 +389,7 @@ describe('CredentialsPermissionChecker', () => {
 			} as never);
 
 			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([]);
-			credentialsRepository.find.mockResolvedValue([]);
+			credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValue([]);
 
 			await expect(
 				permissionChecker.check(workflowId, [httpRequestNodeWithExpressionAuth]),
@@ -413,7 +427,7 @@ describe('CredentialsPermissionChecker', () => {
 			} as never);
 
 			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([]);
-			credentialsRepository.find.mockResolvedValue([]);
+			credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValue([]);
 
 			await expect(
 				permissionChecker.check(workflowId, [httpRequestNodeWithExpressionAuth]),
@@ -469,7 +483,7 @@ describe('CredentialsPermissionChecker', () => {
 
 			beforeEach(() => {
 				nodeTypes.getByNameAndVersion.mockReturnValue({ description } as never);
-				credentialsRepository.find.mockResolvedValue([]);
+				credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValue([]);
 			});
 
 			it('should not check a credential whose selector parameter is hidden', async () => {
@@ -559,7 +573,7 @@ describe('CredentialsPermissionChecker', () => {
 				activeCredentialId,
 				staleCredentialId,
 			]);
-			credentialsRepository.find.mockResolvedValue([]);
+			credentialsRepository.findGlobalProjectCredentialIds.mockResolvedValue([]);
 
 			await expect(permissionChecker.check(workflowId, [httpRequestNode])).resolves.not.toThrow();
 

--- a/packages/cli/src/executions/pre-execution-checks/credentials-permission-checker.ts
+++ b/packages/cli/src/executions/pre-execution-checks/credentials-permission-checker.ts
@@ -100,14 +100,39 @@ export class CredentialsPermissionChecker {
 	 * Check if a workflow has the ability to execute based on the projects it's apart of.
 	 */
 	async check(workflowId: string, nodes: INode[]) {
-		const homeProject = await this.ownershipService.getWorkflowProjectCached(workflowId);
 		const credIdsToNodes = this.mapCredIdsToNodes(nodes);
 
 		const workflowCredIds = Object.keys(credIdsToNodes);
 
 		if (workflowCredIds.length === 0) return;
 
-		await this.ensureOnlyWorkflowCredentials(workflowCredIds, credIdsToNodes, homeProject);
+		const { homeProject, inaccessibleIds } = await this.findInaccessible(
+			workflowId,
+			workflowCredIds,
+		);
+
+		if (inaccessibleIds.length > 0) {
+			const nodeToFlag = credIdsToNodes[inaccessibleIds[0]][0];
+			throw new InaccessibleCredentialError(nodeToFlag, homeProject);
+		}
+	}
+
+	/**
+	 * The credentials among `credentialIds` that the workflow's projects cannot
+	 * use, in the order the check finds them. The same rule as `check`, for a
+	 * caller that has credential ids but no nodes.
+	 */
+	async findInaccessible(
+		workflowId: string,
+		credentialIds: string[],
+	): Promise<{ homeProject: Project; inaccessibleIds: string[] }> {
+		const homeProject = await this.ownershipService.getWorkflowProjectCached(workflowId);
+
+		const unavailableCredentials =
+			await this.credentialsRepository.findNonProjectCredentialsByIds(credentialIds);
+		if (unavailableCredentials.length > 0) {
+			return { homeProject, inaccessibleIds: unavailableCredentials.map((c) => c.id) };
+		}
 
 		const homeProjectOwner = await this.ownershipService.getPersonalProjectOwnerCached(
 			homeProject.id,
@@ -119,53 +144,23 @@ export class CredentialsPermissionChecker {
 		) {
 			// Workflow belongs to a project by a user with privileges
 			// so all credentials are usable. Skip credential checks.
-			return;
+			return { homeProject, inaccessibleIds: [] };
 		}
 		const projectIds = await this.projectService.findProjectsWorkflowIsIn(workflowId);
 
 		const accessible = await this.sharedCredentialsRepository.getFilteredAccessibleCredentials(
 			projectIds,
-			workflowCredIds,
+			credentialIds,
 		);
 
-		const accessibleSet = await this.addGlobalCredentialsToAccessibleSet(accessible);
+		// Global credentials are usable by every project.
+		const global = await this.credentialsRepository.findGlobalProjectCredentialIds(credentialIds);
+		const accessibleSet = new Set([...accessible, ...global]);
 
-		for (const credentialsId of workflowCredIds) {
-			if (!accessibleSet.has(credentialsId)) {
-				const nodeToFlag = credIdsToNodes[credentialsId][0];
-				throw new InaccessibleCredentialError(nodeToFlag, homeProject);
-			}
-		}
-	}
-
-	private async ensureOnlyWorkflowCredentials(
-		workflowCredIds: string[],
-		credIdsToNodes: { [credentialId: string]: INode[] },
-		homeProject: Project,
-	) {
-		const unavailableCredentials =
-			await this.credentialsRepository.findNonProjectCredentialsByIds(workflowCredIds);
-		if (unavailableCredentials.length > 0) {
-			const nodeToFlag = credIdsToNodes[unavailableCredentials[0].id][0];
-			throw new InaccessibleCredentialError(nodeToFlag, homeProject);
-		}
-	}
-
-	/**
-	 * Adds global credentials (isGlobal: true) to the set of accessible credentials.
-	 */
-	private async addGlobalCredentialsToAccessibleSet(
-		accessibleCredentialIds: string[],
-	): Promise<Set<string>> {
-		const accessibleSet = new Set(accessibleCredentialIds);
-		const globalCredentials = await this.credentialsRepository.find({
-			where: { isGlobal: true, usageScope: 'project' },
-			select: ['id'],
-		});
-		for (const globalCred of globalCredentials) {
-			accessibleSet.add(globalCred.id);
-		}
-		return accessibleSet;
+		return {
+			homeProject,
+			inaccessibleIds: credentialIds.filter((id) => !accessibleSet.has(id)),
+		};
 	}
 
 	private mapCredIdsToNodes(nodes: INode[]) {


### PR DESCRIPTION
## Summary

Stacked on #38123. Preparation for the Engine 2.0 credential resolve route (#38218).

`CredentialsPermissionChecker.check` has been split in two. The part that maps nodes to credential ids and raises the node-specific error stays in `check`. The part that decides which of those ids the workflow's projects can use has moved into a new public method, `findInaccessible(workflowId, credentialIds)`, which `check` now calls. A caller that has credential ids but no nodes can call `findInaccessible` directly.

Along the way, the global credential lookup inside that logic has been narrowed. It used to load every global credential and then test membership. It now calls a new repository method, `CredentialsRepository.findGlobalProjectCredentialIds(ids)`, which returns only the global credentials among the ids under check.

## Why

The resolve route receives a credential id and has to answer one question: is this credential shared with one of the workflow's projects? The existing `check` method answers that question for a whole workflow, but it needs the workflow's nodes as input. The route has no nodes. Keeping `check` unchanged would require a workaround: build a node object from the request and pass it to `check`. That is unsafe because `check` reads the node's parameters to decide which of the node's credentials are in use, and it runs the database lookup that decides access to credentials only for those. A node with empty parameters could make `check` classify the credential as "not in use". `check` then would return without running that lookup, and the route would treat the credential as accessible. The other option, writing the same query again in the route, would leave two copies of the access rule that must be kept in sync by hand. So the part of `check` that works on ids is now a public method, and both `check` and the route call it.

The access rule is unchanged. The global credential lookup was a full table scan on the start of every execution that uses credentials. It is now filtered by the ids under check, which matters once the route runs it once per credential fetch.

## How to test

```
pnpm --filter n8n test src/executions/pre-execution-checks
pnpm --filter @n8n/db test src/repositories/__tests__/credentials.repository.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2926

## Review / Merge checklist

- [x] PR title and summary are descriptive. (conventions)
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

