### PR TITLE
fix(core): Keep node settings, positions and error routes through an assistant workflow edit

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -921,6 +921,13 @@ isImportant.onFalse(sendHolding);
 For Switch, wire cases the same way — `.to(switchNode).onCase(0, a).onCase(1, b)`
 or inline — using zero-based `.onCase(index, target)` for each rule output.
 
+Error routes work the same way on any node: `.to(fetchNode).onError(notify)`
+routes the error output and leaves the cursor on `fetchNode`, so a following
+`.to(next)` continues the main branch and a second `.onError()` adds another
+handler. The inline form `.to(fetchNode.onError(notify))` is equivalent. Both
+forms set `onError: 'continueErrorOutput'` on the node for you. Call
+`.onError()` once for each handler — it takes one handler, not an array.
+
 For Split in Batches, use it for per-item side effects and loop back with
 `nextBatch`. Do not add a separate IF gate just to check whether items exist.
 
@@ -938,8 +945,9 @@ For AI Agent workflows:
 - `placeholder('hint')`: marks a parameter value for user input (use directly as
   the parameter value; `workflow-sdk validate` flags wrapping it in `expr()`).
 - `.output(n)`: selects a zero-based output index.
-- `.onError(handler)`: connects a node's error output to a handler. Requires
-  `onError: 'continueErrorOutput'` in the node config.
+- `.onError(handler)`: connects a node's error output to a handler, on the node
+  or on the workflow builder. It sets `onError: 'continueErrorOutput'` on the
+  node, so you do not declare that in the config.
 - `nodeJson(node, 'field.path')`: creates an explicit expression reference to a
   specific node's JSON output.
 - Subnode factories follow the same pattern as `languageModel()` and `tool()`:

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
@@ -354,6 +354,47 @@ describe('compileWorkflowSource > node positions in JSON sources', () => {
 		}
 	});
 
+	it('replaces a malformed position instead of padding it', async () => {
+		// The builder treats any present position as explicit, so `[100]` survives its layout.
+		// Left alone it reaches the save as `[100, undefined]`.
+		const workflow = {
+			name: 'Malformed',
+			nodes: [
+				{
+					id: 'trigger-1',
+					name: 'Every Hour',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1.2,
+					position: [100],
+					parameters: {},
+				},
+				{
+					id: 'http-1',
+					name: 'Fetch',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 4.2,
+					position: ['200', 0],
+					parameters: { url: 'https://example.com' },
+				},
+			],
+			connections: {
+				'Every Hour': { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] },
+			},
+		};
+
+		const result = await compileWorkflowSource(
+			makeContext(),
+			'src/workflows/malformed.workflow.json',
+			JSON.stringify(workflow),
+		);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		for (const node of result.workflow.nodes) {
+			expect(node.position).toEqual([expect.any(Number), expect.any(Number)]);
+		}
+	});
+
 	it('leaves positions the JSON already declares untouched', async () => {
 		const workflow = {
 			name: 'Positioned',

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
@@ -9,7 +9,9 @@ vi.mock('@n8n/agents/sandbox', () => ({
 	getWorkspaceRoot: vi.fn(async () => await Promise.resolve('/home/daytona/workspace')),
 }));
 
-vi.mock('@n8n/workflow-sdk', () => ({
+// Keep the real builder: the JSON path borrows its layout to fill missing node positions.
+vi.mock('@n8n/workflow-sdk', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@n8n/workflow-sdk')>()),
 	validateWorkflow: vi.fn(() => ({ errors: [], warnings: [] })),
 }));
 
@@ -295,6 +297,99 @@ describe('compileWorkflowSource', () => {
 			cwd: '/home/daytona/workspace',
 			abortSignal: controller.signal,
 		});
+	});
+});
+
+describe('compileWorkflowSource > node positions in JSON sources', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(validateWorkflow).mockReturnValue({ valid: true, errors: [], warnings: [] });
+	});
+
+	// INS-1314 defect 3: the agent fell back to a hand-written .json file, whose nodes had no
+	// position. The SDK source path lays nodes out on serialize; the JSON path did not, so the
+	// save rejected every node with `nodes[N].position (invalid_type): Required`.
+	it('gives every node a position when the JSON declares none', async () => {
+		const workflow = {
+			name: 'CRM Motor',
+			nodes: [
+				{
+					id: 'trigger-1',
+					name: 'Every Hour',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1.2,
+					parameters: {},
+				},
+				{
+					id: 'http-1',
+					name: 'Fetch',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 4.2,
+					parameters: { url: 'https://example.com' },
+				},
+				{
+					id: 'code-1',
+					name: 'Compute',
+					type: 'n8n-nodes-base.code',
+					typeVersion: 2,
+					parameters: {},
+				},
+			],
+			connections: {
+				'Every Hour': { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] },
+				Fetch: { main: [[{ node: 'Compute', type: 'main', index: 0 }]] },
+			},
+		};
+
+		const result = await compileWorkflowSource(
+			makeContext(),
+			'src/workflows/crm-motor.workflow.json',
+			JSON.stringify(workflow),
+		);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		for (const node of result.workflow.nodes) {
+			expect(node.position).toEqual([expect.any(Number), expect.any(Number)]);
+		}
+	});
+
+	it('leaves positions the JSON already declares untouched', async () => {
+		const workflow = {
+			name: 'Positioned',
+			nodes: [
+				{
+					id: 'trigger-1',
+					name: 'Every Hour',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1.2,
+					position: [-420, 96] as [number, number],
+					parameters: {},
+				},
+				{
+					id: 'http-1',
+					name: 'Fetch',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 4.2,
+					parameters: { url: 'https://example.com' },
+				},
+			],
+			connections: {
+				'Every Hour': { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] },
+			},
+		};
+
+		const result = await compileWorkflowSource(
+			makeContext(),
+			'src/workflows/positioned.workflow.json',
+			JSON.stringify(workflow),
+		);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		const [trigger, fetch] = result.workflow.nodes;
+		expect(trigger.position).toEqual([-420, 96]);
+		expect(fetch.position).toEqual([expect.any(Number), expect.any(Number)]);
 	});
 });
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
@@ -1,5 +1,5 @@
 import { getWorkspaceRoot } from '@n8n/agents/sandbox';
-import { validateWorkflow } from '@n8n/workflow-sdk';
+import { validateWorkflow, workflow as workflowBuilder } from '@n8n/workflow-sdk';
 
 import type { InstanceAiContext } from '../../../types';
 import { runInSandbox } from '../../../workspace/sandbox-fs';
