### PR TITLE
fix(core): Trust the CA from GIT_SSL_CAINFO for source control HTTPS remotes

### DIFF
--- a/packages/cli/src/modules/promotions.ee/__tests__/promotions-git.integration.test.ts
+++ b/packages/cli/src/modules/promotions.ee/__tests__/promotions-git.integration.test.ts
@@ -1,4 +1,7 @@
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { startSelfSignedGitServer, TLS_VERIFICATION_ERROR } from '@test/self-signed-git-server';
 
 import { buildHttpsGitConfig } from '../promotions-git.utils';
 
@@ -31,5 +34,45 @@ describe('Promotion Git credentials', () => {
 		expect(result).toContain(`password=${password}\n`);
 		expect(args.join(' ')).not.toContain(username);
 		expect(args.join(' ')).not.toContain(password);
+	});
+});
+
+describe('Promotion Git TLS trust', () => {
+	const originalEnv = process.env;
+	let server: Awaited<ReturnType<typeof startSelfSignedGitServer>>;
+
+	beforeAll(async () => {
+		server = await startSelfSignedGitServer();
+	});
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		delete process.env.GIT_SSL_CAINFO;
+	});
+
+	afterAll(async () => {
+		process.env = originalEnv;
+		await server.close();
+	});
+
+	// Runs Git the way simple-git does: with a replaced environment, so only the config reaches it.
+	// Async, because the server that Git talks to lives on this event loop.
+	const listRemote = async () => {
+		const config = buildHttpsGitConfig({ repositoryUrl: server.repositoryUrl });
+		await promisify(execFile)(
+			'git',
+			[...config.flatMap((entry) => ['-c', entry]), 'ls-remote', server.repositoryUrl],
+			{ env: { GIT_TERMINAL_PROMPT: '0' } },
+		);
+	};
+
+	it('rejects a self-signed certificate without GIT_SSL_CAINFO', async () => {
+		await expect(listRemote()).rejects.toThrow(TLS_VERIFICATION_ERROR);
+	});
+
+	it('trusts the certificate when GIT_SSL_CAINFO names it', async () => {
+		process.env.GIT_SSL_CAINFO = server.certPath;
+
+		await expect(listRemote()).resolves.toBeUndefined();
 	});
 });

--- a/packages/cli/src/modules/promotions.ee/__tests__/promotions-git.utils.test.ts
+++ b/packages/cli/src/modules/promotions.ee/__tests__/promotions-git.utils.test.ts
@@ -20,6 +20,8 @@ describe('promotions-git.utils', () => {
 				'no_proxy',
 				'ALL_PROXY',
 				'all_proxy',
+				'GIT_SSL_CAINFO',
+				'GIT_SSL_CAPATH',
 			]) {
 				delete process.env[key];
 			}
@@ -52,6 +54,16 @@ describe('promotions-git.utils', () => {
 			const config = buildHttpsGitConfig({ repositoryUrl: 'https://github.com/user/repo.git' });
 
 			expect(config.some((entry) => entry.includes('proxy='))).toBe(false);
+		});
+
+		it('carries the CA settings from the environment over as config', () => {
+			process.env.GIT_SSL_CAINFO = '/certs/bundle.crt';
+			process.env.GIT_SSL_CAPATH = '/certs';
+
+			const config = buildHttpsGitConfig({ repositoryUrl: 'https://github.com/user/repo.git' });
+
+			expect(config).toContain('http.sslCAInfo=/certs/bundle.crt');
+			expect(config).toContain('http.sslCAPath=/certs');
 		});
 	});
 

--- a/packages/cli/src/modules/promotions.ee/promotions-git.utils.ts
+++ b/packages/cli/src/modules/promotions.ee/promotions-git.utils.ts
@@ -33,6 +33,10 @@ export function buildHttpsGitConfig({ repositoryUrl }: { repositoryUrl: string }
 	// Git uses http.proxy for both HTTP and HTTPS URLs.
 	const proxyUrl = resolveProxyUrl(repositoryUrl);
 	if (proxyUrl) config.push(`http.proxy=${proxyUrl}`);
+	// Git runs with a replaced environment, so carry the CA settings over as config.
+	const { GIT_SSL_CAINFO, GIT_SSL_CAPATH } = process.env;
+	if (GIT_SSL_CAINFO) config.push(`http.sslCAInfo=${GIT_SSL_CAINFO}`);
+	if (GIT_SSL_CAPATH) config.push(`http.sslCAPath=${GIT_SSL_CAPATH}`);
 	return config;
 }
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.integration.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.integration.test.ts
@@ -1,0 +1,48 @@
+import { mock } from 'vitest-mock-extended';
+
+import { startSelfSignedGitServer, TLS_VERIFICATION_ERROR } from '@test/self-signed-git-server';
+
+import { SourceControlGitService } from '../source-control-git.service.ee';
+import type { SourceControlPreferencesService } from '../source-control-preferences.service.ee';
+import type { SourceControlPreferences } from '../types/source-control-preferences';
+
+describe('SourceControlGitService TLS trust', () => {
+	const originalEnv = process.env;
+	let server: Awaited<ReturnType<typeof startSelfSignedGitServer>>;
+
+	beforeAll(async () => {
+		server = await startSelfSignedGitServer();
+	});
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		delete process.env.GIT_SSL_CAINFO;
+	});
+
+	afterAll(async () => {
+		process.env = originalEnv;
+		await server.close();
+	});
+
+	const listRemote = async () => {
+		const { repositoryUrl } = server;
+		const preferences = mock<SourceControlPreferencesService>();
+		preferences.getPreferences.mockReturnValue(
+			mock<SourceControlPreferences>({ connectionType: 'https', repositoryUrl }),
+		);
+		preferences.getDecryptedHttpsCredentials.mockResolvedValue({ username: 'u', password: 'p' });
+		const service = new SourceControlGitService(mock(), mock(), preferences);
+		await service.setGitCommand(server.dir, server.dir);
+		await service.git!.listRemote([repositoryUrl]);
+	};
+
+	it('rejects a self-signed certificate without GIT_SSL_CAINFO', async () => {
+		await expect(listRemote()).rejects.toThrow(TLS_VERIFICATION_ERROR);
+	});
+
+	it('trusts the certificate when GIT_SSL_CAINFO names it', async () => {
+		process.env.GIT_SSL_CAINFO = server.certPath;
+
+		await expect(listRemote()).resolves.toBeUndefined();
+	});
+});

