### PR TITLE
fix(ai-builder): Show reusable credentials in the Instance AI agent credential card

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.n8nCredits.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.n8nCredits.test.ts
@@ -90,7 +90,7 @@ function makeRequest(): InstanceAiCredentialRequest[] {
 	];
 }
 
-describe('InstanceAiCredentialSetup - n8n credits with NodeCredentials', () => {
+describe('InstanceAiCredentialSetup - with real NodeCredentials', () => {
 	let thread: ThreadRuntime;
 
 	beforeEach(() => {
@@ -152,5 +152,73 @@ describe('InstanceAiCredentialSetup - n8n credits with NodeCredentials', () => {
 			kind: 'credentialSelection',
 			credentials: { openAiApi: AI_GATEWAY_MANAGED_TAG },
 		});
+	});
+
+	// The picker renders from the payload before the setup fetch has
+	// filled the store (or after it failed). Picking a row must resolve the
+	// credential from the rows shown, not from a store that does not hold it.
+	it('lets the user pick a payload credential the store has not loaded', async () => {
+		const credentialsStore = useCredentialsStore();
+		credentialsStore.state.credentials = {};
+		Object.defineProperty(credentialsStore, 'getCredentialById', {
+			configurable: true,
+			get: () => () => undefined,
+		});
+		Object.defineProperty(credentialsStore, 'getUsableCredentialByType', {
+			configurable: true,
+			get: () => () => [],
+		});
+		Object.defineProperty(credentialsStore, 'allUsableCredentialsByType', {
+			configurable: true,
+			get: () => ({}),
+		});
+		const confirmSpy = vi.spyOn(thread, 'confirmAction').mockResolvedValue(true);
+
+		renderComponent({
+			props: {
+				requestId: 'req-1',
+				credentialRequests: makeRequest(),
+				message: 'Set up credentials',
+				requireUserSelection: true,
+			},
+		});
+
+		const select = screen.getByTestId('node-credentials-select');
+		// Real credentials are listed, so the empty-slice path must not have
+		// auto-enabled n8n credits behind the user's back.
+		expect(select.querySelector('[data-icon="wallet"]')).toBeNull();
+
+		await userEvent.click(select);
+		await userEvent.click(await screen.findByTestId('node-credentials-select-item-cred-1'));
+		await userEvent.click(screen.getByTestId('instance-ai-credential-continue-button'));
+
+		expect(confirmSpy).toHaveBeenCalledWith('req-1', {
+			kind: 'credentialSelection',
+			credentials: { openAiApi: 'cred-1' },
+		});
+	});
+
+	it('falls back to the store slice when the payload lists no credentials', async () => {
+		renderComponent({
+			props: {
+				requestId: 'req-1',
+				credentialRequests: [
+					{
+						credentialType: 'openAiApi',
+						reason: 'Enter a valid OpenAI API key',
+						existingCredentials: [],
+					},
+				],
+				message: 'Set up credentials',
+				requireUserSelection: true,
+			},
+		});
+
+		// The card gated on the slice, so the picker must read the slice too —
+		// an empty override would render NodeCredentials' empty state instead.
+		expect(screen.queryByTestId('node-credentials-empty-state')).toBeNull();
+		await userEvent.click(screen.getByTestId('node-credentials-select'));
+		expect(await screen.findByTestId('node-credentials-select-item-cred-1')).toBeTruthy();
+		expect(screen.getByTestId('node-credentials-select-item-cred-2')).toBeTruthy();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.n8nCredits.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.n8nCredits.test.ts
@@ -198,6 +198,45 @@ describe('InstanceAiCredentialSetup - with real NodeCredentials', () => {
 		});
 	});
 
+	it('auto-selects from the payload before the usable slice has been fetched', async () => {
+		const credentialsStore = useCredentialsStore();
+		Object.defineProperty(credentialsStore, 'hasFetchedUsableCredentials', {
+			configurable: true,
+			get: () => false,
+		});
+		Object.defineProperty(credentialsStore, 'allUsableCredentialsByType', {
+			configurable: true,
+			get: () => ({}),
+		});
+
+		renderComponent({
+			props: {
+				requestId: 'req-1',
+				credentialRequests: [
+					{
+						credentialType: 'openAiApi',
+						reason: 'Enter a valid OpenAI API key',
+						existingCredentials: [
+							{ id: 'cred-1', name: 'OpenAI account' },
+							{ id: 'cred-2', name: 'OpenAI account 2' },
+						],
+					},
+				],
+				message: 'Set up credentials',
+				requireUserSelection: true,
+			},
+		});
+
+		// The payload is the whole list; waiting for the slice fetch would leave a
+		// multi-credential card unselected until unrelated store activity re-fired.
+		await vi.waitFor(() => {
+			expect(screen.getByTestId('instance-ai-credential-step-check')).toBeTruthy();
+		});
+		expect(
+			screen.getByTestId('node-credentials-select').querySelector('[data-icon="wallet"]'),
+		).toBeNull();
+	});
+
 	it('falls back to the store slice when the payload lists no credentials', async () => {
 		renderComponent({
 			props: {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.n8nCredits.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.n8nCredits.test.ts
@@ -90,7 +90,7 @@ function makeRequest(): InstanceAiCredentialRequest[] {
 	];
 }
 
-describe('InstanceAiCredentialSetup - n8n credits with NodeCredentials', () => {
+describe('InstanceAiCredentialSetup - with real NodeCredentials', () => {
 	let thread: ThreadRuntime;
 
 	beforeEach(() => {
@@ -152,5 +152,73 @@ describe('InstanceAiCredentialSetup - n8n credits with NodeCredentials', () => {
 			kind: 'credentialSelection',
 			credentials: { openAiApi: AI_GATEWAY_MANAGED_TAG },
 		});
+	});
+
+	// AGENT-799: the picker renders from the payload before the setup fetch has
+	// filled the store (or after it failed). Picking a row must resolve the
+	// credential from the rows shown, not from a store that does not hold it.
+	it('lets the user pick a payload credential the store has not loaded', async () => {
+		const credentialsStore = useCredentialsStore();
+		credentialsStore.state.credentials = {};
+		Object.defineProperty(credentialsStore, 'getCredentialById', {
+			configurable: true,
+			get: () => () => undefined,
+		});
+		Object.defineProperty(credentialsStore, 'getUsableCredentialByType', {
+			configurable: true,
+			get: () => () => [],
+		});
+		Object.defineProperty(credentialsStore, 'allUsableCredentialsByType', {
+			configurable: true,
+			get: () => ({}),
+		});
+		const confirmSpy = vi.spyOn(thread, 'confirmAction').mockResolvedValue(true);
+
+		renderComponent({
+			props: {
+				requestId: 'req-1',
+				credentialRequests: makeRequest(),
+				message: 'Set up credentials',
+				requireUserSelection: true,
+			},
+		});
+
+		const select = screen.getByTestId('node-credentials-select');
+		// Real credentials are listed, so the empty-slice path must not have
+		// auto-enabled n8n credits behind the user's back.
+		expect(select.querySelector('[data-icon="wallet"]')).toBeNull();
+
+		await userEvent.click(select);
+		await userEvent.click(await screen.findByTestId('node-credentials-select-item-cred-1'));
+		await userEvent.click(screen.getByTestId('instance-ai-credential-continue-button'));
+
+		expect(confirmSpy).toHaveBeenCalledWith('req-1', {
+			kind: 'credentialSelection',
+			credentials: { openAiApi: 'cred-1' },
+		});
+	});
+
+	it('falls back to the store slice when the payload lists no credentials', async () => {
+		renderComponent({
+			props: {
+				requestId: 'req-1',
+				credentialRequests: [
+					{
+						credentialType: 'openAiApi',
+						reason: 'Enter a valid OpenAI API key',
+						existingCredentials: [],
+					},
+				],
+				message: 'Set up credentials',
+				requireUserSelection: true,
+			},
+		});
+
+		// The card gated on the slice, so the picker must read the slice too —
+		// an empty override would render NodeCredentials' empty state instead.
+		expect(screen.queryByTestId('node-credentials-empty-state')).toBeNull();
+		await userEvent.click(screen.getByTestId('node-credentials-select'));
+		expect(await screen.findByTestId('node-credentials-select-item-cred-1')).toBeTruthy();
+		expect(screen.getByTestId('node-credentials-select-item-cred-2')).toBeTruthy();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -101,7 +101,7 @@ vi.mock('@/features/credentials/components/CredentialIcon.vue', () => ({
 
 vi.mock('@/features/credentials/components/NodeCredentials.vue', () => ({
 	default: {
-		props: ['node', 'overrideCredType', 'projectId', 'standalone', 'hideIssues'],
+		props: ['node', 'overrideCredType', 'projectId', 'standalone', 'hideIssues', 'credentials'],
 		emits: ['credentialSelected'],
 		setup(props: { overrideCredType: string }, { emit }: { emit: Function }) {
 			const onClick = () => {
@@ -113,7 +113,8 @@ vi.mock('@/features/credentials/components/NodeCredentials.vue', () => ({
 			};
 			return { onClick };
 		},
-		template: '<div data-test-id="credential-picker" @click="onClick" />',
+		template:
+			'<div data-test-id="credential-picker" :data-cred-count="credentials ? credentials.length : 0" @click="onClick" />',
 	},
 }));
 
@@ -384,6 +385,43 @@ describe('InstanceAiCredentialSetup', () => {
 
 			expect(getByText('Reason for type 1')).toBeTruthy();
 			expect(getAllByTestId('credential-picker')).toHaveLength(1);
+		});
+
+		// AGENT-799: the reusable-credentials dropdown must render from the
+		// backend-supplied existingCredentials list even when the shared
+		// usable-credentials slice is empty (e.g. a competing scoped fetch on the
+		// canvas cleared it, or no projectId was available to scope the fetch).
+		it('renders the picker from payload existingCredentials when the usable slice is empty', () => {
+			const credentialsStore = useCredentialsStore();
+			// Slice empty — the pre-fix bug: the card would render the setup button
+			// instead of the picker.
+			stubUsableCredentials(credentialsStore, () => []);
+
+			const requests: InstanceAiCredentialRequest[] = [
+				{
+					credentialType: 'linearApi',
+					reason: 'For the Linear tool',
+					existingCredentials: [
+						{ id: 'lin-1', name: 'Linear Team' },
+						{ id: 'lin-2', name: 'Personal Linear' },
+					],
+				},
+			];
+
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: requests,
+					message: 'Set up credentials',
+				},
+			});
+
+			const picker = getByTestId('credential-picker');
+			expect(picker).toBeTruthy();
+			// The setup button must not render alongside the picker.
+			expect(queryByTestId('instance-ai-credential-setup-button')).toBeNull();
+			// The backend-supplied list is forwarded to the picker verbatim.
+			expect(picker.getAttribute('data-cred-count')).toBe('2');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -8,6 +8,7 @@ import CredentialIcon from '@/features/credentials/components/CredentialIcon.vue
 import { deriveServiceName } from '@/features/credentials/templatedAuth.utils';
 import NodeCredentials from '@/features/credentials/components/NodeCredentials.vue';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import type { ICredentialsResponse } from '@/features/credentials/credentials.types';
 import { useQuickConnect } from '@/features/credentials/quickConnect/composables/useQuickConnect';
 import type { INodeUi, INodeUpdatePropertiesInformation } from '@/Interface';
 import {
@@ -273,9 +274,42 @@ function getDisplayName(request: InstanceAiCredentialRequest): string {
 const hasExistingCredentials = computed(() => {
 	if (!currentRequest.value) return false;
 	const credType = currentRequest.value.credentialType;
-	// Gate on the same source NodeCredentials builds its dropdown from, so the
-	// card renders its own setup button instead of NodeCredentials' empty state.
+	// Prefer the backend-supplied list — it is already project-scoped and
+	// type-matched, so it does not depend on the shared usable-credentials slice
+	// (which may be empty or cleared by a competing scoped fetch). Fall back to
+	// the store so the auto-select path still works when the payload omits it.
+	if ((currentRequest.value.existingCredentials?.length ?? 0) > 0) return true;
 	return (credentialsStore.getUsableCredentialByType(credType)?.length ?? 0) > 0;
+});
+
+/**
+ * The dropdown source for the current step. The backend sends a project-scoped,
+ * exact-type `existingCredentials` list in the suspend payload; mapping it here
+ * (enriched with `type`) lets NodeCredentials render it without depending on the
+ * shared usable-credentials slice. Full store records are used when available so
+ * the row keeps its resolvable/managed badges; otherwise a minimal record is
+ * synthesized from the payload's `{ id, name }`.
+ *
+ * `undefined` when the payload lists nothing, so NodeCredentials falls back to
+ * the store slice — the same source `hasExistingCredentials` fell back to. An
+ * empty array would render an empty picker instead of the card's setup button.
+ */
+const dropdownCredentials = computed<ICredentialsResponse[] | undefined>(() => {
+	const req = currentRequest.value;
+	if (!req?.existingCredentials?.length) return undefined;
+	return req.existingCredentials.map((c) => {
+		const stored = credentialsStore.getCredentialById(c.id);
+		return stored && stored.type === req.credentialType
+			? stored
+			: {
+					id: c.id,
+					name: c.name,
+					type: req.credentialType,
+					isManaged: false,
+					createdAt: '',
+					updatedAt: '',
+				};
+	});
 });
 
 function hasEasySetup(credentialType: string): boolean {
@@ -643,6 +677,7 @@ async function handleSetupAutomatically() {
 							:prefer-new-credential="currentRequest.preferNew === true"
 							:credential-setup-hint="currentRequest.setupHint"
 							:credentials-field-label="credentialsFieldLabel"
+							:credentials="dropdownCredentials"
 							@credential-selected="onCredentialSelected(currentRequest.credentialType, $event)"
 						/>
 						<N8nActionDropdown

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -15,6 +15,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore } from '@/__tests__/utils';
 import type { INodeUi } from '@/Interface';
 import { useCredentialsStore } from '../credentials.store';
+import * as credentialsApi from '../credentials.api';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { Project } from '@/features/collaboration/projects/projects.types';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
@@ -1682,6 +1683,135 @@ describe('NodeCredentials', () => {
 				id: 'c8vqdPpPClh4TgIO',
 				name: 'OpenAi account',
 			});
+		});
+	});
+
+	// A host can hand the picker its own list (the Instance AI setup
+	// card receives one in the suspend payload). Every path that reads a picked
+	// or restored credential must then resolve from that list, because the flat
+	// map and the usable slice may hold nothing yet — or ever, if the fetch fails.
+	describe('host-supplied credentials list', () => {
+		const httpNodeNoCreds: INodeUi = { ...httpNode, credentials: {} };
+		const olderCred = {
+			...createCredential({ id: 'payload-older', name: 'Older payload cred' }),
+			updatedAt: '2024-01-01T00:00:00.000Z',
+		};
+		const newerCred = {
+			...createCredential({ id: 'payload-newer', name: 'Newer payload cred' }),
+			updatedAt: '2024-06-01T00:00:00.000Z',
+		};
+
+		type SelectedPayload = {
+			name: string;
+			properties: { credentials: Record<string, { id: string | null; name: string }> };
+		};
+
+		beforeEach(() => {
+			// Nothing in the store: the list is the only source of truth.
+			stopCredentialsMirror();
+			credentialsStore.state.credentials = {};
+			credentialsStore.usableCredentials = {};
+			credentialsStore.hasFetchedUsableCredentials = false;
+			ndvStore.activeNode = httpNodeNoCreds;
+		});
+
+		it('auto-selects the most recent supplied credential without waiting for the slice fetch', () => {
+			const { emitted } = renderComponent({
+				props: { node: httpNodeNoCreds, credentials: [olderCred, newerCred] },
+			});
+
+			const payload = (emitted('credentialSelected')?.[0] as [SelectedPayload])?.[0];
+			expect(payload?.properties.credentials['openAiApi']).toEqual({
+				id: 'payload-newer',
+				name: 'Newer payload cred',
+			});
+		});
+
+		it('lists the supplied credentials and emits the picked row even when the store lacks it', async () => {
+			const { emitted } = renderComponent({
+				props: { node: httpNodeNoCreds, credentials: [olderCred, newerCred], skipAutoSelect: true },
+			});
+
+			await userEvent.click(screen.getByTestId('node-credentials-select'));
+			expect(screen.getByText('Older payload cred')).toBeInTheDocument();
+			expect(screen.getByText('Newer payload cred')).toBeInTheDocument();
+
+			await userEvent.click(screen.getByTestId('node-credentials-select-item-payload-older'));
+
+			const payload = (emitted('credentialSelected')?.[0] as [SelectedPayload])?.[0];
+			expect(payload?.properties.credentials['openAiApi']).toEqual({
+				id: 'payload-older',
+				name: 'Older payload cred',
+			});
+		});
+
+		it('restores from the supplied list when n8n credits is toggled off', () => {
+			// The gateway is enabled but this node version no longer qualifies, so the
+			// mount-time cleanup toggles the managed slot off and must restore a row.
+			vi.mocked(useAiGateway).mockReturnValue({
+				isEnabled: computed(() => true),
+				isCredentialTypeSupported: vi.fn((credType: string) => credType === 'openAiApi'),
+				canServeCredentialType: vi.fn((credType: string) => credType === 'openAiApi'),
+				isNodeTypeVersionSupported: vi.fn(() => false),
+				isActionSupported: vi.fn(() => true),
+				isActionOptionVisible: vi.fn(() => true),
+				isNodePropertyHidden: vi.fn(() => false),
+				balance: computed(() => undefined),
+				budget: computed(() => undefined),
+				creditsLabelKey: computed(() => 'generic.freeCredits'),
+				fetchConfig: vi.fn().mockResolvedValue(undefined),
+				fetchWallet: vi.fn().mockResolvedValue(undefined),
+				saveAfterToggle: vi.fn().mockResolvedValue(undefined),
+				fetchError: computed(() => null),
+			});
+			const getByIdSpy = vi.fn().mockReturnValue(undefined);
+			credentialsStore.getCredentialById = getByIdSpy;
+
+			const managedNode: INodeUi = {
+				...httpNodeNoCreds,
+				credentials: { openAiApi: { id: null, name: '', __aiGatewayManaged: true } },
+			};
+			ndvStore.activeNode = managedNode;
+
+			const { emitted } = renderComponent({
+				props: { node: managedNode, credentials: [olderCred, newerCred] },
+			});
+
+			const payload = (emitted('credentialSelected')?.[0] as [SelectedPayload])?.[0];
+			expect(payload?.properties.credentials['openAiApi']).toEqual({
+				id: 'payload-newer',
+				name: 'Newer payload cred',
+			});
+			expect(getByIdSpy).not.toHaveBeenCalled();
+		});
+
+		it('leaves the selection untouched when a picked id is in neither the list nor the store', async () => {
+			// After a deletion the store listener re-selects the last credential in the
+			// usable slice. With a host-supplied list that id can be unknown to both the
+			// displayed rows and the flat map; the pick must then be dropped, not applied
+			// with undefined fields or thrown.
+			const nodeWithSelection: INodeUi = {
+				...httpNodeNoCreds,
+				credentials: { openAiApi: { id: 'payload-older', name: 'Older payload cred' } },
+			};
+			ndvStore.activeNode = nodeWithSelection;
+			credentialsStore.usableCredentials = {
+				'ghost-cred': createCredential({ id: 'ghost-cred', name: 'Ghost cred' }),
+			};
+			vi.spyOn(credentialsApi, 'deleteCredential').mockResolvedValue(true);
+
+			const { emitted } = renderComponent({
+				props: { node: nodeWithSelection, credentials: [olderCred] },
+			});
+
+			// Subscribes the component to store mutations for this credential type.
+			await userEvent.click(
+				screen.getByTestId('credential-edit-button').querySelector('[data-icon="pen"]')!,
+			);
+			await credentialsStore.deleteCredential({ id: 'payload-older' });
+			await nextTick();
+
+			expect(emitted('credentialSelected')).toBeUndefined();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -429,8 +429,9 @@ watch(
 		if (types.length === 0) return;
 		// Before the scoped fetch lands there are no options to pick from, which would
 		// read as "no credentials exist" and auto-enable the AI Gateway below. The
-		// watcher re-fires once the fetch populates the slice.
-		if (!credentialsStore.hasFetchedUsableCredentials) return;
+		// watcher re-fires once the fetch populates the slice. A host-supplied list
+		// is complete on its own, so it does not wait for the fetch.
+		if (!props.credentials && !credentialsStore.hasFetchedUsableCredentials) return;
 
 		const isInitialEvaluation = !hasEvaluatedCredentials;
 		hasEvaluatedCredentials = true;

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -131,6 +131,13 @@ type Props = {
 	 *  document's nonexistent workflow id and replace the credential store
 	 *  with the empty result. */
 	skipCredentialsFetch?: boolean;
+	/** Host-supplied credential list to render in the dropdown instead of the
+	 *  shared usable-credentials slice. Used by hosts that already hold the
+	 *  exact, project-scoped, type-matched list (e.g. the Instance AI setup
+	 *  card, which receives it in the suspend payload) so the dropdown does
+	 *  not depend on a slice that may be empty or cleared by a competing
+	 *  scoped fetch. Items must carry the credential `type`. */
+	credentials?: ICredentialsResponse[];
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -254,6 +261,7 @@ const {
 	nodeType,
 	() => props.overrideCredType,
 	() => props.showAll,
+	() => props.credentials,
 );
 
 const credentialTypeNames = computed(() => {
@@ -270,6 +278,24 @@ const credentialTypeNames = computed(() => {
 const selected = computed<Record<string, INodeCredentialsDetails>>(
 	() => props.node.credentials ?? {},
 );
+
+/**
+ * Resolve a picked credential from the rows the dropdown is showing before
+ * consulting the store. A host-supplied `credentials` list can hold ids the
+ * flat map has not (yet) loaded — the store lookup alone would be `undefined`.
+ */
+function findDisplayedCredential(
+	credentialType: string,
+	credentialId: string,
+): ICredentialsResponse | undefined {
+	const typeEntry = credentialTypesNodeDescriptionDisplayed.value.find(
+		({ type }) => type.name === credentialType,
+	);
+	return (
+		typeEntry?.options.find((option) => option.id === credentialId) ??
+		credentialsStore.getCredentialById(credentialId)
+	);
+}
 
 function isCredentialResolvable(credentialType: string): boolean {
 	if (!isPrivateCredentialsEnabled.value) return false;
@@ -423,7 +449,11 @@ watch(
 
 		if (!isEmpty(selected.value)) return;
 
-		const autoSelected = getAutoSelectedCredential(node.value, props.overrideCredType);
+		const autoSelected = getAutoSelectedCredential(
+			node.value,
+			props.overrideCredType,
+			props.credentials,
+		);
 		if (autoSelected) {
 			onCredentialSelected(
 				autoSelected.credentialType,
@@ -704,7 +734,8 @@ function onCredentialSelected(
 		});
 	}
 
-	const selectedCredentials = credentialsStore.getCredentialById(credentialId);
+	const selectedCredentials = findDisplayedCredential(credentialType, credentialId);
+	if (!selectedCredentials) return;
 	const selectedCredentialsType = props.showAll ? selectedCredentials.type : credentialType;
 	const oldCredentials = props.node.credentials?.[selectedCredentialsType] ?? null;
 
@@ -902,11 +933,12 @@ function onAiGatewaySelector(credentialType: string, enable: boolean, isUserActi
 		);
 
 		if (typeEntry && typeEntry.options.length > 0) {
+			// The option row already carries id and name — no store round-trip, so a
+			// host-supplied credential not yet in the flat map restores too.
 			const mostRecent = typeEntry.options.reduce((a, b) => (a.updatedAt > b.updatedAt ? a : b));
-			const restoredCredential = credentialsStore.getCredentialById(mostRecent.id);
-			credentials[credentialType] = { id: restoredCredential.id, name: restoredCredential.name };
+			credentials[credentialType] = { id: mostRecent.id, name: mostRecent.name };
 			assignedKind = 'own';
-			assignedCredentialId = restoredCredential.id;
+			assignedCredentialId = mostRecent.id;
 		} else {
 			delete credentials[credentialType];
 		}

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
@@ -153,6 +153,54 @@ describe('useNodeCredentialOptions', () => {
 		]);
 	});
 
+	it('uses the override credentials list instead of the usable slice when provided', () => {
+		// Slice empty — the override must supply the options. This is the
+		// Instance AI setup card's path: it holds the backend-supplied list and
+		// must not depend on a slice that may be empty or cleared.
+		credentialsStore.usableCredentials = {};
+		const node = computed(() => slackNode);
+		const nodeType = computed(() => slackNodeType);
+		const override = [
+			createCredential({ id: 'override-1', name: 'Override Cred', type: 'slackApi' }),
+			createCredential({ id: 'override-2', name: 'Override Cred 2', type: 'slackApi' }),
+		];
+
+		const { credentialTypesNodeDescriptionDisplayed } = useNodeCredentialOptions(
+			node,
+			nodeType,
+			'slackApi',
+			false,
+			override,
+		);
+
+		expect(credentialTypesNodeDescriptionDisplayed.value).toHaveLength(1);
+		expect(credentialTypesNodeDescriptionDisplayed.value[0].options.map((o) => o.id)).toEqual([
+			'override-1',
+			'override-2',
+		]);
+	});
+
+	it('filters the override list by credential type', () => {
+		const node = computed(() => slackNode);
+		const nodeType = computed(() => slackNodeType);
+		const override = [
+			createCredential({ id: 'override-1', name: 'Override Cred', type: 'slackApi' }),
+			createCredential({ id: 'other-1', name: 'Other Type', type: 'httpBasicAuth' }),
+		];
+
+		const { credentialTypesNodeDescriptionDisplayed } = useNodeCredentialOptions(
+			node,
+			nodeType,
+			'slackApi',
+			false,
+			override,
+		);
+
+		expect(credentialTypesNodeDescriptionDisplayed.value[0].options.map((o) => o.id)).toEqual([
+			'override-1',
+		]);
+	});
+
 	it('keeps mixed credential options in the NDV when no override is set', () => {
 		const { credentialTypesNodeDescriptionDisplayed } = setupOptions('');
 

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
@@ -25,6 +25,13 @@ export function useNodeCredentialOptions(
 	nodeType: MaybeRefOrGetter<INodeTypeDescription | null>,
 	overrideCredType: MaybeRefOrGetter<NodeParameterValueType | undefined>,
 	displayAllOptions: MaybeRefOrGetter<boolean> = false,
+	/** When provided, build dropdown options from this list instead of the
+	 *  shared usable-credentials slice. Hosts that already hold the exact,
+	 *  project-scoped, type-matched credential list (e.g. the Instance AI
+	 *  setup card, which receives it in the suspend payload) pass it here so
+	 *  the dropdown does not depend on a slice that may be empty or cleared
+	 *  by a competing scoped fetch. */
+	overrideCredentials: MaybeRefOrGetter<ICredentialsResponse[] | undefined> = undefined,
 ) {
 	const nodeHelpers = useNodeHelpers();
 	const credentialsStore = useCredentialsStore();
@@ -53,15 +60,21 @@ export function useNodeCredentialOptions(
 	);
 
 	function getCredentialOptions(types: string[]): CredentialDropdownOption[] {
+		const override = toValue(overrideCredentials);
 		let options: CredentialDropdownOption[] = [];
 		types.forEach((type) => {
+			// The override is a host-supplied, already-scoped list; fall back to the
+			// shared usable-credentials slice when no override is given. An unfetched
+			// slice reads as empty, never as a fallback to the flat map — falling
+			// back is the bug this override exists to avoid.
+			const source = override
+				? override.filter((credential) => credential.type === type)
+				: credentialsStore.allUsableCredentialsByType[type];
 			options = options.concat(
-				credentialsStore.allUsableCredentialsByType[type]?.map<CredentialDropdownOption>(
-					(option: ICredentialsResponse) => ({
-						...option,
-						typeDisplayName: credentialsStore.getCredentialTypeByName(type)?.displayName ?? '',
-					}),
-				) ?? [],
+				source?.map<CredentialDropdownOption>((option: ICredentialsResponse) => ({
+					...option,
+					typeDisplayName: credentialsStore.getCredentialTypeByName(type)?.displayName ?? '',
+				})) ?? [],
 			);
 		});
 

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.utils.test.ts
@@ -117,6 +117,22 @@ describe('getAutoSelectedCredential', () => {
 		expect(getAutoSelectedCredential(createNode())).toBeUndefined();
 	});
 
+	it('picks from the host-supplied list when one is given, even with an empty slice', () => {
+		// Must agree with the dropdown, which renders the same list — otherwise
+		// "nothing to auto-select" would fire while rows are visibly listed.
+		credentialsStore.usableCredentials = {};
+
+		expect(
+			getAutoSelectedCredential(createNode(), 'openAiApi', [
+				createCredential({ id: 'older', name: 'Older', updatedAt: '2024-01-01T00:00:00.000Z' }),
+				createCredential({ id: 'newer', name: 'Newer', updatedAt: '2024-06-01T00:00:00.000Z' }),
+			]),
+		).toEqual({
+			credentialType: 'openAiApi',
+			credential: { id: 'newer', name: 'Newer' },
+		});
+	});
+
 	it('returns undefined for a node type without credentials', () => {
 		nodeTypesStore.setNodeTypes([
 			{ ...openAiNodeType, name: 'n8n-nodes-base.noOp', credentials: undefined },

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.utils.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.utils.ts
@@ -4,6 +4,7 @@ import type { INodeUi } from '@/Interface';
 import { isEmpty } from '@/app/utils/typesUtils';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useNodeCredentialOptions } from './composables/useNodeCredentialOptions';
+import type { ICredentialsResponse } from './credentials.types';
 
 export interface AutoSelectedCredential {
 	credentialType: string;
@@ -13,10 +14,14 @@ export interface AutoSelectedCredential {
 /**
  * For a node with no credentials set, pick the most recently updated usable
  * credential across its displayed credential types.
+ *
+ * `overrideCredentials` must match what the host's dropdown renders from, so
+ * "nothing to auto-select" and "dropdown is empty" stay the same condition.
  */
 export function getAutoSelectedCredential(
 	node: INodeUi,
 	overrideCredType: NodeParameterValueType = '',
+	overrideCredentials?: ICredentialsResponse[],
 ): AutoSelectedCredential | undefined {
 	if (!isEmpty(node.credentials ?? {})) return undefined;
 
@@ -25,6 +30,8 @@ export function getAutoSelectedCredential(
 		node,
 		nodeTypesStore.getNodeType(node.type, node.typeVersion),
 		overrideCredType,
+		false,
+		overrideCredentials,
 	);
 
 	const allOptions = credentialTypesNodeDescriptionDisplayed.value.flatMap((type) => type.options);


### PR DESCRIPTION
## Summary

When the Instance AI Agent Builder adds a tool that needs a credential, the credential card showed only a "Connect" button, even when a matching credential existed in the project. The card gated its dropdown on the shared usable-credentials store slice, which can be empty (no `projectId` to scope the fetch) or cleared by a competing scoped fetch on the canvas.

The card now renders the dropdown from the `existingCredentials` list the backend already sends in the suspend payload:

- `NodeCredentials` accepts an optional `credentials` prop that overrides the store slice as the dropdown source; auto-select and the picked-row lookup read the same list, so a credential the store has not loaded yet can be selected without a crash.
- `InstanceAiCredentialSetup` passes the payload list (or `undefined` to fall back to the store when the payload is empty).

Frontend only. Same-type channel credentials stay reusable for tools; channel setup is unchanged.

## How to test

## How to test

1. In a project, create a Linear credential or any other credential - Linear was the one reported on the OG ticket.
2. Open a workflow in the canvas, then open Instance AI and ask it to build an Agent with a Linear tool.
3. When the credential card appears, confirm the existing Linear credential is listed in the dropdown and can be selected.
4. Optional: with no Linear credential in the project, confirm the card still shows the "Connect" button.


Snaps:
<img width="866" height="748" alt="image" src="https://github.com/user-attachments/assets/6ad6d466-cf0d-418a-8d27-e76902d4011d" />
<img width="879" height="847" alt="image" src="https://github.com/user-attachments/assets/66ea37e6-2bd6-48c8-87e9-6aa040870b73" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-799


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

