### PR TITLE
feat(core)!: Stop publishing the `n8n` package to npm

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -67,21 +67,18 @@ jobs:
         run: node .github/scripts/detect-new-packages.mjs
 
       - name: Dry-run publishing
-        run: |
-          pnpm --filter n8n publish --no-git-checks --dry-run
-          pnpm publish -r --filter '!n8n' --no-git-checks --dry-run
+        run: pnpm publish -r --no-git-checks --dry-run
 
       - name: Pre publishing changes
         run: |
           node .github/scripts/trim-fe-packageJson.js
           node .github/scripts/ensure-provenance-fields.mjs
-          cp README.md packages/cli/README.md
-          sed -i "s/default: 'dev'/default: '${{ needs.determine-version-info.outputs.release_type }}'/g" packages/cli/dist/config/schema.js
 
+      # Since v3 the `n8n` package (packages/cli) is private and is only shipped inside the
+      # Docker image. `pnpm publish -r` skips private packages, so only the libraries go to npm.
       # Publishing via `pnpm publish -r` is idempotent, as it checks if the package exists
-      # and only publishes if it doesn't. This is why we do the sub-packages before the main n8n package.
-      # So if anything goes wrong, we can easily re-try the run instead of abandoning the release.
-      - name: Publish other packages to NPM
+      # and only publishes if it doesn't. So if anything goes wrong, we can easily re-try the run.
+      - name: Publish packages to NPM
         env:
           PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
           PUBLISH_TAG: ${{ needs.determine-version-info.outputs.track }}
@@ -90,17 +87,7 @@ jobs:
           if [[ "$PUBLISH_TAG" =~ ^v?[0-9] ]]; then
             PUBLISH_TAG="release-${PUBLISH_TAG}"
           fi
-          pnpm publish -r --filter '!n8n' --publish-branch "$PUBLISH_BRANCH" --access public --tag "$PUBLISH_TAG" --no-git-checks
-
-      # If we don't use the --tag rc, all releases will default to "latest".
-      - name: Publish n8n to NPM with rc tag
-        env:
-          PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
-        run: pnpm --filter n8n publish --publish-branch "$PUBLISH_BRANCH" --access public --tag rc --no-git-checks
-
-      - name: Cleanup rc tag
-        run: npm dist-tag rm n8n rc
-        continue-on-error: true
+          pnpm publish -r --publish-branch "$PUBLISH_BRANCH" --access public --tag "$PUBLISH_TAG" --no-git-checks
 
   publish-to-docker-hub:
     name: Publish to DockerHub

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -36,7 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check_version.outputs.version }}
-      major: ${{ steps.check_version.outputs.major }}
       release_channel: ${{ inputs.release-channel }}
     steps:
       - name: Check Version Format
@@ -50,7 +49,6 @@ jobs:
           if [[ "$input_version" =~ $version_regex ]]; then
             echo "Version format is valid: $input_version"
             echo "version=$input_version" >> "$GITHUB_OUTPUT"
-            echo "major=${input_version%%.*}" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Invalid version format provided: '$input_version'. Must match regex '$version_regex'."
             exit 1
@@ -66,38 +64,6 @@ jobs:
             exit 1
           fi
           echo "✅ Version '$INPUT_VERSION' is allowed for '$CHANNEL' channel"
-
-  # Since v3 the `n8n` package is no longer published to npm, so there is nothing to tag.
-  release-to-npm:
-    name: Release to NPM
-    runs-on: ubuntu-latest
-    needs: validate-inputs
-    if: needs.validate-inputs.outputs.major < 3
-    timeout-minutes: 5
-    environment: release
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 24.18.1
-
-      # Remove after https://github.com/npm/cli/issues/8547 gets resolved
-      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Add beta/next tags to NPM
-        if: needs.validate-inputs.outputs.release_channel == 'beta'
-        run: |
-          npm dist-tag add "n8n@${{ needs.validate-inputs.outputs.version }}" next
-          npm dist-tag add "n8n@${{ needs.validate-inputs.outputs.version }}" beta
-
-      - name: Add latest/stable tags to NPM
-        if: needs.validate-inputs.outputs.release_channel == 'stable'
-        run: |
-          npm dist-tag add "n8n@${{ needs.validate-inputs.outputs.version }}" latest
-          npm dist-tag add "n8n@${{ needs.validate-inputs.outputs.version }}" stable
 
   release-to-docker-hub:
     name: Release to DockerHub