--- a/packages/cli/test/shared/self-signed-git-server.ts
+++ b/packages/cli/test/shared/self-signed-git-server.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer } from 'node:https';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/** Git reports a failed TLS verification differently per libcurl TLS backend. */
+export const TLS_VERIFICATION_ERROR =
+	/SSL certificate problem|server certificate verification failed/;
+
+/**
+ * An HTTPS server with a self-signed certificate that answers every request
+ * with the smart HTTP advertisement of an empty repository. That is enough to
+ * tell a TLS failure from a successful `git ls-remote`.
+ */
+export async function startSelfSignedGitServer() {
+	const dir = await mkdtemp(path.join(tmpdir(), 'n8n-git-tls-'));
+	const keyPath = path.join(dir, 'key.pem');
+	const certPath = path.join(dir, 'cert.pem');
+	execFileSync('openssl', [
+		'req',
+		'-x509',
+		'-nodes',
+		'-newkey',
+		'rsa:2048',
+		'-keyout',
+		keyPath,
+		'-out',
+		certPath,
+		'-days',
+		'1',
+		'-subj',
+		'/CN=127.0.0.1',
+		'-addext',
+		'subjectAltName=IP:127.0.0.1',
+	]);
+	const server = createServer(
+		{ key: await readFile(keyPath), cert: await readFile(certPath) },
+		(_request, response) => {
+			response.setHeader('Content-Type', 'application/x-git-upload-pack-advertisement');
+			response.end('001e# service=git-upload-pack\n00000000');
+		},
+	);
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('Server has no port');
+
+	return {
+		dir,
+		certPath,
+		repositoryUrl: `https://127.0.0.1:${address.port}/repo.git`,
+		close: async () => {
+			server.closeAllConnections();
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await rm(dir, { recursive: true, force: true });
+		},
+	};
+}


### PR DESCRIPTION
## Summary

Source Control and Promotions spawn Git through simple-git with an explicit environment, so the child process only gets the variables we set. `GIT_SSL_CAINFO` on the n8n process never reaches Git. A Git host signed by a private CA fails with `SSL certificate problem` or `unable to get local issuer certificate`, even though the same `git` command works from the pod terminal. Node-side settings such as `NODE_EXTRA_CA_CERTS` do not help, because Git has its own trust store.

#24104 hit the same defect for proxies and solved it by re-injecting `http.proxy`. This PR does the same for the CA: `buildHttpsGitConfig` reads `GIT_SSL_CAINFO` and `GIT_SSL_CAPATH` from the n8n process and passes them to Git as `http.sslCAInfo` and `http.sslCAPath`. Both Git services route through this function.

Two integration tests run the real Git binary against a local HTTPS server with a self-signed certificate, once without the variable (expects the TLS error) and once with it. One goes through `SourceControlGitService.setGitCommand` and simple-git, the path the ticket reports. The other runs the config that `buildHttpsGitConfig` produces with a replaced environment, the way the promotions service spawns Git. `SSL_CERT_FILE` and `SSL_CERT_DIR` stay unsupported; `GIT_SSL_CAINFO` is the variable to document.

## How to test
| Before | After |
| --- | --- |
| `SSL certificate problem: self signed certificate` | `repository not found`, because the dummy repo does not exist. Git got past TLS. |
| <img width="1478" alt="Before" src="https://github.com/user-attachments/assets/0d1dc718-c3c9-49aa-8c64-2e1437e9d974" /> | <img width="1478" alt="After" src="https://github.com/user-attachments/assets/8e55db4f-0f64-4bcb-b725-0e7fb10e2b4a" /> |



You do not need a private CA. `self-signed.badssl.com` serves a self-signed certificate, so its own certificate works as the CA bundle.

1. Save the certificate:

   ```sh
   openssl s_client -connect self-signed.badssl.com:443 -servername self-signed.badssl.com </dev/null 2>/dev/null \
     | openssl x509 > /tmp/ca.pem
   ```

2. Start a licensed instance with the variable set:

   ```sh
   GIT_SSL_CAINFO=/tmp/ca.pem pnpm dev:be
   ```

3. Open **Settings > Environments**, select **HTTPS**, enter `https://self-signed.badssl.com/repo.git` with any username and token, and select **Connect**.
4. On `master` the toast reports an SSL certificate error. With this change Git gets past TLS and reports that the repository was not found, because badssl is not a Git server.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-1022

Same root cause as https://linear.app/n8n/issue/LIGO-27, fixed for proxies in #24104.

Docs: https://github.com/n8n-io/n8n-docs/pull/5369

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->