### PR TITLE
fix(core): Match new URL().pathname when extractUrlPath runs in an isolate

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/__tests__/string-extensions.test.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/__tests__/string-extensions.test.ts
@@ -34,6 +34,40 @@ describe('extractUrlPath (imperative parser, no URL constructor)', () => {
 	])('should return undefined for malformed input: %s', (input) => {
 		expect(extractUrlPath(input)).toBeUndefined();
 	});
+
+	// The legacy engine, and the expression preview in the editor, read the path
+	// from `new URL()`. The parser must give the same path for the same URL.
+	it.each([
+		'https://example.com/v1/../v2/users',
+		'https://example.com/a/./b',
+		'https://example.com/a/b/..',
+		'https://example.com/../a',
+		'https://example.com/a/../../b',
+		'https://example.com/./',
+		'https://example.com/a/..',
+		'https://example.com/path/',
+		'https://de.wikipedia.org/wiki/Käse',
+		'https://example.com/日本',
+		'https://example.com/my report.pdf',
+		'https://example.com/a"b',
+		'https://example.com/a<b>c',
+		'https://example.com/a`b',
+		'https://example.com/a{b}c',
+		'https://example.com/a^b',
+		'https://example.com/a|b',
+		"https://example.com/a'b",
+		'https://example.com/a+b;c=d',
+		'https://example.com/a:b@c',
+		'https://example.com/a%2fb',
+		'https://example.com/%7Efoo',
+		'https://example.com/%20',
+		'https://example.com/a%b',
+		'https://example.com/emoji/😀',
+		'https://example.com/path?q=1',
+		'https://example.com/path#frag',
+	])('should give the same path as new URL() for %s', (input) => {
+		expect(extractUrlPath(input)).toBe(new URL(input).pathname);
+	});
 });
 
 describe('toSentenceCase', () => {

--- a/packages/@n8n/expression-runtime/src/extensions/__tests__/string-extensions.test.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/__tests__/string-extensions.test.ts
@@ -65,6 +65,15 @@ describe('extractUrlPath (imperative parser, no URL constructor)', () => {
 		'https://example.com/emoji/😀',
 		'https://example.com/path?q=1',
 		'https://example.com/path#frag',
+		'https://example.com/a/%2e%2e/b',
+		'https://example.com/a/%2E./b',
+		'https://example.com/a/%2e/b',
+		'https://example.com/a%2eb',
+		'https://example.com/a\\b',
+		'https://example.com\\a\\b',
+		'https://example.com/a\\..\\b',
+		'ws://example.com/a\\b',
+		'ftp://example.com/a/../b',
 	])('should give the same path as new URL() for %s', (input) => {
 		expect(extractUrlPath(input)).toBe(new URL(input).pathname);
 	});

--- a/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
@@ -375,6 +375,9 @@ function isDigit(ch: number): boolean {
 	return ch >= 48 && ch <= 57;
 }
 
+// The schemes for which the WHATWG URL parser reads "\" as a path separator
+const SPECIAL_SCHEMES = new Set(['ftp', 'file', 'http', 'https', 'ws', 'wss']);
+
 // The punctuation in the path percent-encode set of the WHATWG URL parser. The
 // set also holds `?` and `#`, but they end the path and cannot reach here.
 const PATH_PERCENT_ENCODE_PUNCTUATION = '"<>^`{}';
@@ -400,6 +403,15 @@ function percentEncodePath(path: string): string {
 	return encoded;
 }
 
+// Count the dots in a single-dot or double-dot path segment. The URL parser
+// reads `%2e` as a dot here, in either case, so `.%2E` is a double-dot segment.
+function dotSegmentDots(segment: string): number {
+	const dots = segment.toLowerCase().replaceAll('%2e', '.');
+	if (dots === '.') return 1;
+	if (dots === '..') return 2;
+	return 0;
+}
+
 // Resolve `.` and `..` segments, as RFC 3986 section 5.2.4 specifies. `path`
 // always starts with a "/", so the first segment is empty and the join adds it
 // back.
@@ -407,14 +419,14 @@ function removeDotSegments(path: string): string {
 	const segments = path.split('/');
 	const kept: string[] = [];
 	for (let i = 1; i < segments.length; i++) {
-		const segment = segments[i];
-		if (segment === '.' || segment === '..') {
-			if (segment === '..') kept.pop();
-			// A trailing dot segment leaves the path ending in a slash
-			if (i === segments.length - 1) kept.push('');
-		} else {
-			kept.push(segment);
+		const dots = dotSegmentDots(segments[i]);
+		if (dots === 0) {
+			kept.push(segments[i]);
+			continue;
 		}
+		if (dots === 2) kept.pop();
+		// A trailing dot segment leaves the path ending in a slash
+		if (i === segments.length - 1) kept.push('');
 	}
 	return `/${kept.join('/')}`;
 }
@@ -439,14 +451,18 @@ function extractUrlPath(value: string) {
 		}
 	}
 
+	// For a special scheme the URL parser reads "\" as a path separator too
+	const isSpecial = SPECIAL_SCHEMES.has(value.slice(0, protoEnd).toLowerCase());
+	const startsPath = (char: string) => char === '/' || (isSpecial && char === '\\');
+
 	const hostStart = protoEnd + 3;
 	if (hostStart >= value.length) return undefined;
 
-	// Find where host ends (first /, ?, or #)
+	// Find where host ends (first path separator, ?, or #)
 	let pathStart = hostStart;
 	while (
 		pathStart < value.length &&
-		value[pathStart] !== '/' &&
+		!startsPath(value[pathStart]) &&
 		value[pathStart] !== '?' &&
 		value[pathStart] !== '#'
 	) {
@@ -454,7 +470,7 @@ function extractUrlPath(value: string) {
 	}
 
 	// No path segment found
-	if (pathStart >= value.length || value[pathStart] !== '/') return '/';
+	if (pathStart >= value.length || !startsPath(value[pathStart])) return '/';
 
 	// Find where path ends (first ? or #)
 	let pathEnd = pathStart;
@@ -463,7 +479,8 @@ function extractUrlPath(value: string) {
 	}
 
 	// The URL parser removes tabs and newlines before it reads the path.
-	const path = value.slice(pathStart, pathEnd).replace(/[\t\n\r]/g, '') || '/';
+	let path = value.slice(pathStart, pathEnd).replace(/[\t\n\r]/g, '') || '/';
+	if (isSpecial) path = path.replaceAll('\\', '/');
 	return percentEncodePath(removeDotSegments(path));
 }
 

--- a/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
@@ -375,11 +375,56 @@ function isDigit(ch: number): boolean {
 	return ch >= 48 && ch <= 57;
 }
 
+// The punctuation in the path percent-encode set of the WHATWG URL parser. The
+// set also holds `?` and `#`, but they end the path and cannot reach here.
+const PATH_PERCENT_ENCODE_PUNCTUATION = '"<>^`{}';
+
+// Percent-encode the path percent-encode set: the punctuation above, C0
+// controls, space, DEL, and every code point above ASCII.
+function percentEncodePath(path: string): string {
+	let encoded = '';
+	// A string iterates by code point, so an astral character is encoded once.
+	for (const codePoint of path) {
+		const code = codePoint.codePointAt(0) as number;
+		if (code > 0x20 && code < 0x7f && !PATH_PERCENT_ENCODE_PUNCTUATION.includes(codePoint)) {
+			encoded += codePoint;
+		} else {
+			try {
+				encoded += encodeURIComponent(codePoint);
+			} catch {
+				// A lone surrogate. The URL parser replaces it with U+FFFD.
+				encoded += '%EF%BF%BD';
+			}
+		}
+	}
+	return encoded;
+}
+
+// Resolve `.` and `..` segments, as RFC 3986 section 5.2.4 specifies. `path`
+// always starts with a "/", so the first segment is empty and the join adds it
+// back.
+function removeDotSegments(path: string): string {
+	const segments = path.split('/');
+	const kept: string[] = [];
+	for (let i = 1; i < segments.length; i++) {
+		const segment = segments[i];
+		if (segment === '.' || segment === '..') {
+			if (segment === '..') kept.pop();
+			// A trailing dot segment leaves the path ending in a slash
+			if (i === segments.length - 1) kept.push('');
+		} else {
+			kept.push(segment);
+		}
+	}
+	return `/${kept.join('/')}`;
+}
+
 // DIVERGENCE from packages/workflow/src/extensions/string-extensions.ts:
 // The original uses the URL constructor which is a Web API unavailable inside
 // the V8 isolate. A simple imperative parser extracts the pathname instead.
 // It requires a scheme (e.g. "https://") followed by a non-empty host, then
-// returns everything from the first "/" up to "?" or "#" (or "/" if no path).
+// returns everything from the first "/" up to "?" or "#" (or "/" if no path),
+// normalized the way the URL constructor normalizes a pathname.
 function extractUrlPath(value: string) {
 	const protoEnd = value.indexOf('://');
 	if (protoEnd < 1) return undefined;
@@ -417,7 +462,9 @@ function extractUrlPath(value: string) {
 		pathEnd++;
 	}
 
-	return value.slice(pathStart, pathEnd) || '/';
+	// The URL parser removes tabs and newlines before it reads the path.
+	const path = value.slice(pathStart, pathEnd).replace(/[\t\n\r]/g, '') || '/';
+	return percentEncodePath(removeDotSegments(path));
 }
 
 function parseJson(value: string): unknown {

--- a/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
@@ -328,6 +328,8 @@ describe('Data Transformation Functions', () => {
 			['https://de.wikipedia.org/wiki/Käse', '/wiki/K%C3%A4se'],
 			['https://example.com/my report.pdf', '/my%20report.pdf'],
 			['https://example.com/a<b>c', '/a%3Cb%3Ec'],
+			['https://example.com/a/%2e%2e/b', '/b'],
+			['https://example.com/a\\b', '/a/b'],
 			['https://example.com/a%2fb', '/a%2fb'],
 			['https://example.com/a+b;c=d', '/a+b;c=d'],
 		])('.extractUrlPath should normalize the path of %s', (url, expected) => {

--- a/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
@@ -318,6 +318,22 @@ describe('Data Transformation Functions', () => {
 			expect(evaluate('={{ "hi".extractUrlPath() }}')).toBeUndefined();
 		});
 
+		// The legacy engine and the editor preview read the path from the URL
+		// constructor, which resolves dot segments and percent-encodes the path.
+		// Every engine must return the same path for the same URL.
+		test.each([
+			['https://example.com/v1/../v2/users', '/v2/users'],
+			['https://example.com/a/./b', '/a/b'],
+			['https://example.com/a/b/..', '/a/'],
+			['https://de.wikipedia.org/wiki/Käse', '/wiki/K%C3%A4se'],
+			['https://example.com/my report.pdf', '/my%20report.pdf'],
+			['https://example.com/a<b>c', '/a%3Cb%3Ec'],
+			['https://example.com/a%2fb', '/a%2fb'],
+			['https://example.com/a+b;c=d', '/a+b;c=d'],
+		])('.extractUrlPath should normalize the path of %s', (url, expected) => {
+			expect(evaluate('={{ $json.url.extractUrlPath() }}', [{ url }])).toEqual(expected);
+		});
+
 		test('.parseJson should work on a string', () => {
 			expect(evaluate('={{ \'{"test1":1,"test2":"2"}\'.parseJson() }}')).toEqual({
 				test1: 1,


### PR DESCRIPTION
## Summary

Build a workflow that reads a path out of a URL:

* Edit Fields → `url` (string) = `https://de.wikipedia.org/wiki/Käse`
* Edit Fields → `path` (string) = `{{ $json.url.extractUrlPath() }}`

The preview under the field says `/wiki/K%C3%A4se`. Run the workflow and the node writes `/wiki/Käse`. Both are reported as success, and the value the rest of the workflow uses is the one the builder never saw.

The two values come from two implementations of the same function:

* The browser has no isolate, so the editor always evaluates through the legacy path in `packages/workflow/src/extensions/string-extensions.ts`, which reads `new URL(value).pathname`. `renderExpression()` in `packages/workflow/src/expression.ts` states this: *"The VM engines (isolated-vm, quickjs) are Node-only; the browser always uses the legacy path below."*
* The server default is the `vm` engine (`ExpressionEngineConfig.engine = 'vm'`), which runs the copy in `packages/@n8n/expression-runtime`. There is no `URL` constructor inside the isolate, so #26689 replaced it with an imperative parser.

The parser slices the path out of the string and returns it as it found it. `new URL().pathname` normalizes it first. That is the whole gap, and this PR adds the missing steps:

* `removeDotSegments()` — RFC 3986 section 5.2.4, which is what the WHATWG path state applies to `.` and `..`. A segment counts as a dot segment when it is spelled `%2e`, in either case, which is what the URL parser does.
* `percentEncodePath()` — the path percent-encode set: C0 controls, space, DEL, every code point above ASCII, and `"` `<` `>` `^` `` ` `` `{` `}`. (`?` and `#` are in the set as well, but they end the path and never reach it.) The string is iterated by code point, so an astral character is encoded once rather than one surrogate half at a time.
* For a special scheme (`ftp file http https ws wss`) the parser reads `\` as a path separator, before both steps above.

Characters outside the encode set are left alone, so an already-encoded path is not encoded twice: `/a%2fb` stays `/a%2fb`, and `+ ; = ' | : @` stay literal.

Nothing in `packages/workflow` changes. The legacy path already calls the real `URL` constructor and was already correct.

### Why this approach

Importing a URL polyfill into the isolate bundle is a lot of code to make one function agree on a path. The gap is these normalization steps, all of them short and specified, so the parser applies them itself. The oracle test below then pins the result to the real constructor, so later drift fails a test instead of going quiet again.

## How to test

**Manually**

1. Start n8n with the default engine (leave `N8N_EXPRESSION_ENGINE` unset).
2. Build the two Edit Fields nodes above.
3. Read the preview under `path`, then run the workflow and read the node output. Before this change they differ; after it both are `/wiki/K%C3%A4se`.

These URLs show it too: `https://example.com/my report.pdf`, `https://example.com/v1/../v2/users`, `https://example.com/a<b>c`, `https://example.com/a\b`.

**Regression test that fails on `master`**

`packages/workflow` runs its expression tests once for each engine (`vm`, `legacy`, `quickjs`), so one file shows the split. The 10 cases added to `packages/workflow/test/ExpressionExtensions/string-extensions.test.ts` fail under `vm-engine` and `quickjs-engine` on `master` and pass under `legacy-engine`, whose answers are `new URL(input).pathname`.

On `master` at b4fee56db3, with only the tests applied:

```
$ cd packages/workflow && pnpm vitest run test/ExpressionExtensions/string-extensions.test.ts
Test Files  2 failed | 1 passed (3)
     Tests  16 failed | 143 passed (159)

FAIL |vm-engine| .extractUrlPath should normalize the path of https://de.wikipedia.org/wiki/Käse
  Expected: "/wiki/K%C3%A4se"     Received: "/wiki/Käse"
FAIL |vm-engine| .extractUrlPath should normalize the path of https://example.com/my report.pdf
  Expected: "/my%20report.pdf"    Received: "/my report.pdf"
FAIL |vm-engine| .extractUrlPath should normalize the path of https://example.com/a<b>c
  Expected: "/a%3Cb%3Ec"          Received: "/a<b>c"
FAIL |vm-engine| .extractUrlPath should normalize the path of https://example.com/v1/../v2/users
  Expected: "/v2/users"           Received: "/v1/../v2/users"
FAIL |vm-engine| .extractUrlPath should normalize the path of https://example.com/a/./b
  Expected: "/a/b"                Received: "/a/./b"
FAIL |vm-engine| .extractUrlPath should normalize the path of https://example.com/a/b/..
  Expected: "/a/"                 Received: "/a/b/.."
FAIL |vm-engine| .extractUrlPath should normalize the path of https://example.com/a/%2e%2e/b
  Expected: "/b"                  Received: "/a/%2e%2e/b"
FAIL |vm-engine| .extractUrlPath should normalize the path of https://example.com/a\b
  Expected: "/a/b"                Received: "/a\b"
```

`quickjs-engine` fails the same 8. The two cases that must keep working, `/a%2fb` and `/a+b;c=d`, pass on all three engines before and after.

The unit test in `packages/@n8n/expression-runtime/src/extensions/__tests__/string-extensions.test.ts` compares the parser against the real constructor over 38 URLs, `expect(extractUrlPath(input)).toBe(new URL(input).pathname)`. That package runs under Node, where `URL` exists, so the expectations cannot drift from the API this replaces. On `master`:

```
$ cd packages/@n8n/expression-runtime && pnpm vitest run src/extensions/__tests__/string-extensions.test.ts
Test Files  1 failed (1)
     Tests  24 failed | 38 passed (62)

AssertionError: expected '/v1/../v2/users' to be '/v2/users'
AssertionError: expected '/a/b/..' to be '/a/'
AssertionError: expected '/emoji/😀' to be '/emoji/%F0%9F%98%80'
AssertionError: expected '/a^b' to be '/a%5Eb'
```

With this PR applied both suites pass, and the package suites stay green:

```
$ cd packages/@n8n/expression-runtime && pnpm vitest run src/extensions/__tests__/string-extensions.test.ts
Test Files  1 passed (1)
     Tests  62 passed (62)

$ cd packages/@n8n/expression-runtime && pnpm vitest run
Test Files  26 passed (26)
     Tests  614 passed | 3 skipped (617)

$ cd packages/@n8n/expression-runtime && pnpm typecheck
(clean)

$ cd packages/workflow && pnpm vitest run test/ExpressionExtensions/string-extensions.test.ts
 ✓ |legacy-engine|  (53 tests)
 ✓ |vm-engine|      (53 tests)
 ✓ |quickjs-engine| (53 tests)
Test Files  3 passed (3)
     Tests  159 passed (159)

$ cd packages/workflow && pnpm typecheck && pnpm lint
(clean)
```

The full `packages/workflow` suite is `3 failed | 9673 passed | 2 skipped (9678)`. The 3 failures are in `test/ExpressionExtensions/date-extensions.test.ts`, which reads a local time zone; that file is `3 failed | 162 passed (165)` on an unmodified `master` on the same machine. This change does not touch it.

The isolate loads a bundle, so `pnpm --filter @n8n/expression-runtime build` has to run before the `packages/workflow` tests pick the change up.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #38264

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- The docs page for extractUrlPath describes the behaviour this restores, so there is nothing to change there. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

Per the note on AI tools in CONTRIBUTING.md: an AI assistant helped run the reproduction and draft this description. Every number above comes from a command that was run in this repository, and I can explain the parser and the URL path rules it has to match without it.
