### PR TITLE
fix(core): Route to error output when paired item lookup fails in handleNodeErrorOutput

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1923,6 +1923,48 @@ describe('WorkflowExecute', () => {
 				{ json: {}, error: { message: 'Test error' } as NodeApiError },
 			]);
 		});
+
+		test('should route error items to error output when $getPairedItem throws because paired item is missing', () => {
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: { error: 'Error occurred' },
+						pairedItem: { item: 99, input: 0 },
+					},
+				],
+			];
+
+			workflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+
+			expect(nodeSuccessData[0]).toEqual([]);
+			expect(nodeSuccessData[1]).toEqual([
+				{
+					json: { error: 'Error occurred' },
+					pairedItem: { item: 99, input: 0 },
+				},
+			]);
+		});
+
+		test('should route error items to error output when sourceData for pairedItem input index is missing', () => {
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: { error: 'Error occurred' },
+						pairedItem: { item: 0, input: 10 },
+					},
+				],
+			];
+
+			workflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+
+			expect(nodeSuccessData[0]).toEqual([]);
+			expect(nodeSuccessData[1]).toEqual([
+				{
+					json: { error: 'Error occurred' },
+					pairedItem: { item: 0, input: 10 },
+				},
+			]);
+		});
 	});
 
 	describe('AI tool continue-on-fail default', () => {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2785,24 +2785,34 @@ export class WorkflowExecute {
 					} else {
 						const pairedItemInputIndex = pairedItemData.input || 0;
 
-						const sourceData = executionData.source[NodeConnectionTypes.Main][pairedItemInputIndex];
+						const sourceData =
+							executionData.source[NodeConnectionTypes.Main]?.[pairedItemInputIndex];
 
-						const constPairedItem = dataProxy.$getPairedItem(
-							sourceData!.previousNode,
-							sourceData,
-							pairedItemData,
-						);
-
-						if (constPairedItem === null) {
+						if (!sourceData) {
 							errorItems.push(item);
 						} else {
-							errorItems.push({
-								...item,
-								json: {
-									...constPairedItem.json,
-									...item.json,
-								},
-							});
+							let constPairedItem: INodeExecutionData | null = null;
+							try {
+								constPairedItem = dataProxy.$getPairedItem(
+									sourceData.previousNode,
+									sourceData,
+									pairedItemData,
+								);
+							} catch {
+								constPairedItem = null;
+							}
+
+							if (constPairedItem === null) {
+								errorItems.push(item);
+							} else {
+								errorItems.push({
+									...item,
+									json: {
+										...constPairedItem.json,
+										...item.json,
+									},
+								});
+							}
 						}
 					}
 				} else {


### PR DESCRIPTION
## Summary

When a node configured with `onError: 'continueErrorOutput'` errors, `WorkflowExecute.handleNodeErrorOutput()` routes the error items to the error output. It calls `dataProxy.$getPairedItem(...)` to enrich the error items with input JSON.

In `WorkflowDataProxy`, `$getPairedItem` throws when paired item data cannot be resolved (for example, when item index is out of range or source output differs). Because this call was unhandled, the error escaped `handleNodeErrorOutput()`. Node execution caught the error and fell back to emitting the input items on the success output because `continuesOnError()` was true. The error output never executed.

This PR fixes the issue:
1. It safely accesses `sourceData` from `executionData.source`.
2. It wraps `$getPairedItem(...)` in a `try...catch` block.
3. When paired item lookup fails or throws, it falls back to routing the error item directly to the error output.

## How to test

Run the unit tests in `packages/core`:

```bash
pushd packages/core
pnpm test src/execution-engine/__tests__/workflow-execute.test.ts
popd
```

Observe that error items route to the error output even when paired item lookup fails or throws.

## Related Linear tickets, Github issues, and Community forum posts

fixes https://github.com/n8n-io/n8n/issues/37407

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