@@ -431,6 +431,41 @@ describe('compileWorkflowSource > node positions in JSON sources', () => {
 		const [trigger, fetch] = result.workflow.nodes;
 		expect(trigger.position).toEqual([-420, 96]);
 		expect(fetch.position).toEqual([expect.any(Number), expect.any(Number)]);
+	});
+
+	it('still gives every node a position when the builder cannot lay the workflow out', async () => {
+		// The builder can reject a workflow the save would accept. Without a fallback the
+		// node reached the save positionless and failed there for the wrong reason.
+		const layout = vi.spyOn(workflowBuilder, 'fromJSON').mockImplementation(() => {
+			throw new Error('cannot import this workflow');
+		});
+		const workflow = {
+			name: 'Unlayoutable',
+			nodes: [
+				{
+					id: 'trigger-1',
+					name: 'Every Hour',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1.2,
+					parameters: {},
+				},
+			],
+			connections: {},
+		};
+
+		try {
+			const result = await compileWorkflowSource(
+				makeContext(),
+				'src/workflows/unlayoutable.workflow.json',
+				JSON.stringify(workflow),
+			);
+
+			expect(result.success).toBe(true);
+			if (!result.success) return;
+			expect(result.workflow.nodes[0].position).toEqual([expect.any(Number), expect.any(Number)]);
+		} finally {
+			layout.mockRestore();
+		}
 	});
 });
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
@@ -138,6 +138,7 @@ function parseWorkflowJsonSource(source: string): WorkflowSourceCompileResult {
  * The SDK source path lays nodes out when the builder serializes, but hand-written JSON
  * never passes through the builder. A node without a position fails the save, so borrow
  * the builder's layout for the nodes that lack one and leave the rest of the JSON alone.
+ * Every such node leaves here with a position, even when the layout has none to lend.
  */
 function fillMissingNodePositions(json: WorkflowJSON): void {
 	const needsPosition = (node: WorkflowJSON['nodes'][number]) =>
@@ -157,29 +158,31 @@ function fillMissingNodePositions(json: WorkflowJSON): void {
 		return withoutPosition as WorkflowJSON['nodes'][number];
 	});
 
-	let laidOut: WorkflowJSON;
+	// A layout is a nicety, not the point: fall back to a row so the save never fails on a
+	// missing position. The builder can throw on a workflow the save would still accept,
+	// and it does not have to emit every node it was given.
+	let laidOut: WorkflowJSON | undefined;
 	try {
 		laidOut = workflowBuilder.fromJSON({ ...json, nodes: layoutNodes }).toJSON();
 	} catch {
-		// Leave the JSON as it is. The save reports what is wrong with it.
-		return;
+		laidOut = undefined;
 	}
 
 	const positionsById = new Map<string, [number, number]>();
 	const positionsByName = new Map<string, [number, number]>();
-	for (const node of laidOut.nodes ?? []) {
+	for (const node of laidOut?.nodes ?? []) {
 		if (needsPosition(node)) continue;
 		if (node.id) positionsById.set(node.id, node.position);
 		if (node.name) positionsByName.set(node.name, node.position);
 	}
 
-	for (const node of json.nodes) {
-		if (!needsPosition(node)) continue;
+	json.nodes.forEach((node, index) => {
+		if (!needsPosition(node)) return;
 		const position =
 			(node.id ? positionsById.get(node.id) : undefined) ??
 			(node.name ? positionsByName.get(node.name) : undefined);
-		if (position) node.position = [position[0], position[1]];
-	}
+		node.position = position ? [position[0], position[1]] : [index * 200, 0];
+	});
 }
 
 function parseSandboxWarnings(value: unknown): ValidationWarning[] {

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
@@ -147,9 +147,19 @@ function fillMissingNodePositions(json: WorkflowJSON): void {
 
 	if (!json.nodes?.some(needsPosition)) return;
 
+	// The builder treats any present position as explicit, so a malformed one such as
+	// `[100]` survives the layout and would reach the save as `[100, undefined]`. Drop it
+	// first. The declared type says `position` is always a valid pair, but this JSON is
+	// written by hand, so it can be absent or malformed.
+	const layoutNodes = json.nodes.map((node) => {
+		if (!needsPosition(node)) return node;
+		const { position: _malformed, ...withoutPosition } = node;
+		return withoutPosition as WorkflowJSON['nodes'][number];
+	});
+
 	let laidOut: WorkflowJSON;
 	try {
-		laidOut = workflowBuilder.fromJSON(json).toJSON();
+		laidOut = workflowBuilder.fromJSON({ ...json, nodes: layoutNodes }).toJSON();
 	} catch {
 		// Leave the JSON as it is. The save reports what is wrong with it.
 		return;
@@ -158,7 +168,7 @@ function fillMissingNodePositions(json: WorkflowJSON): void {
 	const positionsById = new Map<string, [number, number]>();
 	const positionsByName = new Map<string, [number, number]>();
 	for (const node of laidOut.nodes ?? []) {
-		if (!Array.isArray(node.position)) continue;
+		if (needsPosition(node)) continue;
 		if (node.id) positionsById.set(node.id, node.position);
 		if (node.name) positionsByName.set(node.name, node.position);
 	}

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
@@ -1,7 +1,11 @@
 import { createAbortError, isAbortError } from '@n8n/agents';
 import { getWorkspaceRoot } from '@n8n/agents/sandbox';
 import { isRecord } from '@n8n/utils/is-record';
-import { validateWorkflow, type WorkflowJSON } from '@n8n/workflow-sdk';
+import {
+	validateWorkflow,
+	workflow as workflowBuilder,
+	type WorkflowJSON,
+} from '@n8n/workflow-sdk';
 import { normalizeNodeShape } from 'n8n-workflow';
 
 import { buildCredentialHostIndex, resolveCredentialByUrl } from './credential-url-resolver';
@@ -125,7 +129,47 @@ function parseWorkflowJsonSource(source: string): WorkflowSourceCompileResult {
 		};
 	}
 
+	fillMissingNodePositions(parsed);
+
 	return { success: true, workflow: parsed, warnings: [], compiler: 'workflow-json' };
+}
+
+/**
+ * The SDK source path lays nodes out when the builder serializes, but hand-written JSON
+ * never passes through the builder. A node without a position fails the save, so borrow
+ * the builder's layout for the nodes that lack one and leave the rest of the JSON alone.
+ */
+function fillMissingNodePositions(json: WorkflowJSON): void {
+	const needsPosition = (node: WorkflowJSON['nodes'][number]) =>
+		!Array.isArray(node.position) ||
+		node.position.length !== 2 ||
+		!node.position.every((coordinate) => typeof coordinate === 'number');
+
+	if (!json.nodes?.some(needsPosition)) return;
+
+	let laidOut: WorkflowJSON;
+	try {
+		laidOut = workflowBuilder.fromJSON(json).toJSON();
+	} catch {
+		// Leave the JSON as it is. The save reports what is wrong with it.
+		return;
+	}
+
+	const positionsById = new Map<string, [number, number]>();
+	const positionsByName = new Map<string, [number, number]>();
+	for (const node of laidOut.nodes ?? []) {
+		if (!Array.isArray(node.position)) continue;
+		if (node.id) positionsById.set(node.id, node.position);
+		if (node.name) positionsByName.set(node.name, node.position);
+	}
+
+	for (const node of json.nodes) {
+		if (!needsPosition(node)) continue;
+		const position =
+			(node.id ? positionsById.get(node.id) : undefined) ??
+			(node.name ? positionsByName.get(node.name) : undefined);
+		if (position) node.position = [position[0], position[1]];
+	}
 }
 
 function parseSandboxWarnings(value: unknown): ValidationWarning[] {

--- a/packages/@n8n/workflow-sdk/src/codegen/code-generator.ts
+++ b/packages/@n8n/workflow-sdk/src/codegen/code-generator.ts
@@ -294,6 +294,9 @@ function appendNodeConfigOptions(configParts: string[], node: SemanticNode): voi
 	if (node.json.extendsCredential) {
 		configParts.push(`extendsCredential: '${escapeString(node.json.extendsCredential)}'`);
 	}
+	if (node.json.customTelemetryTags?.tag?.length) {
+		configParts.push(`customTelemetryTags: ${formatValue(node.json.customTelemetryTags)}`);
+	}
 }
 
 /**

--- a/packages/@n8n/workflow-sdk/src/codegen/codegen-roundtrip.test.ts
+++ b/packages/@n8n/workflow-sdk/src/codegen/codegen-roundtrip.test.ts
@@ -206,6 +206,12 @@ describe('parseWorkflowCode', () => {
 					notesInFlow: true,
 					notes: 'Keep execution settings',
 					extendsCredential: 'notionApi',
+					customTelemetryTags: {
+						tag: [
+							{ key: 'team', value: 'growth' },
+							{ key: "owner's rota", value: 'week — 42' },
+						],
+					},
 				},
 				{
 					id: 'success-id',
@@ -256,6 +262,12 @@ describe('parseWorkflowCode', () => {
 				notesInFlow: true,
 				notes: 'Keep execution settings',
 				extendsCredential: 'notionApi',
+				customTelemetryTags: {
+					tag: [
+						{ key: 'team', value: 'growth' },
+						{ key: "owner's rota", value: 'week — 42' },
+					],
+				},
 			}),
 		);
 	});

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -87,6 +87,11 @@ export interface NewCredentialValue {
  */
 export type OnError = 'stopWorkflow' | 'continueRegularOutput' | 'continueErrorOutput';
 
+/** Custom OpenTelemetry span attributes, set for each node in the node's Settings tab. */
+export interface CustomTelemetryTags {
+	tag?: Array<{ key: string; value: string }>;
+}
+
 // =============================================================================
 // Workflow Settings (with extensibility)
 // =============================================================================
@@ -323,6 +328,7 @@ export interface NodeJSON {
 	alwaysOutputData?: boolean;
 	onError?: OnError;
 	extendsCredential?: string;
+	customTelemetryTags?: CustomTelemetryTags;
 }
 
 /**
@@ -462,6 +468,7 @@ export interface NodeConfig<TParams = IDataObject> {
 	alwaysOutputData?: boolean;
 	onError?: OnError;
 	extendsCredential?: string;
+	customTelemetryTags?: CustomTelemetryTags;
 	pinData?: IDataObject[];
 	/**
 	 * Declared output shape for data flow validation.

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -1125,6 +1125,13 @@ export interface WorkflowBuilder {
 	 * `.to(switchNode).onCase(0, a).onCase(1, b)`. Throws if the current node is not a Switch.
 	 */
 	onCase(index: number, target: SwitchCaseTarget): WorkflowBuilder;
+	/**
+	 * Route the error output of the node the cursor is on to `handler`, e.g.
+	 * `.to(httpNode).onError(notifyFailure).to(next)`. The cursor stays on that node,
+	 * so a following `.to()` continues the main branch. Equivalent to
+	 * `.to(httpNode.onError(notifyFailure))`.
+	 */
+	onError(handler: NodeInstance<string, string, unknown> | InputTarget): WorkflowBuilder;
 
 	settings(settings: WorkflowSettings): WorkflowBuilder;
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -862,6 +862,131 @@ describe('Workflow Builder', () => {
 		});
 	});
 
+	describe('WorkflowBuilder.onError()', () => {
+		// INS-1314 defect 4: `.add(a).to(b).onError(h)` threw
+		// "...to(...).onError is not a function". `.onError()` existed on the node and on
+		// the chain, but not on the workflow builder that `.to()` returns.
+		const buildRetryFlow = () => {
+			const schedule = trigger({
+				type: 'n8n-nodes-base.scheduleTrigger',
+				version: 1.2,
+				config: { name: 'Every Hour' },
+			});
+			const loadUniverse = node({
+				type: 'n8n-nodes-base.dataTable',
+				version: 1.1,
+				config: { name: 'Load Universe' },
+			});
+			const fetchPositions = node({
+				type: 'n8n-nodes-base.httpRequest',
+				version: 4.2,
+				config: { name: 'Fetch Positions' },
+			});
+			const sendFetchFailure = node({
+				type: 'n8n-nodes-base.slack',
+				version: 2.3,
+				config: { name: 'Send Fetch Failure' },
+			});
+			const compute = node({
+				type: 'n8n-nodes-base.code',
+				version: 2,
+				config: { name: 'Compute' },
+			});
+			return { schedule, loadUniverse, fetchPositions, sendFetchFailure, compute };
+		};
+
+		it('routes the error output of the node the cursor is on', () => {
+			const { schedule, loadUniverse, fetchPositions, sendFetchFailure, compute } =
+				buildRetryFlow();
+
+			const json = workflow('test-id', 'Test')
+				.add(schedule)
+				.to(loadUniverse)
+				.to(fetchPositions)
+				.onError(sendFetchFailure)
+				.to(compute)
+				.toJSON();
+
+			expect(json.nodes.map((n) => n.name)).toEqual([
+				'Every Hour',
+				'Load Universe',
+				'Fetch Positions',
+				'Send Fetch Failure',
+				'Compute',
+			]);
+			// Main output continues the flow; the error pin carries the handler.
+			expect(json.connections['Fetch Positions']?.main[0]?.[0]?.node).toBe('Compute');
+			expect(json.connections['Fetch Positions']?.main[1]?.[0]?.node).toBe('Send Fetch Failure');
+			// The handler is a leaf, not the source of the continuation.
+			expect(json.connections['Send Fetch Failure']).toBeUndefined();
+		});
+
+		it('turns on the error output port of the node it attaches to', () => {
+			const { schedule, fetchPositions, sendFetchFailure } = buildRetryFlow();
+
+			const json = workflow('test-id', 'Test')
+				.add(schedule)
+				.to(fetchPositions)
+				.onError(sendFetchFailure)
+				.toJSON();
+
+			expect(json.nodes.find((n) => n.name === 'Fetch Positions')?.onError).toBe(
+				'continueErrorOutput',
+			);
+		});
+
+		it('matches wiring the same error route on the node itself', () => {
+			const viaBuilder = buildRetryFlow();
+			const viaNode = buildRetryFlow();
+
+			const fromBuilder = workflow('test-id', 'Test')
+				.add(viaBuilder.schedule)
+				.to(viaBuilder.fetchPositions)
+				.onError(viaBuilder.sendFetchFailure)
+				.to(viaBuilder.compute)
+				.toJSON();
+
+			const fromNode = workflow('test-id', 'Test')
+				.add(viaNode.schedule)
+				.to(viaNode.fetchPositions.onError(viaNode.sendFetchFailure))
+				.to(viaNode.compute)
+				.toJSON();
+
+			expect(fromBuilder.connections).toEqual(fromNode.connections);
+		});
+
+		it('keeps the cursor on the source node so sibling routes stack', () => {
+			const { schedule, fetchPositions, sendFetchFailure, compute } = buildRetryFlow();
+			const auditFailure = node({
+				type: 'n8n-nodes-base.dataTable',
+				version: 1.1,
+				config: { name: 'Audit Failure' },
+			});
+
+			const json = workflow('test-id', 'Test')
+				.add(schedule)
+				.to(fetchPositions)
+				.onError(sendFetchFailure)
+				.onError(auditFailure)
+				.to(compute)
+				.toJSON();
+
+			expect(json.connections['Fetch Positions']?.main[1]?.map((c) => c.node)).toEqual([
+				'Send Fetch Failure',
+				'Audit Failure',
+			]);
+			expect(json.connections['Fetch Positions']?.main[0]?.[0]?.node).toBe('Compute');
+		});
+
+		it('explains itself when there is no node to attach to', () => {
+			const { sendFetchFailure } = buildRetryFlow();
+
+			expect(() => workflow('test-id', 'Test').onError(sendFetchFailure)).toThrow(
+				'.onError() must follow adding a node',
+			);
+		});
+	});
+
 	describe('.settings()', () => {
 		it('should update workflow settings', () => {
 			const wf = workflow('test-id', 'Test Workflow').settings({

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -1100,6 +1100,20 @@ describe('Workflow Builder', () => {
 			expect(json.connections.Escalate).toBeUndefined();
 		});
 
+		// An array target has no name for the graph to resolve, so both handlers used to
+		// vanish: no connection, no node, no complaint.
+		it('explains itself when handed an array of handlers', () => {
+			const { schedule, fetchPositions, sendFetchFailure, compute } = buildRetryFlow();
+			const build = () =>
+				workflow('test-id', 'Test')
+					.add(schedule)
+					.to(fetchPositions)
+					.onError([sendFetchFailure, compute] as never);
+
+			expect(build).toThrow('.onError() takes one handler, not an array');
+			expect(build).toThrow('.onError(notify).onError(logFailure)');
+		});
+
 		it('explains itself when there is no node to attach to', () => {
 			const { sendFetchFailure } = buildRetryFlow();
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -978,6 +978,46 @@ describe('Workflow Builder', () => {
 			expect(json.connections['Fetch Positions']?.main[0]?.[0]?.node).toBe('Compute');
 		});
 
+		it('routes the error output of an imported node, which declares no connections itself', () => {
+			// A node handle from fromJSON() throws on every connection method by design, so
+			// the builder has to wire this route into the graph itself.
+			const imported: WorkflowJSON = {
+				id: 'test-id',
+				name: 'Imported',
+				nodes: [
+					{
+						id: 't',
+						name: 'Start',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+						parameters: {},
+					},
+					{
+						id: 'h',
+						name: 'Fetch',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						position: [200, 0],
+						parameters: {},
+					},
+				],
+				connections: { Start: { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] } },
+			};
+			const notify = node({
+				type: 'n8n-nodes-base.slack',
+				version: 2.3,
+				config: { name: 'Notify' },
+			});
+
+			const json = workflow.fromJSON(imported).onError(notify).toJSON();
+
+			// fromJSON leaves the cursor on the last imported node.
+			expect(json.connections.Fetch?.main[1]?.[0]?.node).toBe('Notify');
+			expect(json.nodes.find((n) => n.name === 'Fetch')?.onError).toBe('continueErrorOutput');
+			expect(json.nodes.map((n) => n.name)).toContain('Notify');
+		});
+
 		it('explains itself when there is no node to attach to', () => {
 			const { sendFetchFailure } = buildRetryFlow();
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -1037,9 +1037,9 @@ describe('Workflow Builder', () => {
 			expect(json.connections['Fetch Positions']?.main[0]?.[0]?.node).toBe('Compute');
 		});
 
-		it('routes the error output of an imported node, which declares no connections itself', () => {
-			// A node handle from fromJSON() throws on every connection method by design, so
-			// the builder has to wire this route into the graph itself.
+		it('routes the error output of an imported node', () => {
+			// Every other connection method on a handle from fromJSON() throws by design;
+			// an error route is the one the handle records, so the builder can declare it.
 			const notify = node({
 				type: 'n8n-nodes-base.slack',
 				version: 2.3,

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -1018,6 +1018,51 @@ describe('Workflow Builder', () => {
 			expect(json.nodes.map((n) => n.name)).toContain('Notify');
 		});
 
+		it('expands a chain handler on an imported node instead of collapsing it', () => {
+			const imported: WorkflowJSON = {
+				id: 'test-id',
+				name: 'Imported',
+				nodes: [
+					{
+						id: 't',
+						name: 'Start',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+						parameters: {},
+					},
+					{
+						id: 'h',
+						name: 'Fetch',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						position: [200, 0],
+						parameters: {},
+					},
+				],
+				connections: { Start: { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] } },
+			};
+			const notify = node({
+				type: 'n8n-nodes-base.slack',
+				version: 2.3,
+				config: { name: 'Notify' },
+			});
+			const escalate = node({
+				type: 'n8n-nodes-base.noOp',
+				version: 1,
+				config: { name: 'Escalate' },
+			});
+
+			const json = workflow.fromJSON(imported).onError(notify.to(escalate)).toJSON();
+
+			// Every chain node is present, and the route enters at the chain head.
+			expect(json.nodes.map((n) => n.name)).toEqual(['Start', 'Fetch', 'Notify', 'Escalate']);
+			expect(json.connections.Fetch?.main[1]?.[0]?.node).toBe('Notify');
+			expect(json.connections.Notify?.main[0]?.[0]?.node).toBe('Escalate');
+			// No self-loop on the tail.
+			expect(json.connections.Escalate).toBeUndefined();
+		});
+
 		it('explains itself when there is no node to attach to', () => {
 			const { sendFetchFailure } = buildRetryFlow();
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -840,7 +840,11 @@ describe('Workflow Builder', () => {
 			expect(json.connections['HTTP']?.main[1]?.[0]?.node).toBe('Error Handler');
 		});
 
-		it('does not override an explicit onError mode set in config', () => {
+		// The route is the more specific instruction, so it wins over an onError mode that
+		// exposes no error pin. Keeping the mode emitted a connection from an output the node
+		// does not have: the handler never ran, and the `error_routes_consistent` check counts
+		// that as a broken workflow.
+		it('opens the error output port over an explicit onError mode that has none', () => {
 			const httpNode = node({
 				type: 'n8n-nodes-base.httpRequest',
 				version: 4.2,
@@ -858,7 +862,8 @@ describe('Workflow Builder', () => {
 			const json = wf.toJSON();
 
 			const httpJson = json.nodes.find((n) => n.name === 'HTTP');
-			expect(httpJson?.onError).toBe('continueRegularOutput');
+			expect(httpJson?.onError).toBe('continueErrorOutput');
+			expect(json.connections['HTTP']?.main[1]?.[0]?.node).toBe('Error Handler');
 		});
 	});
 
@@ -894,6 +899,33 @@ describe('Workflow Builder', () => {
 			});
 			return { schedule, loadUniverse, fetchPositions, sendFetchFailure, compute };
 		};
+
+		/** A two-node workflow as `fromJSON()` reads it, with the cursor left on `Fetch`. */
+		const importedFlow = (fetchOverrides?: Partial<WorkflowJSON['nodes'][number]>) =>
+			({
+				id: 'test-id',
+				name: 'Imported',
+				nodes: [
+					{
+						id: 't',
+						name: 'Start',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [0, 0],
+						parameters: {},
+					},
+					{
+						id: 'h',
+						name: 'Fetch',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						position: [200, 0],
+						parameters: {},
+						...fetchOverrides,
+					},
+				],
+				connections: { Start: { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] } },
+			}) satisfies WorkflowJSON;
 
 		it('routes the error output of the node the cursor is on', () => {
 			const { schedule, loadUniverse, fetchPositions, sendFetchFailure, compute } =
@@ -934,6 +966,33 @@ describe('Workflow Builder', () => {
 				'continueErrorOutput',
 			);
 		});
+
+		// A node that continues on its regular output has no error pin. Left as it was, the
+		// route serialized as a connection from an output the node does not have: the handler
+		// never received an item, and the save only reported a warning. Nodes read from a user
+		// workflow carry this value whenever the node uses the legacy `continueOnFail` flag.
+		it.each(['continueRegularOutput', 'stopWorkflow'] as const)(
+			'opens the error output port of a node that declares %s',
+			(onError) => {
+				const { schedule, sendFetchFailure } = buildRetryFlow();
+				const fetchPositions = node({
+					type: 'n8n-nodes-base.httpRequest',
+					version: 4.2,
+					config: { name: 'Fetch Positions', onError },
+				});
+
+				const json = workflow('test-id', 'Test')
+					.add(schedule)
+					.to(fetchPositions)
+					.onError(sendFetchFailure)
+					.toJSON();
+
+				expect(json.nodes.find((n) => n.name === 'Fetch Positions')?.onError).toBe(
+					'continueErrorOutput',
+				);
+				expect(json.connections['Fetch Positions']?.main[1]?.[0]?.node).toBe('Send Fetch Failure');
+			},
+		);
 
 		it('matches wiring the same error route on the node itself', () => {
 			const viaBuilder = buildRetryFlow();
@@ -981,36 +1040,13 @@ describe('Workflow Builder', () => {
 		it('routes the error output of an imported node, which declares no connections itself', () => {
 			// A node handle from fromJSON() throws on every connection method by design, so
 			// the builder has to wire this route into the graph itself.
-			const imported: WorkflowJSON = {
-				id: 'test-id',
-				name: 'Imported',
-				nodes: [
-					{
-						id: 't',
-						name: 'Start',
-						type: 'n8n-nodes-base.manualTrigger',
-						typeVersion: 1,
-						position: [0, 0],
-						parameters: {},
-					},
-					{
-						id: 'h',
-						name: 'Fetch',
-						type: 'n8n-nodes-base.httpRequest',
-						typeVersion: 4.2,
-						position: [200, 0],
-						parameters: {},
-					},
-				],
-				connections: { Start: { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] } },
-			};
 			const notify = node({
 				type: 'n8n-nodes-base.slack',
 				version: 2.3,
 				config: { name: 'Notify' },
 			});
 
-			const json = workflow.fromJSON(imported).onError(notify).toJSON();
+			const json = workflow.fromJSON(importedFlow()).onError(notify).toJSON();
 
 			// fromJSON leaves the cursor on the last imported node.
 			expect(json.connections.Fetch?.main[1]?.[0]?.node).toBe('Notify');
@@ -1018,30 +1054,31 @@ describe('Workflow Builder', () => {
 			expect(json.nodes.map((n) => n.name)).toContain('Notify');
 		});
 
+		it('opens the error output port of an imported node that continues on its regular output', () => {
+			// The read path carries a legacy `continueOnFail` node over as
+			// `continueRegularOutput`, so this is the common shape of a user's node.
+			const notify = node({
+				type: 'n8n-nodes-base.slack',
+				version: 2.3,
+				config: { name: 'Notify' },
+			});
+
+			const json = workflow
+				.fromJSON(importedFlow({ onError: 'continueRegularOutput' }))
+				.onError(notify)
+				.toJSON();
+
+			expect(json.nodes.find((n) => n.name === 'Fetch')?.onError).toBe('continueErrorOutput');
+			expect(json.connections.Fetch?.main[1]?.[0]?.node).toBe('Notify');
+		});
+
+		it('leaves the imported onError value alone when no route is declared', () => {
+			const json = workflow.fromJSON(importedFlow({ onError: 'continueRegularOutput' })).toJSON();
+
+			expect(json.nodes.find((n) => n.name === 'Fetch')?.onError).toBe('continueRegularOutput');
+		});
+
 		it('expands a chain handler on an imported node instead of collapsing it', () => {
-			const imported: WorkflowJSON = {
-				id: 'test-id',
-				name: 'Imported',
-				nodes: [
-					{
-						id: 't',
-						name: 'Start',
-						type: 'n8n-nodes-base.manualTrigger',
-						typeVersion: 1,
-						position: [0, 0],
-						parameters: {},
-					},
-					{
-						id: 'h',
-						name: 'Fetch',
-						type: 'n8n-nodes-base.httpRequest',
-						typeVersion: 4.2,
-						position: [200, 0],
-						parameters: {},
-					},
-				],
-				connections: { Start: { main: [[{ node: 'Fetch', type: 'main', index: 0 }]] } },
-			};
 			const notify = node({
 				type: 'n8n-nodes-base.slack',
 				version: 2.3,
@@ -1053,7 +1090,7 @@ describe('Workflow Builder', () => {
 				config: { name: 'Escalate' },
 			});
 
-			const json = workflow.fromJSON(imported).onError(notify.to(escalate)).toJSON();
+			const json = workflow.fromJSON(importedFlow()).onError(notify.to(escalate)).toJSON();
 
 			// Every chain node is present, and the route enters at the chain head.
 			expect(json.nodes.map((n) => n.name)).toEqual(['Start', 'Fetch', 'Notify', 'Escalate']);

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -462,8 +462,8 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		assertNotOutputSelector(handler, 'onError');
 
 		const sourceKey = this._currentNode;
-		const sourceInstance = sourceKey ? this._nodes.get(sourceKey)?.instance : undefined;
-		if (!sourceInstance || typeof sourceInstance.onError !== 'function') {
+		const sourceGraphNode = sourceKey ? this._nodes.get(sourceKey) : undefined;
+		if (!sourceGraphNode || typeof sourceGraphNode.instance.onError !== 'function') {
 			throw new Error(
 				'.onError() must follow adding a node. Use it as ' +
 					'workflow.add(trigger).to(httpNode).onError(errorHandler).',
@@ -472,11 +472,41 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 
 		if (handler === null || handler === undefined) return this;
 
+		const sourceInstance = sourceGraphNode.instance;
+		// A node handle from `fromJSON()` declares no connections — every one of its
+		// connection methods throws by design, and connections are made on the builder
+		// instead. Write the route into the graph in the shape the serializer folds into
+		// the error pin, so `.onError()` works on an imported workflow like `.to()` does.
+		if ('_originalName' in sourceInstance.config) {
+			this.connectErrorRouteInGraph(sourceGraphNode, handler);
+			return this;
+		}
+
 		sourceInstance.onError(handler as NodeInstance<string, string, unknown>);
 		// The handler is reachable only through the node's declared connections, so pull it
 		// — and anything it fans out to — into the graph.
 		this.addSingleNodeConnectionTargets(this._nodes, sourceInstance);
 		return this;
+	}
+
+	/** Error route for a node that cannot declare one on itself. See {@link onError}. */
+	private connectErrorRouteInGraph(sourceGraphNode: GraphNode, handler: unknown): void {
+		const target = isInputTarget(handler)
+			? handler.node
+			: (handler as NodeInstance<string, string, unknown>);
+		const targetIndex = isInputTarget(handler) ? handler.inputIndex : 0;
+		const targetKey = this.addNodeWithSubnodes(this._nodes, target) ?? target.name;
+
+		sourceGraphNode.instance.config.onError ??= 'continueErrorOutput';
+
+		const errorConns =
+			sourceGraphNode.connections.get('error') ?? new Map<number, ConnectionTarget[]>();
+		const outputConns: ConnectionTarget[] = errorConns.get(0) ?? [];
+		if (!outputConns.some((c) => c.node === targetKey && c.index === targetIndex)) {
+			outputConns.push({ node: targetKey, type: 'main', index: targetIndex });
+			errorConns.set(0, outputConns);
+			sourceGraphNode.connections.set('error', errorConns);
+		}
 	}
 
 	/**

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -454,6 +454,32 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	}
 
 	/**
+	 * Route the error output of the node the cursor is on (the last node added via
+	 * `.to()`/`.add()`) to `handler`. The cursor stays on that node, so a following
+	 * `.to()` continues the main branch — the same way `.onTrue()`/`.onFalse()` behave.
+	 */
+	onError(handler: unknown): WorkflowBuilder {
+		assertNotOutputSelector(handler, 'onError');
+
+		const sourceKey = this._currentNode;
+		const sourceInstance = sourceKey ? this._nodes.get(sourceKey)?.instance : undefined;
+		if (!sourceInstance || typeof sourceInstance.onError !== 'function') {
+			throw new Error(
+				'.onError() must follow adding a node. Use it as ' +
+					'workflow.add(trigger).to(httpNode).onError(errorHandler).',
+			);
+		}
+
+		if (handler === null || handler === undefined) return this;
+
+		sourceInstance.onError(handler as NodeInstance<string, string, unknown>);
+		// The handler is reachable only through the node's declared connections, so pull it
+		// — and anything it fans out to — into the graph.
+		this.addSingleNodeConnectionTargets(this._nodes, sourceInstance);
+		return this;
+	}
+
+	/**
 	 * Connect a branch output of the node the cursor is on (the last node added
 	 * via `.to()`/`.add()`) to `target`, without advancing the cursor — so
 	 * sibling branches (`.onTrue().onFalse()`, `.onCase(0).onCase(1)`) all attach
@@ -1330,7 +1356,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	}
 }
 
-function assertNotOutputSelector(value: unknown, method: 'add' | 'to'): void {
+function assertNotOutputSelector(value: unknown, method: 'add' | 'to' | 'onError'): void {
 	if (!isOutputSelector(value)) return;
 	const sourceName = value.node.name;
 	throw new TypeError(

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -463,7 +463,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 
 		const sourceKey = this._currentNode;
 		const sourceGraphNode = sourceKey ? this._nodes.get(sourceKey) : undefined;
-		if (!sourceGraphNode || typeof sourceGraphNode.instance.onError !== 'function') {
+		if (!sourceGraphNode) {
 			throw new Error(
 				'.onError() must follow adding a node. Use it as ' +
 					'workflow.add(trigger).to(httpNode).onError(errorHandler).',
@@ -674,13 +674,13 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	}
 
 	/**
-	 * Merge connections declared on node instances via .to() into the graph connections.
-	 * This prepares the graph for serialization by ensuring all connections are stored
-	 * in graphNode.connections.
+	 * Merge connections declared on node instances — via `.to()`, or `.onError()` on an
+	 * imported handle — into the graph connections. This prepares the graph for
+	 * serialization by ensuring all connections are stored in graphNode.connections.
 	 */
 	private mergeInstanceConnections(): void {
 		for (const graphNode of this._nodes.values()) {
-			// Only process if the node instance has getConnections() (nodes from builder, not fromJSON)
+			// Some composites (e.g. SplitInBatchesBuilder) declare no connections of their own.
 			if (typeof graphNode.instance.getConnections === 'function') {
 				const nodeConns = graphNode.instance.getConnections();
 				for (const { target, outputIndex, targetInputIndex, connectionType } of nodeConns) {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -473,40 +473,11 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		if (handler === null || handler === undefined) return this;
 
 		const sourceInstance = sourceGraphNode.instance;
-		// A node handle from `fromJSON()` declares no connections — every one of its
-		// connection methods throws by design, and connections are made on the builder
-		// instead. Write the route into the graph in the shape the serializer folds into
-		// the error pin, so `.onError()` works on an imported workflow like `.to()` does.
-		if ('_originalName' in sourceInstance.config) {
-			this.connectErrorRouteInGraph(sourceGraphNode, handler);
-			return this;
-		}
-
 		sourceInstance.onError(handler as NodeInstance<string, string, unknown>);
 		// The handler is reachable only through the node's declared connections, so pull it
 		// — and anything it fans out to — into the graph.
 		this.addSingleNodeConnectionTargets(this._nodes, sourceInstance);
 		return this;
-	}
-
-	/** Error route for a node that cannot declare one on itself. See {@link onError}. */
-	private connectErrorRouteInGraph(sourceGraphNode: GraphNode, handler: unknown): void {
-		const target = isInputTarget(handler)
-			? handler.node
-			: (handler as NodeInstance<string, string, unknown>);
-		const targetIndex = isInputTarget(handler) ? handler.inputIndex : 0;
-		const targetKey = this.addNodeWithSubnodes(this._nodes, target) ?? target.name;
-
-		sourceGraphNode.instance.config.onError ??= 'continueErrorOutput';
-
-		const errorConns =
-			sourceGraphNode.connections.get('error') ?? new Map<number, ConnectionTarget[]>();
-		const outputConns: ConnectionTarget[] = errorConns.get(0) ?? [];
-		if (!outputConns.some((c) => c.node === targetKey && c.index === targetIndex)) {
-			outputConns.push({ node: targetKey, type: 'main', index: targetIndex });
-			errorConns.set(0, outputConns);
-			sourceGraphNode.connections.set('error', errorConns);
-		}
 	}
 
 	/**

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.test.ts
@@ -99,6 +99,19 @@ describe('Node Builder', () => {
 			expect(n.config.executeOnce).toBe(true);
 		});
 
+		it('should open the error output port when a route is declared on a node without one', () => {
+			const handler = node({ type: 'n8n-nodes-base.noOp', version: 1, config: {} });
+			const n = node({
+				type: 'n8n-nodes-base.httpRequest',
+				version: 4.2,
+				config: { onError: 'continueRegularOutput' },
+			});
+
+			n.onError(handler);
+
+			expect(n.config.onError).toBe('continueErrorOutput');
+		});
+
 		it('should auto-generate a unique ID', () => {
 			const n1 = node({ type: 'n8n-nodes-base.httpRequest', version: 4.2, config: {} });
 			const n2 = node({ type: 'n8n-nodes-base.httpRequest', version: 4.2, config: {} });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
@@ -372,8 +372,10 @@ class NodeInstanceImpl<TType extends string, TVersion extends string, TOutput = 
 	}
 
 	onError<T extends NodeInstance<string, string, unknown>>(handler: T | InputTarget): this {
-		// Declaring an error route implies the error output port exists.
-		this.config.onError ??= 'continueErrorOutput';
+		// Declaring an error route implies the error output port exists. The other two
+		// values expose no error pin, so keeping one would serialize this route as a
+		// connection from an output the node does not have — the route wins.
+		this.config.onError = 'continueErrorOutput';
 		if (isInputTarget(handler)) {
 			this._connections.push({
 				target: handler.node,

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/node-builders/node-builder.ts
@@ -43,6 +43,19 @@ export function isInputTarget(value: unknown): value is InputTarget {
 }
 
 /**
+ * `.onError()` routes to one handler. An array reached the graph as a target with no
+ * name, so every handler in it was dropped without a word. Say so instead.
+ */
+export function assertSingleErrorHandler(handler: unknown): void {
+	if (!Array.isArray(handler)) return;
+	throw new TypeError(
+		'.onError() takes one handler, not an array. ' +
+			'Call it once for each handler — .onError(notify).onError(logFailure) — ' +
+			'or route to a chain: .onError(notify.to(logFailure)).',
+	);
+}
+
+/**
  * Type guard to check if a value is an OutputSelector
  */
 export function isOutputSelector(value: unknown): value is OutputSelector<string, string, unknown> {
@@ -372,6 +385,7 @@ class NodeInstanceImpl<TType extends string, TVersion extends string, TOutput = 
 	}
 
 	onError<T extends NodeInstance<string, string, unknown>>(handler: T | InputTarget): this {
+		assertSingleErrorHandler(handler);
 		// Declaring an error route implies the error output port exists. The other two
 		// values expose no error pin, so keeping one would serialize this route as a
 		// connection from an output the node does not have — the route wins.

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -173,6 +173,9 @@ function serializeNode(
 	if (config.extendsCredential) {
 		n8nNode.extendsCredential = config.extendsCredential;
 	}
+	if (config.customTelemetryTags?.tag?.length) {
+		n8nNode.customTelemetryTags = deepCopy(config.customTelemetryTags);
+	}
 
 	return normalizeNodeShape(n8nNode);
 }

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/validators/unknown-config-keys-validator.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/validators/unknown-config-keys-validator.ts
@@ -43,6 +43,7 @@ const KNOWN_CONFIG_KEY_MAP: Record<keyof NodeConfig, true> = {
 	alwaysOutputData: true,
 	onError: true,
 	extendsCredential: true,
+	customTelemetryTags: true,
 	pinData: true,
 	output: true,
 	subnodes: true,

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -93,6 +93,7 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 				alwaysOutputData: n8nNode.alwaysOutputData,
 				onError: n8nNode.onError,
 				extendsCredential: n8nNode.extendsCredential,
+				customTelemetryTags: n8nNode.customTelemetryTags,
 			},
 			update(config) {
 				return { ...this, config: { ...this.config, ...config } };

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -115,7 +115,10 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 				throw new Error('Nodes from fromJSON() do not support output()');
 			},
 			onError(handler: NodeInstance<string, string, unknown> | InputTarget) {
-				this.config.onError ??= 'continueErrorOutput';
+				// The route wins over the saved value, the same way it does on an authored
+				// node: a node that continues on its regular output has no error pin to
+				// route from. A node the builder never routes from keeps what it imported.
+				this.config.onError = 'continueErrorOutput';
 				declaredConnections.push(
 					isInputTarget(handler)
 						? {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -18,6 +18,8 @@ import {
 	type IDataObject,
 	type CredentialReference,
 	type NewCredentialValue,
+	type DeclaredConnection,
+	type InputTarget,
 } from '../types/base';
 
 /**
@@ -39,6 +41,14 @@ export interface ParsedWorkflow {
  * Parse workflow JSON into internal graph structures.
  * This is a pure function that doesn't depend on WorkflowBuilderImpl.
  */
+/**
+ * Local copy of the `InputTarget` guard. Importing it from the node builder would pull that
+ * module — and the plugins it registers — into every consumer of `fromJSON()`.
+ */
+function isInputTarget(value: unknown): value is InputTarget {
+	return typeof value === 'object' && value !== null && '_isInputTarget' in value;
+}
+
 export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 	const nodes = new Map<string, GraphNode>();
 	// Map from connection name (how nodes reference each other) to map key
@@ -64,6 +74,11 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 
 		// For nodes without a name (like sticky notes), use the id as the internal name
 		const nodeName = n8nNode.name ?? n8nNode.id;
+		// An imported handle builds no connections of its own — the builder wires the graph.
+		// An error route is the exception: the builder's `.onError()` has no other way to say
+		// which node the route leaves from, so the handle records it like an authored node
+		// does, and the usual expansion adds the handler's chain or composite for free.
+		const declaredConnections: DeclaredConnection[] = [];
 		const instance: NodeInstance<string, string, unknown> = {
 			type: n8nNode.type,
 			version,
@@ -99,11 +114,22 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 			output() {
 				throw new Error('Nodes from fromJSON() do not support output()');
 			},
-			onError() {
-				throw new Error('Nodes from fromJSON() do not support onError()');
+			onError(handler: NodeInstance<string, string, unknown> | InputTarget) {
+				this.config.onError ??= 'continueErrorOutput';
+				declaredConnections.push(
+					isInputTarget(handler)
+						? {
+								target: handler.node,
+								outputIndex: 0,
+								targetInputIndex: handler.inputIndex,
+								connectionType: 'error',
+							}
+						: { target: handler, outputIndex: 0, connectionType: 'error' },
+				);
+				return this;
 			},
 			getConnections() {
-				return [];
+				return [...declaredConnections];
 			},
 		};
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -68,9 +68,8 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 		// For nodes without a name (like sticky notes), use the id as the internal name
 		const nodeName = n8nNode.name ?? n8nNode.id;
 		// An imported handle builds no connections of its own — the builder wires the graph.
-		// An error route is the exception: the builder's `.onError()` has no other way to say
-		// which node the route leaves from, so the handle records it like an authored node
-		// does, and the usual expansion adds the handler's chain or composite for free.
+		// An error route is the exception: recording it like an authored node does is what
+		// gives the handler's chain or composite the usual expansion.
 		const declaredConnections: DeclaredConnection[] = [];
 		const instance: NodeInstance<string, string, unknown> = {
 			type: n8nNode.type,

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -21,7 +21,7 @@ import {
 	type DeclaredConnection,
 	type InputTarget,
 } from '../types/base';
-import { isInputTarget } from './node-builders/node-builder';
+import { assertSingleErrorHandler, isInputTarget } from './node-builders/node-builder';
 
 /**
  * Result of parsing a workflow JSON
@@ -107,6 +107,7 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 				throw new Error('Nodes from fromJSON() do not support output()');
 			},
 			onError(handler: NodeInstance<string, string, unknown> | InputTarget) {
+				assertSingleErrorHandler(handler);
 				// The route wins over the saved value, the same way it does on an authored
 				// node: a node that continues on its regular output has no error pin to
 				// route from. A node the builder never routes from keeps what it imported.

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -21,6 +21,7 @@ import {
 	type DeclaredConnection,
 	type InputTarget,
 } from '../types/base';
+import { isInputTarget } from './node-builders/node-builder';
 
 /**
  * Result of parsing a workflow JSON
@@ -41,14 +42,6 @@ export interface ParsedWorkflow {
  * Parse workflow JSON into internal graph structures.
  * This is a pure function that doesn't depend on WorkflowBuilderImpl.
  */
-/**
- * Local copy of the `InputTarget` guard. Importing it from the node builder would pull that
- * module — and the plugins it registers — into every consumer of `fromJSON()`.
- */
-function isInputTarget(value: unknown): value is InputTarget {
-	return typeof value === 'object' && value !== null && '_isInputTarget' in value;
-}
-
 export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 	const nodes = new Map<string, GraphNode>();
 	// Map from connection name (how nodes reference each other) to map key

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -50,7 +50,7 @@ vi.mock('@n8n/ai-utilities', () => ({
 
 import type { PolicyCleared } from '@n8n/decorators';
 import { Container } from '@n8n/di';
-import { generateWorkflowCode } from '@n8n/workflow-sdk';
+import { generateWorkflowCode, parseWorkflowCode } from '@n8n/workflow-sdk';
 import { mock } from 'vitest-mock-extended';
 import { Expression } from 'n8n-workflow';
 import type {
@@ -1944,6 +1944,9 @@ function createWorkflowAdapterForTests(overrides?: {
 	// Defaults to a bound project (every production run has one). Pass `null` to
 	// simulate a run with no bound project.
 	projectId?: string | null;
+	// Mirrors `N8N_AI_ALLOW_SENDING_PARAMETER_VALUES`, which defaults to true in
+	// production. This harness leaves it off, so opt in to read real parameters.
+	allowSendingParameterValues?: boolean;
 }) {
 	const mockProjectRepository = {
 		getPersonalProjectForUserOrFail: vi.fn().mockResolvedValue({ id: 'personal-project-id' }),
@@ -2031,7 +2034,7 @@ function createWorkflowAdapterForTests(overrides?: {
 
 	const service = new InstanceAiAdapterService(
 		mockLogger as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[0],
-		globalConfigStub(),
+		globalConfigStub({ allowSendingParameterValues: overrides?.allowSendingParameterValues }),
 		mockWorkflowService as unknown as WorkflowService,
 		mockWorkflowFinderService as unknown as ConstructorParameters<
 			typeof InstanceAiAdapterService
@@ -2192,8 +2195,11 @@ describe('createWorkflowAdapter', () => {
 					notesInFlow: true,
 					executeOnce: true,
 					retryOnFail: true,
+					maxTries: 5,
+					waitBetweenTries: 2500,
 					alwaysOutputData: true,
 					onError: 'continueErrorOutput',
+					extendsCredential: 'httpHeaderAuth',
 				},
 			],
 			connections: {},
@@ -2208,10 +2214,139 @@ describe('createWorkflowAdapter', () => {
 				notesInFlow: true,
 				executeOnce: true,
 				retryOnFail: true,
+				maxTries: 5,
+				waitBetweenTries: 2500,
 				alwaysOutputData: true,
 				onError: 'continueErrorOutput',
+				extendsCredential: 'httpHeaderAuth',
 			}),
 		);
+	});
+
+	// The agent reads a workflow with `get-as-code`, edits the file and saves it with
+	// `build-workflow`, which writes the parsed nodes over the saved ones. A field this
+	// read path drops is therefore not just missing from the code — it is erased from the
+	// user's workflow on the next save.
+	it('keeps every node-level setting through a get-as-code / build-workflow round trip', async () => {
+		const { adapter, mockWorkflowFinderService } = createWorkflowAdapterForTests({
+			allowSendingParameterValues: true,
+		});
+		const savedNode = {
+			id: 'http-id',
+			name: 'Download Image',
+			type: 'n8n-nodes-base.httpRequest',
+			typeVersion: 4.2,
+			position: [208, 0] as [number, number],
+			parameters: { url: 'https://example.com/image', options: {} },
+			credentials: { httpHeaderAuth: { id: 'cred-1', name: 'Feishu Header' } },
+			notes: 'Downloads the message image',
+			notesInFlow: true,
+			executeOnce: true,
+			retryOnFail: true,
+			maxTries: 4,
+			waitBetweenTries: 1500,
+			alwaysOutputData: true,
+			onError: 'continueRegularOutput',
+			extendsCredential: 'httpHeaderAuth',
+		};
+		mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue({
+			id: 'wf-roundtrip',
+			name: 'Round Trip',
+			active: false,
+			versionId: 'version-id',
+			activeVersionId: null,
+			isArchived: false,
+			createdAt: new Date('2026-01-01'),
+			updatedAt: new Date('2026-01-01'),
+			nodes: [
+				{
+					id: 'trigger-id',
+					name: 'Every Hour',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1.2,
+					position: [0, 0],
+					parameters: {},
+				},
+				savedNode,
+			],
+			connections: {
+				'Every Hour': { main: [[{ node: 'Download Image', type: 'main', index: 0 }]] },
+			},
+			settings: {},
+		});
+
+		const json = await adapter.getAsWorkflowJSON('wf-roundtrip');
+		// Same options `get-as-code` uses: ids in so node identity survives, positions out.
+		const code = generateWorkflowCode({
+			workflow: json,
+			includeNodeIds: true,
+			includePositions: false,
+		});
+		const rebuilt = parseWorkflowCode(code);
+
+		const rebuiltNode = rebuilt.nodes.find((n) => n.name === 'Download Image');
+		expect(rebuiltNode).toEqual(
+			expect.objectContaining({
+				credentials: { httpHeaderAuth: { id: 'cred-1', name: 'Feishu Header' } },
+				parameters: savedNode.parameters,
+				notes: savedNode.notes,
+				notesInFlow: true,
+				executeOnce: true,
+				retryOnFail: true,
+				maxTries: 4,
+				waitBetweenTries: 1500,
+				alwaysOutputData: true,
+				onError: 'continueRegularOutput',
+				extendsCredential: 'httpHeaderAuth',
+			}),
+		);
+	});
+
+	it.each([
+		{
+			name: 'reads a legacy continueOnFail node as its onError equivalent',
+			node: { continueOnFail: true },
+			expected: 'continueRegularOutput',
+		},
+		{
+			name: 'lets an explicit onError win over continueOnFail',
+			node: { continueOnFail: true, onError: 'continueErrorOutput' },
+			expected: 'continueErrorOutput',
+		},
+		{
+			name: 'leaves onError unset when the node continues on neither',
+			node: {},
+			expected: undefined,
+		},
+	])('$name', async ({ node, expected }) => {
+		const { adapter, mockWorkflowFinderService } = createWorkflowAdapterForTests();
+		mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue({
+			id: 'wf-legacy',
+			name: 'Legacy',
+			active: false,
+			versionId: 'version-id',
+			activeVersionId: null,
+			isArchived: false,
+			createdAt: new Date('2026-01-01'),
+			updatedAt: new Date('2026-01-01'),
+			nodes: [
+				{
+					id: 'legacy-id',
+					name: 'Legacy Node',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 4.2,
+					position: [0, 0],
+					parameters: {},
+					...node,
+				},
+			],
+			connections: {},
+			settings: {},
+		});
+
+		const result = await adapter.getAsWorkflowJSON('wf-legacy');
+
+		expect(result.nodes[0].onError).toBe(expected);
 	});
 
 	it('returns AI Gateway-managed credentials in a shape accepted by workflow codegen', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2200,6 +2200,7 @@ describe('createWorkflowAdapter', () => {
 					alwaysOutputData: true,
 					onError: 'continueErrorOutput',
 					extendsCredential: 'httpHeaderAuth',
+					customTelemetryTags: { tag: [{ key: 'team', value: 'growth' }] },
 				},
 			],
 			connections: {},
@@ -2219,6 +2220,7 @@ describe('createWorkflowAdapter', () => {
 				alwaysOutputData: true,
 				onError: 'continueErrorOutput',
 				extendsCredential: 'httpHeaderAuth',
+				customTelemetryTags: { tag: [{ key: 'team', value: 'growth' }] },
 			}),
 		);
 	});
@@ -2248,6 +2250,7 @@ describe('createWorkflowAdapter', () => {
 			alwaysOutputData: true,
 			onError: 'continueRegularOutput',
 			extendsCredential: 'httpHeaderAuth',
+			customTelemetryTags: { tag: [{ key: 'team', value: 'growth' }] },
 		};
 		mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue({
 			id: 'wf-roundtrip',
@@ -2298,6 +2301,7 @@ describe('createWorkflowAdapter', () => {
 				alwaysOutputData: true,
 				onError: 'continueRegularOutput',
 				extendsCredential: 'httpHeaderAuth',
+				customTelemetryTags: { tag: [{ key: 'team', value: 'growth' }] },
 			}),
 		);
 	});

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -4641,6 +4641,7 @@ function toWorkflowJSON(
 			// ones, and dropping the flag would silently reset the node to `stopWorkflow`.
 			onError: n.onError ?? (n.continueOnFail ? 'continueRegularOutput' : undefined),
 			extendsCredential: n.extendsCredential,
+			customTelemetryTags: n.customTelemetryTags,
 		})),
 		connections: source.connections as WorkflowJSON['connections'],
 		settings: workflow.settings as WorkflowJSON['settings'],

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -4633,8 +4633,14 @@ function toWorkflowJSON(
 			notesInFlow: n.notesInFlow,
 			executeOnce: n.executeOnce,
 			retryOnFail: n.retryOnFail,
+			maxTries: n.maxTries,
+			waitBetweenTries: n.waitBetweenTries,
 			alwaysOutputData: n.alwaysOutputData,
-			onError: n.onError,
+			// `continueOnFail` is the pre-`onError` spelling and has no SDK config field, so
+			// read it the way the editor does. An agent save writes these nodes over the saved
+			// ones, and dropping the flag would silently reset the node to `stopWorkflow`.
+			onError: n.onError ?? (n.continueOnFail ? 'continueRegularOutput' : undefined),
+			extendsCredential: n.extendsCredential,
 		})),
 		connections: source.connections as WorkflowJSON['connections'],
 		settings: workflow.settings as WorkflowJSON['settings'],


### PR DESCRIPTION
## Summary

Defects 2, 3 and 4 of https://linear.app/n8n/issue/INS-1314 — all in the path the AI Assistant uses to read a workflow, edit it and save it back. The save writes the parsed nodes over the saved ones, so anything this path drops is erased from the user's workflow.

**Node settings survive the round trip.** `toWorkflowJSON` did not carry `maxTries`, `waitBetweenTries`, `extendsCredential`, `continueOnFail` or `customTelemetryTags`, so an unrelated edit erased them. `continueOnFail` is the pre-`onError` spelling and is now read as `onError: 'continueRegularOutput'`, the way the editor reads it; an explicit `onError` still wins. `customTelemetryTags` (custom OpenTelemetry span attributes, per node, added in #30442) was missing from `NodeJSON` entirely and now travels the same path as `extendsCredential`.

**A JSON workflow source saves.** `build-workflow` accepts a hand-written `.json` file, but only the SDK path lays nodes out, so a node without a position was rejected with `nodes[N].position (invalid_type): Required`. The JSON path now borrows the builder's layout, replaces a malformed position instead of padding it, and falls back to a row if the builder cannot lay the workflow out — the save never fails on a position the author never wrote.

**`.onError()` works on the workflow builder.** `.add(a).to(b).onError(handler)` threw `to(...).onError is not a function`. It now joins `onTrue`/`onFalse`/`onCase`: it routes the error output of the node the cursor is on and leaves the cursor there, so a following `.to()` continues the main branch and a second `.onError()` stacks. Works on an imported node too, and expands a chain handler rather than collapsing it to its tail.

**Behaviour change:** a declared error route now sets `onError: 'continueErrorOutput'` even when the node already declared another mode. Only that mode exposes an error pin, so keeping the old value emitted a connection from an output the node does not have — the handler never ran. An array passed to `.onError()` used to drop every handler silently; it now throws.

The fields the original ticket names (`credentials`, `onError`, `builtInTools`) were lost through `workflows[get-json]`, removed in #36740 — the surviving round trip keeps all three, verified across IF/Switch branches, agent and tool subnodes, and disabled and orphan nodes. And `rewireOutputLogTo` / `forceCustomOperation` are still not carried, deliberately: the execution engine and the evaluation test-runner set them at runtime, so there is nothing to preserve.

## How to test

```bash
pnpm --filter n8n exec vitest run src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
pnpm --filter @n8n/workflow-sdk exec vitest run src/workflow-builder.test.ts src/codegen/codegen-roundtrip.test.ts
pnpm --filter @n8n/instance-ai exec vitest run src/tools/workflows/__tests__/workflow-source-compiler.test.ts
```

`codegen-roundtrip.test.ts` reports 57 failures on `PLAIN_GENERIC_AUTH` warning expectations. They reproduce on master and are unrelated to this branch (https://linear.app/n8n/issue/INS-1399/run-the-workflow-sdk-real-workflow-roundtrip-corpus-in-ci)

By hand: set **Retry On Fail** with a non-default **Max Tries** on a node, then ask the assistant for an unrelated edit — the retry settings must survive. Then ask it to notify you when that node fails: the saved node must carry `onError: 'continueErrorOutput'` and an edge from its error output.

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/INS-1314

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
