### PR TITLE
fix(core): Point the Docker-only deprecation notices at the hosting docs (no-changelog)

### DIFF
--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -190,7 +190,7 @@ export class DeprecationService {
 
 		if (!this.instanceSettings.isDocker) {
 			mustWarn.push(
-				' - Running n8n outside a container is deprecated. Future versions will require running n8n via the official Docker image. See https://docs.n8n.io/deploy/host-n8n/install-options/install-with-docker\n',
+				' - Running n8n outside a container is deprecated. Future versions will require running n8n via the official Docker image. See https://docs.n8n.io/deploy/host-n8n\n',
 			);
 		}
 

--- a/packages/cli/src/modules/breaking-changes/rules/v3/docker-only-deployment.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/docker-only-deployment.rule.ts
@@ -22,7 +22,7 @@ export class DockerOnlyDeploymentRule implements IBreakingChangeInstanceRule {
 				'Support for running n8n via npm is removed. The new version must be run via the official Docker image.',
 			category: BreakingChangeCategory.infrastructure,
 			severity: 'medium',
-			documentationUrl: 'https://docs.n8n.io/deploy/host-n8n/install-options/install-with-docker',
+			documentationUrl: 'https://docs.n8n.io/deploy/host-n8n',
 		};
 	}
 


### PR DESCRIPTION
Both the `docker-only-deployment-v3` migration report rule and the non-Docker startup warning now link to https://docs.n8n.io/deploy/host-n8n. Matches the link the v3 npm stub in #38278 uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

