### PR TITLE
fix(core): Preserve agent state during retries

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -1,6 +1,7 @@
 import type {
 	IDataObject,
 	IWorkflowExecuteAdditionalData,
+	EngineRequest,
 	EngineResponse,
 	WorkflowExecuteMode,
 	IExecuteFunctions,
@@ -241,6 +242,96 @@ describe('processRunExecutionData', () => {
 			{ name: 'nodeExecuteAfter', node: 'agent' },
 			{ name: 'workflowExecuteAfter' },
 		]);
+	});
+
+	test('preserves the engine response when retrying a resumed agent node', async () => {
+		const maxIterationsError = 'Max iterations (1) reached';
+		const responsesSeen: Array<EngineResponse | undefined> = [];
+		const getIterationCount = (response: EngineResponse | undefined) => {
+			const metadata = response?.metadata;
+			if (typeof metadata !== 'object' || metadata === null || !('iterationCount' in metadata)) {
+				return undefined;
+			}
+			return typeof metadata.iterationCount === 'number' ? metadata.iterationCount : undefined;
+		};
+		const request: EngineRequest = {
+			actions: [
+				{
+					actionType: 'ExecutionNodeAction',
+					nodeName: 'tool',
+					input: { query: 'test input' },
+					type: NodeConnectionTypes.AiTool,
+					id: 'action_1',
+					metadata: {},
+				},
+			],
+			metadata: { iterationCount: 1 },
+		};
+		const errorOutput = () => [[{ json: { error: maxIterationsError } }]];
+
+		const agentNodeType = modifyNode(passThroughNode)
+			.return((response) => {
+				responsesSeen.push(response);
+				return request;
+			})
+			.return((response) => {
+				responsesSeen.push(response);
+				return errorOutput();
+			})
+			.return((response) => {
+				responsesSeen.push(response);
+				return getIterationCount(response) === 1 ? errorOutput() : request;
+			})
+			.return((response) => {
+				responsesSeen.push(response);
+				return errorOutput();
+			})
+			.return((response) => {
+				responsesSeen.push(response);
+				return errorOutput();
+			})
+			.done();
+
+		const trigger = createNodeData({ name: 'trigger', type: types.passThrough });
+		const agent = {
+			...createNodeData({ name: 'agent', type: 'agent' }),
+			retryOnFail: true,
+			maxTries: 2,
+			waitBetweenTries: 10,
+			onError: 'continueErrorOutput' as const,
+		};
+		const tool = createNodeData({ name: 'tool', type: types.passThrough });
+		const retryNodeTypes = NodeTypes({
+			...nodeTypeArguments,
+			agent: { type: agentNodeType, sourcePath: '' },
+		});
+		const workflow = new DirectedGraph()
+			.addNodes(trigger, agent, tool)
+			.addConnections(
+				{ from: trigger, to: agent },
+				{ from: tool, to: agent, type: NodeConnectionTypes.AiTool },
+			)
+			.toWorkflow({ name: '', active: false, nodeTypes: retryNodeTypes });
+		const executionData = createRunExecutionData({
+			startData: { startNodes: [{ name: trigger.name, sourceData: null }] },
+			executionData: {
+				nodeExecutionStack: [
+					{ data: { main: [[{ json: { foo: 1 } }]] }, node: trigger, source: null },
+				],
+			},
+		});
+		const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+		const result = await workflowExecute.processRunExecutionData(workflow);
+
+		const iterationCounts = responsesSeen.map(getIterationCount);
+		const toolRuns = result.data.resultData.runData.tool.length;
+		expect(responsesSeen).toHaveLength(3);
+		expect(iterationCounts).toEqual([undefined, 1, 1]);
+		expect(toolRuns).toBe(1);
+		expect(result.data.resultData.runData.agent.at(-1)?.data?.main?.[1]?.[0]?.json.error).toBe(
+			maxIterationsError,
+		);
 	});
 
 	describe('runExecutionData.waitTill', () => {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2350,6 +2350,7 @@ export class WorkflowExecute {
 										this.additionalData,
 										this.mode,
 										this.abortController.signal,
+										subNodeExecutionResults,
 									);
 
 									nodeFailed = checkFailure(runNodeData);


### PR DESCRIPTION
## Summary

Agent V3 nodes pause while a tool runs, then resume with an `EngineResponse` that carries the tool result and iteration metadata.

The first resumed run received that response. If the node returned an error item and `Retry On Fail` was enabled, the inner retry called `runNode()` without it. The agent restarted from empty state and could call the same tool again.

This passes the same response into the retry. The retry still happens, but the agent keeps the state from the tool run and returns the expected max-iterations error instead of reporting a false success.

I added a regression test that covers the full pause → tool → resume → retry path. Without the one-line fix, it fails because the agent runs five times and the tool runs twice. With the fix, the agent runs three times, the tool runs once, and the error goes to the error output.

## How to test

```bash
cd packages/core
pnpm test workflow-execute-process-process-run-execution-data.test.ts
```

The new test is `preserves the engine response when retrying a resumed agent node`.

Checks run locally:

- `pnpm test` — 2,127 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter n8n-core build`
- `pnpm --filter n8n-nodes-base build`

I also ran the reported workflow three times before and after the patch with a scripted model response:

| Build | Model requests | Tool runs | Result |
| --- | ---: | ---: | --- |
| 2.37.7 | 3 | 2 | Incorrect success |
| Patched 2.37.7 | 1 | 1 | Max-iterations error |

All three runs produced the same result in each build.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/GHC-9404
- Fixes #37779

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs are not affected.
- [x] Tests included.
- [ ] Backport label added if needed.

Codex helped build the reproduction and run the checks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

