### PR TITLE
fix: Add terminal fallback for cloud sessions (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/cloud-session.test.mjs
+++ b/.devcontainer/codespaces/cloud-session.test.mjs
@@ -27,6 +27,14 @@ if (args[0] === 'codespace' && args[1] === 'list') {
 `,
 	);
 	chmodSync(mockGh, 0o755);
+	for (const [name, script] of Object.entries({
+		infocmp: '[ "$1" = "$SUPPORTED_TERM" ]',
+		tmux: 'printf "%s" "$TERM"',
+	})) {
+		const executable = join(fixtureDir, name);
+		writeFileSync(executable, `#!/bin/sh\n${script}\n`);
+		chmodSync(executable, 0o755);
+	}
 });
 
 after(() => rmSync(fixtureDir, { recursive: true, force: true }));
@@ -56,6 +64,34 @@ function remoteCommand(args) {
 		'-t',
 	]);
 	return invocationArgs[6];
+}
+
+for (const { name, supportedTerm, expectedTerm } of [
+	{
+		name: 'uses xterm-256color when the remote terminal definition is missing',
+		supportedTerm: 'xterm-256color',
+		expectedTerm: 'xterm-256color',
+	},
+	{
+		name: 'keeps the terminal type when the remote definition is available',
+		supportedTerm: 'xterm-ghostty',
+		expectedTerm: 'xterm-ghostty',
+	},
+]) {
+	test(name, () => {
+		const result = spawnSync('/bin/sh', ['-c', remoteCommand(['--opencode'])], {
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				PATH: `${fixtureDir}:${process.env.PATH}`,
+				TERM: 'xterm-ghostty',
+				SUPPORTED_TERM: supportedTerm,
+			},
+		});
+
+		assert.equal(result.status, 0, result.stderr);
+		assert.equal(result.stdout, expectedTerm);
+	});
 }
 
 test('starts a named OpenCode session in a worktree', () => {

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -23,6 +23,11 @@ const MACHINE = 'premiumLinux';
 const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8' }).trim();
 const ghTty = (...args) => spawnSync('gh', args, { stdio: 'inherit' });
 
+// Check the remote terminal database before tmux starts. Older images can lack
+// terminal definitions such as xterm-ghostty.
+const TERMINAL_FALLBACK =
+	'if ! infocmp "$TERM" >/dev/null 2>&1; then export TERM=xterm-256color; fi';
+
 function findCodespace(retry = false) {
 	try {
 		const list = JSON.parse(gh('codespace', 'list', '-R', REPO, '--json', 'name,state'));
@@ -212,7 +217,7 @@ switch (cmd) {
 			name,
 			'--',
 			'-t',
-			`tmux new -As ${tmuxSession} '${remoteCommand(cmd, launcher, rest.join(' '))}'`,
+			`${TERMINAL_FALLBACK}; tmux new -As ${tmuxSession} '${remoteCommand(cmd, launcher, rest.join(' '))}'`,
 		);
 		process.exitCode = status ?? 1;
 	}


### PR DESCRIPTION
## Summary
<img width="821" height="151" alt="image" src="https://github.com/user-attachments/assets/4d15d7e4-fc08-41e4-b805-4b08a1f57776" />

Cloud sessions fail before the agent starts when the Codespace lacks the local terminal definition. This affects Ghostty on the current Codespace image.

Check the remote terminal database before starting tmux. Use `xterm-256color` when the definition is missing. Keep supported terminal types. Apply the check to OpenCode, Claude, and shell sessions.

## How to test

1. Open Ghostty.
2. Run `pnpm session:opencode` against a Codespace without the `xterm-ghostty` definition.
3. Confirm that tmux starts without a terminal error.

Validation completed:
- All 5 session tests pass: `pnpm exec node --test .devcontainer/codespaces/cloud-session.test.mjs`.
- JavaScript syntax and `git diff --check` pass.
- A check in the active Codespace confirms that the fallback changes `xterm-ghostty` to `xterm-256color`. It preserves `xterm-256color` and `tmux-256color`.
- `pnpm lint` and `pnpm typecheck` could not run because Turbo is not installed in this checkout. The formatting check could not run because Prettier is not installed.
- Execution tests cover a missing terminal definition and a supported Ghostty definition. The missing-definition test fails when the fallback is removed.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

