### PR TITLE
fix(core): Make profile update telemetry consistent with account creation (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2513,7 +2513,7 @@ describe('TelemetryEventRelay', () => {
 	});
 
 	describe('user events', () => {
-		it('should track on `user-updated` event', () => {
+		describe('on `user-updated` event', () => {
 			const event: RelayEventMap['user-updated'] = {
 				user: {
 					id: 'user123',
@@ -2525,18 +2525,31 @@ describe('TelemetryEventRelay', () => {
 				fieldsChanged: ['firstName', 'lastName'],
 			};
 
-			eventService.emit('user-updated', event);
+			it('should track without `user_email` on a self-hosted deployment', () => {
+				eventService.emit('user-updated', event);
 
-			expect(telemetry.identify).toHaveBeenCalledWith(
-				{
-					user_role: GLOBAL_OWNER_ROLE.slug,
-					user_email: 'user@example.com',
-				},
-				'user123',
-			);
-			expect(telemetry.track).toHaveBeenCalledWith('User changed personal settings', {
-				user_id: 'user123',
-				fields_changed: ['firstName', 'lastName'],
+				expect(telemetry.identify).toHaveBeenCalledWith(
+					{ user_role: GLOBAL_OWNER_ROLE.slug },
+					'user123',
+				);
+				expect(telemetry.track).toHaveBeenCalledWith('User changed personal settings', {
+					user_id: 'user123',
+					fields_changed: ['firstName', 'lastName'],
+				});
+			});
+
+			it('should track with `user_email` on a cloud deployment', () => {
+				globalConfig.deployment.type = 'cloud';
+				try {
+					eventService.emit('user-updated', event);
+				} finally {
+					globalConfig.deployment.type = 'default';
+				}
+
+				expect(telemetry.identify).toHaveBeenCalledWith(
+					{ user_role: GLOBAL_OWNER_ROLE.slug, user_email: 'user@example.com' },
+					'user123',
+				);
 			});
 		});
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1864,7 +1864,7 @@ export class TelemetryEventRelay extends EventRelay {
 		this.telemetry.identify(
 			{
 				user_role: user?.role?.slug,
-				user_email: user.email,
+				...(this.globalConfig.deployment.type === 'cloud' && { user_email: user.email }),
 			},
 			user.id,
 		);


### PR DESCRIPTION
## Summary

When a user updates the n8n profile, the backend sends `user_email` to telemetry as a profile fact. At account creation, the backend sends `user_email` only on cloud. The profile update path had no such guard. Self-hosted instances therefore sent the email addresses of their users on every profile update.

This PR applies the same cloud-only guard to `userUpdated` in the telemetry relay. `user_role` stays in the payload on all deployments, because `userChangedRole` also sends it on all deployments.

The guard sits in the relay, before `Telemetry.identify` fans out. As a result, PostHog and RudderStack no longer receive `user_email` for self-hosted profile updates. Cloud behavior does not change.

No other relay handler sends `user_email`. The check was:

```sh
git grep -n 'user_email' -- packages/cli/src/events/relays/
```

## How to test

1. From `packages/cli`, run the relay tests:

   ```sh
   pnpm test src/events/__tests__/telemetry-event-relay.test.ts -t 'user-updated'
   ```

2. Make sure that both cases pass. The self-hosted case asserts `user_role` and no `user_email`. The cloud case asserts `user_role` and `user_email`.

3. After the rollout, run the PostHog query from the Linear ticket. The self-hosted buckets decrease to 0 as instances upgrade. The cloud bucket stays flat.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GROP-131

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