@@ -171,7 +137,7 @@ jobs:
   update-docs:
     name: Update latest and next in the docs
     runs-on: ubuntu-latest
-    needs: [validate-inputs, release-to-npm, release-to-docker-hub]
+    needs: [validate-inputs, release-to-docker-hub]
     timeout-minutes: 2
     environment: release
     env:

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check_version.outputs.version }}
+      major: ${{ steps.check_version.outputs.major }}
       release_channel: ${{ inputs.release-channel }}
     steps:
       - name: Check Version Format
@@ -49,6 +50,7 @@ jobs:
           if [[ "$input_version" =~ $version_regex ]]; then
             echo "Version format is valid: $input_version"
             echo "version=$input_version" >> "$GITHUB_OUTPUT"
+            echo "major=${input_version%%.*}" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Invalid version format provided: '$input_version'. Must match regex '$version_regex'."
             exit 1
@@ -65,10 +67,12 @@ jobs:
           fi
           echo "✅ Version '$INPUT_VERSION' is allowed for '$CHANNEL' channel"
 
+  # Since v3 the `n8n` package is no longer published to npm, so there is nothing to tag.
   release-to-npm:
     name: Release to NPM
     runs-on: ubuntu-latest
     needs: validate-inputs
+    if: needs.validate-inputs.outputs.major < 3
     timeout-minutes: 5
     environment: release
     permissions:

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+# 3.0.0
+
+### What changed?
+
+n8n is no longer published to npm. The `n8n` package on npm stays at the last 2.x release and is marked as deprecated. The official Docker image is the only supported way to run n8n.
+
+### When is action necessary?
+
+If you run n8n from the npm package, move to the Docker image before you update. Reuse your existing database and encryption key. See https://docs.n8n.io/deploy/host-n8n
+
 # 2.0.0
 
 ### What changed?

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "n8n",
   "version": "2.39.0",
+  "private": true,
   "description": "n8n Workflow Automation Tool",
   "main": "dist/index",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Since v3 the official Docker image is the only supported way to run n8n. Per the team discussion, this PR stops publishing the `n8n` package to npm instead of shipping a stub. The package on npm stays at the last 2.x release, which keeps receiving security backports, and is deprecated manually after the v3 crossover.

- Mark `packages/cli` as `private`. `pnpm publish -r` skips private packages, so the `--filter '!n8n'` exclusions and the separate `n8n` publish step in `release-publish.yml` are gone, together with the `rc` tag dance, the README copy and the `release_type` patch of `dist/config/schema.js`, all of which only served the npm tarball.
- `release-push-to-channel.yml`: the `release-to-npm` job that moved the `n8n` dist-tags is removed. This workflow only runs from the `3.x` branch, so there is no npm package to tag.
- Add the `3.0.0` entry to `packages/cli/BREAKING-CHANGES.md`.

The Docker build uses `pnpm deploy` from the repo and is not affected.

## Follow-ups after the v3 crossover (not in this PR)

- Deprecate the npm package manually, from a machine with publish rights:
  ```
  npm deprecate n8n@"*" "n8n is no longer published to npm since v3. Use the official Docker image: https://docs.n8n.io/deploy/host-n8n"
  ```
- Add a deprecation notice to the 2.x release line (README of the published package and/or startup warning) once v3 is out.

## Related Linear tickets, Github issues, and Community forum posts

Breaking Changes Tracker: "Remove npm deployment / require Docker". Migration report rule `docker-only-deployment-v3` and the non-Docker deprecation warning landed on master in #33733 and #33295.

## Review / Merge checklist

- [x] PR title and summary are descriptive. (conventions)
- [x] PR targets `3.x`, branched off `master` per `.github/DEVELOPING_V3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)