### PR TITLE
feat: Add page-aware automation recommendations to the browser extension (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -121,6 +121,12 @@ export type {
 	InstanceAiBrowserRecordingResponse,
 } from './schemas/browser-recording.schema';
 
+export {
+	browserAutomationIdeaSchema,
+	MAX_BROWSER_AUTOMATION_IDEAS,
+} from './schemas/browser-recommendation.schema';
+export type { BrowserAutomationIdea } from './schemas/browser-recommendation.schema';
+
 export type {
 	ChatHubPushMessage,
 	ChatHubStreamEvent,

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -124,6 +124,8 @@ export type {
 export {
 	browserAutomationIdeaSchema,
 	MAX_BROWSER_AUTOMATION_IDEAS,
+	MAX_BROWSER_AUTOMATION_IDEA_TITLE_LENGTH,
+	MAX_BROWSER_AUTOMATION_IDEA_DESCRIPTION_LENGTH,
 } from './schemas/browser-recommendation.schema';
 export type { BrowserAutomationIdea } from './schemas/browser-recommendation.schema';
 

--- a/packages/@n8n/api-types/src/schemas/browser-recommendation.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/browser-recommendation.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const MAX_BROWSER_AUTOMATION_IDEAS = 3;
+
+export const browserAutomationIdeaSchema = z
+	.object({
+		id: z.string().uuid(),
+		title: z.string().min(1).max(80),
+		description: z.string().min(1).max(140),
+	})
+	.strict();
+
+export type BrowserAutomationIdea = z.infer<typeof browserAutomationIdeaSchema>;

--- a/packages/@n8n/api-types/src/schemas/browser-recommendation.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/browser-recommendation.schema.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 
 export const MAX_BROWSER_AUTOMATION_IDEAS = 3;
+export const MAX_BROWSER_AUTOMATION_IDEA_TITLE_LENGTH = 80;
+export const MAX_BROWSER_AUTOMATION_IDEA_DESCRIPTION_LENGTH = 140;
 
 export const browserAutomationIdeaSchema = z
 	.object({
 		id: z.string().uuid(),
-		title: z.string().min(1).max(80),
-		description: z.string().min(1).max(140),
+		title: z.string().min(1).max(MAX_BROWSER_AUTOMATION_IDEA_TITLE_LENGTH),
+		description: z.string().min(1).max(MAX_BROWSER_AUTOMATION_IDEA_DESCRIPTION_LENGTH),
 	})
 	.strict();
 

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1429,6 +1429,7 @@ export const INSTANCE_AI_THREAD_SOURCES = [
 	'agent_builder_page',
 	'agent_preview',
 	'browser_recording',
+	'browser_recommendation',
 	'assistant_page',
 	// Experiment cleanup: remove with openWorkflowInAssistant.
 	'workflow_list_auto',

--- a/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
+++ b/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
@@ -84,6 +84,18 @@ describe('eval agent model config', () => {
 		});
 	});
 
+	it('skips thinking when the caller opts out for a latency-sensitive call', () => {
+		process.env.OPENAI_API_KEY = 'openai-key';
+
+		createEvalAgent('test-agent', {
+			model: 'openai/gpt-5.6-sol',
+			instructions: 'Do the task.',
+			thinking: false,
+		});
+
+		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();
+	});
+
 	it('throws without env keys or a fallback model config', () => {
 		expect(() => createEvalAgent('test-agent', { instructions: 'Do the task.' })).toThrow(
 			/Missing API key/,

--- a/packages/@n8n/instance-ai/src/utils/__tests__/generate-validated-json.test.ts
+++ b/packages/@n8n/instance-ai/src/utils/__tests__/generate-validated-json.test.ts
@@ -98,4 +98,18 @@ describe('generateValidatedJson', () => {
 			expect.objectContaining({ fallbackModelConfig }),
 		);
 	});
+
+	it('forwards thinking: false to agent creation for latency-sensitive calls', async () => {
+		setupAgentMock('{"ok": true}');
+		await generateValidatedJson('test-agent', {
+			instructions: 'instructions',
+			userText: 'do it',
+			schema,
+			thinking: false,
+		});
+		expect(mockCreateEvalAgent).toHaveBeenCalledWith(
+			'test-agent',
+			expect.objectContaining({ thinking: false }),
+		);
+	});
 });

--- a/packages/@n8n/instance-ai/src/utils/eval-agents.ts
+++ b/packages/@n8n/instance-ai/src/utils/eval-agents.ts
@@ -166,6 +166,9 @@ export function createEvalAgent(
 		cache?: boolean;
 		/** Host-resolved model used when no eval model API key is configured in the environment. */
 		fallbackModelConfig?: ModelConfig;
+		/** Set false to skip extended thinking — for latency-sensitive calls (e.g. a quick
+		 *  suggestion) where the added reasoning time isn't worth it. Defaults to true. */
+		thinking?: boolean;
 	},
 ): Agent {
 	const model = resolveAgentModel(options.model, options.fallbackModelConfig);
@@ -177,7 +180,7 @@ export function createEvalAgent(
 		agent.instructions(options.instructions);
 	}
 
-	applyAgentThinking(agent, model);
+	if (options.thinking !== false) applyAgentThinking(agent, model);
 
 	return agent;
 }

--- a/packages/@n8n/instance-ai/src/utils/generate-validated-json.ts
+++ b/packages/@n8n/instance-ai/src/utils/generate-validated-json.ts
@@ -28,6 +28,9 @@ export interface GenerateValidatedJsonOptions<T> {
 	schema: z.ZodType<T>;
 	/** Host-resolved model used when no eval model API key is configured in the environment. */
 	fallbackModelConfig?: ModelConfig;
+	/** Set false to skip extended thinking, for a latency-sensitive call that doesn't need
+	 *  deep reasoning. Defaults to true. */
+	thinking?: boolean;
 }
 
 function stripMarkdownFences(text: string): string {
@@ -46,6 +49,7 @@ export async function generateValidatedJson<T>(
 			model: options.model,
 			instructions: options.instructions,
 			fallbackModelConfig: options.fallbackModelConfig,
+			thinking: options.thinking,
 		});
 		const result = await llm.generate([
 			{ role: 'user' as const, content: [{ type: 'text' as const, text: options.userText }] },

--- a/packages/@n8n/mcp-browser-extension/src/background.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.ts
@@ -875,10 +875,25 @@ const RECOMMENDATIONS_TIMEOUT_MS = 20_000;
  *  which page it came from without it having to ask. */
 let lastRecommendationsUrl: string | undefined;
 
-let pendingRecommendationsResolve: ((ideas: BrowserAutomationIdea[]) => void) | undefined;
-let pendingRecommendationAcceptedResolve:
-	| ((result: { accepted: boolean; threadUrl?: string }) => void)
-	| undefined;
+// Keyed by a per-request id (not a single shared slot) — the drawer popup and a connect
+// window can both be open and both ask for/accept recommendations, so more than one of each
+// can be genuinely in flight at once.
+const pendingRecommendationsResolvers = new Map<string, (ideas: BrowserAutomationIdea[]) => void>();
+const pendingRecommendationAcceptedResolvers = new Map<
+	string,
+	(result: { accepted: boolean; threadUrl?: string }) => void
+>();
+
+function resetRecommendationsState(): void {
+	for (const resolve of pendingRecommendationsResolvers.values()) resolve([]);
+	pendingRecommendationsResolvers.clear();
+	for (const resolve of pendingRecommendationAcceptedResolvers.values()) {
+		resolve({ accepted: false });
+	}
+	pendingRecommendationAcceptedResolvers.clear();
+	lastRecommendationsUrl = undefined;
+	broadcastRecommendationsChange('unavailable');
+}
 
 function broadcastRecommendationsChange(
 	status: RecommendationsStatus,
@@ -890,7 +905,9 @@ function broadcastRecommendationsChange(
 }
 
 /** Pull the active tab's URL and a short text extract via `chrome.scripting` — no debugger
- *  attach needed, so this works on any tab, not just ones the user shared for recording. */
+ *  attach needed, so this works on any tab, not just ones the user shared for recording. The
+ *  cap is applied inside the injected function so a huge page's full text is never computed
+ *  and transferred just to be immediately truncated. */
 async function extractPageContext(
 	tabId: number,
 ): Promise<{ url: string; pageText: string } | undefined> {
@@ -898,12 +915,13 @@ async function extractPageContext(
 		chrome.tabs.get(tabId),
 		chrome.scripting.executeScript({
 			target: { tabId },
-			func: () => ({ title: document.title, text: document.body?.innerText ?? '' }),
+			func: (limit: number) =>
+				`${document.title}\n${document.body?.innerText ?? ''}`.slice(0, limit),
+			args: [MAX_PAGE_TEXT_LENGTH],
 		}),
 	]);
-	if (!tab.url) return undefined;
-	const { title, text } = injection.result as { title: string; text: string };
-	return { url: tab.url, pageText: `${title}\n${text}`.slice(0, MAX_PAGE_TEXT_LENGTH) };
+	if (!tab.url || typeof injection.result !== 'string') return undefined;
+	return { url: tab.url, pageText: injection.result };
 }
 
 async function requestRecommendations(): Promise<{ success: boolean; error?: string }> {
@@ -929,7 +947,8 @@ async function requestRecommendations(): Promise<{ success: boolean; error?: str
 		log.warn('recommendations unavailable: failed to extract page context:', error);
 		context = undefined;
 	}
-	if (!context || !relay.requestRecommendations(context.url, context.pageText)) {
+	const requestId = crypto.randomUUID();
+	if (!context || !relay.requestRecommendations(context.url, context.pageText, requestId)) {
 		log.warn('recommendations unavailable: could not send the request to the relay');
 		broadcastRecommendationsChange('unavailable');
 		return { success: false, error: 'No automation ideas are available for this page.' };
@@ -937,13 +956,13 @@ async function requestRecommendations(): Promise<{ success: boolean; error?: str
 
 	const ideas = await Promise.race([
 		new Promise<BrowserAutomationIdea[]>((resolve) => {
-			pendingRecommendationsResolve = resolve;
+			pendingRecommendationsResolvers.set(requestId, resolve);
 		}),
 		new Promise<BrowserAutomationIdea[]>((resolve) => {
 			setTimeout(() => resolve([]), RECOMMENDATIONS_TIMEOUT_MS);
 		}),
 	]);
-	pendingRecommendationsResolve = undefined;
+	pendingRecommendationsResolvers.delete(requestId);
 
 	if (ideas.length === 0) {
 		log.warn('recommendations unavailable: no ideas came back before the timeout');
@@ -960,25 +979,25 @@ async function sendRecommendation(idea: BrowserAutomationIdea): Promise<{
 	error?: string;
 }> {
 	const relay = activeConnection?.relay;
+	const requestId = crypto.randomUUID();
 	if (
-		!relay?.sendRecommendationAccepted({
-			title: idea.title,
-			description: idea.description,
-			url: lastRecommendationsUrl,
-		})
+		!relay?.sendRecommendationAccepted(
+			{ title: idea.title, description: idea.description, url: lastRecommendationsUrl },
+			requestId,
+		)
 	) {
 		return { success: false, error: 'The idea could not be sent. Try again.' };
 	}
 
 	const result = await Promise.race([
 		new Promise<{ accepted: boolean; threadUrl?: string }>((resolve) => {
-			pendingRecommendationAcceptedResolve = resolve;
+			pendingRecommendationAcceptedResolvers.set(requestId, resolve);
 		}),
 		new Promise<{ accepted: boolean; threadUrl?: string }>((resolve) => {
 			setTimeout(() => resolve({ accepted: false }), RECOMMENDATIONS_TIMEOUT_MS);
 		}),
 	]);
-	pendingRecommendationAcceptedResolve = undefined;
+	pendingRecommendationAcceptedResolvers.delete(requestId);
 
 	if (!result.accepted) {
 		return { success: false, error: 'n8n did not confirm the idea. Try again.' };
@@ -1476,6 +1495,7 @@ async function connectToRelay(
 			activeConnection = null;
 			updateBadge(0);
 			broadcastStatusChange();
+			resetRecommendationsState();
 		};
 
 		relay.ontabcreated = () => {
@@ -1520,14 +1540,14 @@ async function connectToRelay(
 			);
 		};
 
-		relay.onrecommendationsready = (ideas) => {
-			pendingRecommendationsResolve?.(ideas);
-			pendingRecommendationsResolve = undefined;
+		relay.onrecommendationsready = (requestId, ideas) => {
+			pendingRecommendationsResolvers.get(requestId)?.(ideas);
+			pendingRecommendationsResolvers.delete(requestId);
 		};
 
-		relay.onrecommendationacceptedresult = (accepted, threadUrl) => {
-			pendingRecommendationAcceptedResolve?.({ accepted, threadUrl });
-			pendingRecommendationAcceptedResolve = undefined;
+		relay.onrecommendationacceptedresult = (requestId, accepted, threadUrl) => {
+			pendingRecommendationAcceptedResolvers.get(requestId)?.({ accepted, threadUrl });
+			pendingRecommendationAcceptedResolvers.delete(requestId);
 		};
 
 		const tabCount = relay.getControlledIds().length;

--- a/packages/@n8n/mcp-browser-extension/src/background.ts
+++ b/packages/@n8n/mcp-browser-extension/src/background.ts
@@ -5,7 +5,11 @@
  * and tracks tab lifecycle for agent-created tabs only.
  */
 
-import type { BrowserRecordingAction, BrowserRecordingScreenshot } from '@n8n/api-types';
+import type {
+	BrowserAutomationIdea,
+	BrowserRecordingAction,
+	BrowserRecordingScreenshot,
+} from '@n8n/api-types';
 
 import { isHostApproved, listApprovedOrigins } from './approvedHosts';
 import { createLogger } from './logger';
@@ -19,6 +23,7 @@ import type {
 	ExternalConnectResponse,
 	ExternalConnectResultResponse,
 	RecordingDestination,
+	RecommendationsStatus,
 } from './types';
 import { isExternalMessage } from './types';
 
@@ -246,6 +251,12 @@ async function handleMessage(
 
 		case 'recordingHeartbeat':
 			return { keepAlive: recording !== null };
+
+		case 'getRecommendations':
+			return await requestRecommendations();
+
+		case 'sendRecommendation':
+			return await sendRecommendation(message.idea);
 
 		default:
 			return { error: 'Unknown message type' };
@@ -854,6 +865,130 @@ function sanitizeContextText(value: string | undefined, limit: number): string |
 }
 
 // ---------------------------------------------------------------------------
+// Automation recommendations
+// ---------------------------------------------------------------------------
+
+const MAX_PAGE_TEXT_LENGTH = 4000;
+const RECOMMENDATIONS_TIMEOUT_MS = 20_000;
+
+/** URL the currently shown ideas were generated for, so picking one can tell Instance AI
+ *  which page it came from without it having to ask. */
+let lastRecommendationsUrl: string | undefined;
+
+let pendingRecommendationsResolve: ((ideas: BrowserAutomationIdea[]) => void) | undefined;
+let pendingRecommendationAcceptedResolve:
+	| ((result: { accepted: boolean; threadUrl?: string }) => void)
+	| undefined;
+
+function broadcastRecommendationsChange(
+	status: RecommendationsStatus,
+	ideas?: BrowserAutomationIdea[],
+): void {
+	chrome.runtime.sendMessage({ type: 'recommendationsChanged', status, ideas }).catch(() => {
+		// No receivers — this is fine if the popup is not open
+	});
+}
+
+/** Pull the active tab's URL and a short text extract via `chrome.scripting` — no debugger
+ *  attach needed, so this works on any tab, not just ones the user shared for recording. */
+async function extractPageContext(
+	tabId: number,
+): Promise<{ url: string; pageText: string } | undefined> {
+	const [tab, [injection]] = await Promise.all([
+		chrome.tabs.get(tabId),
+		chrome.scripting.executeScript({
+			target: { tabId },
+			func: () => ({ title: document.title, text: document.body?.innerText ?? '' }),
+		}),
+	]);
+	if (!tab.url) return undefined;
+	const { title, text } = injection.result as { title: string; text: string };
+	return { url: tab.url, pageText: `${title}\n${text}`.slice(0, MAX_PAGE_TEXT_LENGTH) };
+}
+
+async function requestRecommendations(): Promise<{ success: boolean; error?: string }> {
+	const relay = activeConnection?.relay;
+	if (!relay || recording) {
+		log.debug('recommendations skipped: not connected or a recording is in progress');
+		broadcastRecommendationsChange('unavailable');
+		return { success: false, error: 'No automation ideas are available right now.' };
+	}
+
+	const [activeTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+	if (activeTab?.id === undefined || !isEligibleTab(activeTab)) {
+		log.debug('recommendations skipped: active tab is not eligible', activeTab?.url);
+		broadcastRecommendationsChange('unavailable');
+		return { success: false, error: 'No automation ideas are available for this page.' };
+	}
+
+	broadcastRecommendationsChange('loading');
+	let context: { url: string; pageText: string } | undefined;
+	try {
+		context = await extractPageContext(activeTab.id);
+	} catch (error) {
+		log.warn('recommendations unavailable: failed to extract page context:', error);
+		context = undefined;
+	}
+	if (!context || !relay.requestRecommendations(context.url, context.pageText)) {
+		log.warn('recommendations unavailable: could not send the request to the relay');
+		broadcastRecommendationsChange('unavailable');
+		return { success: false, error: 'No automation ideas are available for this page.' };
+	}
+
+	const ideas = await Promise.race([
+		new Promise<BrowserAutomationIdea[]>((resolve) => {
+			pendingRecommendationsResolve = resolve;
+		}),
+		new Promise<BrowserAutomationIdea[]>((resolve) => {
+			setTimeout(() => resolve([]), RECOMMENDATIONS_TIMEOUT_MS);
+		}),
+	]);
+	pendingRecommendationsResolve = undefined;
+
+	if (ideas.length === 0) {
+		log.warn('recommendations unavailable: no ideas came back before the timeout');
+		broadcastRecommendationsChange('unavailable');
+		return { success: false, error: 'No automation ideas are available for this page.' };
+	}
+	lastRecommendationsUrl = context.url;
+	broadcastRecommendationsChange('ready', ideas);
+	return { success: true };
+}
+
+async function sendRecommendation(idea: BrowserAutomationIdea): Promise<{
+	success: boolean;
+	error?: string;
+}> {
+	const relay = activeConnection?.relay;
+	if (
+		!relay?.sendRecommendationAccepted({
+			title: idea.title,
+			description: idea.description,
+			url: lastRecommendationsUrl,
+		})
+	) {
+		return { success: false, error: 'The idea could not be sent. Try again.' };
+	}
+
+	const result = await Promise.race([
+		new Promise<{ accepted: boolean; threadUrl?: string }>((resolve) => {
+			pendingRecommendationAcceptedResolve = resolve;
+		}),
+		new Promise<{ accepted: boolean; threadUrl?: string }>((resolve) => {
+			setTimeout(() => resolve({ accepted: false }), RECOMMENDATIONS_TIMEOUT_MS);
+		}),
+	]);
+	pendingRecommendationAcceptedResolve = undefined;
+
+	if (!result.accepted) {
+		return { success: false, error: 'n8n did not confirm the idea. Try again.' };
+	}
+	if (result.threadUrl) void openRecordingThread(result.threadUrl);
+	broadcastRecommendationsChange('sent');
+	return { success: true };
+}
+
+// ---------------------------------------------------------------------------
 // Tab enumeration
 // ---------------------------------------------------------------------------
 
@@ -1383,6 +1518,16 @@ async function connectToRelay(
 			broadcastRecordingChange(
 				accepted ? undefined : 'The recording could not be processed. Try again.',
 			);
+		};
+
+		relay.onrecommendationsready = (ideas) => {
+			pendingRecommendationsResolve?.(ideas);
+			pendingRecommendationsResolve = undefined;
+		};
+
+		relay.onrecommendationacceptedresult = (accepted, threadUrl) => {
+			pendingRecommendationAcceptedResolve?.({ accepted, threadUrl });
+			pendingRecommendationAcceptedResolve = undefined;
 		};
 
 		const tabCount = relay.getControlledIds().length;

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
@@ -1188,54 +1188,73 @@ describe('RelayConnection', () => {
 
 	describe('recommendations', () => {
 		it('sends a recommendationsRequested frame for the given page', () => {
-			relay.requestRecommendations('https://github.com/org/repo/pull/1', 'Pull request title');
+			relay.requestRecommendations(
+				'https://github.com/org/repo/pull/1',
+				'Pull request title',
+				'req-1',
+			);
 
 			expect(findSent(ws, 'recommendationsRequested')).toEqual({
 				method: 'recommendationsRequested',
-				params: { url: 'https://github.com/org/repo/pull/1', pageText: 'Pull request title' },
+				params: {
+					requestId: 'req-1',
+					url: 'https://github.com/org/repo/pull/1',
+					pageText: 'Pull request title',
+				},
 			});
 		});
 
 		it('does not send a recommendationsRequested frame while the socket is closed', () => {
 			ws.readyState = MockWebSocket.CLOSED;
 
-			expect(relay.requestRecommendations('https://example.com', 'text')).toBe(false);
+			expect(relay.requestRecommendations('https://example.com', 'text', 'req-1')).toBe(false);
 			expect(findSent(ws, 'recommendationsRequested')).toBeUndefined();
 		});
 
-		it('delivers ideas from a recommendationsReady command to onrecommendationsready', async () => {
+		it('delivers ideas from a recommendationsReady command to onrecommendationsready, tagged with the requestId', async () => {
 			const onrecommendationsready = vi.fn();
 			relay.onrecommendationsready = onrecommendationsready;
 			const ideas = [{ id: 'i1', title: 'Triage issues', description: 'Label new issues' }];
 
 			ws.onmessage?.({
-				data: JSON.stringify({ id: 8, method: 'recommendationsReady', params: { ideas } }),
+				data: JSON.stringify({
+					id: 8,
+					method: 'recommendationsReady',
+					params: { requestId: 'req-1', ideas },
+				}),
 			});
 			await tick();
 
-			expect(onrecommendationsready).toHaveBeenCalledWith(ideas);
+			expect(onrecommendationsready).toHaveBeenCalledWith('req-1', ideas);
 			expect(parseSent(ws)).toEqual({ id: 8, result: {} });
 		});
 
 		it('sends a recommendationAccepted frame for the picked idea', () => {
-			relay.sendRecommendationAccepted({ title: 'Triage issues', description: 'Label new issues' });
+			relay.sendRecommendationAccepted(
+				{ title: 'Triage issues', description: 'Label new issues' },
+				'req-1',
+			);
 
 			expect(findSent(ws, 'recommendationAccepted')).toEqual({
 				method: 'recommendationAccepted',
-				params: { title: 'Triage issues', description: 'Label new issues' },
+				params: { requestId: 'req-1', title: 'Triage issues', description: 'Label new issues' },
 			});
 		});
 
 		it('includes the source page url when the idea carries one', () => {
-			relay.sendRecommendationAccepted({
-				title: 'Triage issues',
-				description: 'Label new issues',
-				url: 'https://github.com/n8n-io/n8n/pull/1',
-			});
+			relay.sendRecommendationAccepted(
+				{
+					title: 'Triage issues',
+					description: 'Label new issues',
+					url: 'https://github.com/n8n-io/n8n/pull/1',
+				},
+				'req-1',
+			);
 
 			expect(findSent(ws, 'recommendationAccepted')).toEqual({
 				method: 'recommendationAccepted',
 				params: {
+					requestId: 'req-1',
 					title: 'Triage issues',
 					description: 'Label new issues',
 					url: 'https://github.com/n8n-io/n8n/pull/1',
@@ -1243,7 +1262,7 @@ describe('RelayConnection', () => {
 			});
 		});
 
-		it('delivers a recommendationAcceptedResult command to onrecommendationacceptedresult', async () => {
+		it('delivers a recommendationAcceptedResult command to onrecommendationacceptedresult, tagged with the requestId', async () => {
 			const onrecommendationacceptedresult = vi.fn();
 			relay.onrecommendationacceptedresult = onrecommendationacceptedresult;
 
@@ -1251,12 +1270,17 @@ describe('RelayConnection', () => {
 				data: JSON.stringify({
 					id: 9,
 					method: 'recommendationAcceptedResult',
-					params: { accepted: true, threadUrl: 'https://n8n.example.com/assistant/t1' },
+					params: {
+						requestId: 'req-1',
+						accepted: true,
+						threadUrl: 'https://n8n.example.com/assistant/t1',
+					},
 				}),
 			});
 			await tick();
 
 			expect(onrecommendationacceptedresult).toHaveBeenCalledWith(
+				'req-1',
 				true,
 				'https://n8n.example.com/assistant/t1',
 			);

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
@@ -1185,6 +1185,83 @@ describe('RelayConnection', () => {
 			expect(findSent(ws, 'recordingScreenshotCaptured')).toBeUndefined();
 		});
 	});
+
+	describe('recommendations', () => {
+		it('sends a recommendationsRequested frame for the given page', () => {
+			relay.requestRecommendations('https://github.com/org/repo/pull/1', 'Pull request title');
+
+			expect(findSent(ws, 'recommendationsRequested')).toEqual({
+				method: 'recommendationsRequested',
+				params: { url: 'https://github.com/org/repo/pull/1', pageText: 'Pull request title' },
+			});
+		});
+
+		it('does not send a recommendationsRequested frame while the socket is closed', () => {
+			ws.readyState = MockWebSocket.CLOSED;
+
+			expect(relay.requestRecommendations('https://example.com', 'text')).toBe(false);
+			expect(findSent(ws, 'recommendationsRequested')).toBeUndefined();
+		});
+
+		it('delivers ideas from a recommendationsReady command to onrecommendationsready', async () => {
+			const onrecommendationsready = vi.fn();
+			relay.onrecommendationsready = onrecommendationsready;
+			const ideas = [{ id: 'i1', title: 'Triage issues', description: 'Label new issues' }];
+
+			ws.onmessage?.({
+				data: JSON.stringify({ id: 8, method: 'recommendationsReady', params: { ideas } }),
+			});
+			await tick();
+
+			expect(onrecommendationsready).toHaveBeenCalledWith(ideas);
+			expect(parseSent(ws)).toEqual({ id: 8, result: {} });
+		});
+
+		it('sends a recommendationAccepted frame for the picked idea', () => {
+			relay.sendRecommendationAccepted({ title: 'Triage issues', description: 'Label new issues' });
+
+			expect(findSent(ws, 'recommendationAccepted')).toEqual({
+				method: 'recommendationAccepted',
+				params: { title: 'Triage issues', description: 'Label new issues' },
+			});
+		});
+
+		it('includes the source page url when the idea carries one', () => {
+			relay.sendRecommendationAccepted({
+				title: 'Triage issues',
+				description: 'Label new issues',
+				url: 'https://github.com/n8n-io/n8n/pull/1',
+			});
+
+			expect(findSent(ws, 'recommendationAccepted')).toEqual({
+				method: 'recommendationAccepted',
+				params: {
+					title: 'Triage issues',
+					description: 'Label new issues',
+					url: 'https://github.com/n8n-io/n8n/pull/1',
+				},
+			});
+		});
+
+		it('delivers a recommendationAcceptedResult command to onrecommendationacceptedresult', async () => {
+			const onrecommendationacceptedresult = vi.fn();
+			relay.onrecommendationacceptedresult = onrecommendationacceptedresult;
+
+			ws.onmessage?.({
+				data: JSON.stringify({
+					id: 9,
+					method: 'recommendationAcceptedResult',
+					params: { accepted: true, threadUrl: 'https://n8n.example.com/assistant/t1' },
+				}),
+			});
+			await tick();
+
+			expect(onrecommendationacceptedresult).toHaveBeenCalledWith(
+				true,
+				'https://n8n.example.com/assistant/t1',
+			);
+		});
+	});
 });
 
 describe('RelayConnection keepalive', () => {

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+	BrowserAutomationIdea,
 	BrowserRecording,
 	BrowserRecordingAction,
 	BrowserRecordingScreenshot,
@@ -130,6 +131,8 @@ export class RelayConnection {
 	onstopandsubmitrecording?: () => Promise<RecordingCommandResult>;
 	ondiscardrecording?: () => Promise<RecordingCommandResult>;
 	onnetworkrequest?: (request: CapturedNetworkRequest) => void;
+	onrecommendationsready?: (ideas: BrowserAutomationIdea[]) => void;
+	onrecommendationacceptedresult?: (accepted: boolean, threadUrl?: string) => void;
 
 	constructor(ws: WebSocket) {
 		this.ws = ws;
@@ -286,6 +289,22 @@ export class RelayConnection {
 	sendRecording(recording: BrowserRecording): boolean {
 		if (this.ws.readyState !== WebSocket.OPEN) return false;
 		this.sendMessage({ method: 'recordingCompleted', params: { recording } });
+		return true;
+	}
+
+	/** Ask the relay for automation ideas for the given page. Result arrives via
+	 *  `onrecommendationsready`. */
+	requestRecommendations(url: string, pageText: string): boolean {
+		if (this.ws.readyState !== WebSocket.OPEN) return false;
+		this.sendMessage({ method: 'recommendationsRequested', params: { url, pageText } });
+		return true;
+	}
+
+	/** Tell the relay the user picked an idea to build. Result arrives via
+	 *  `onrecommendationacceptedresult`. */
+	sendRecommendationAccepted(idea: { title: string; description: string; url?: string }): boolean {
+		if (this.ws.readyState !== WebSocket.OPEN) return false;
+		this.sendMessage({ method: 'recommendationAccepted', params: idea });
 		return true;
 	}
 
@@ -693,6 +712,22 @@ export class RelayConnection {
 				return (await this.onstopandsubmitrecording?.()) ?? {};
 			case 'discardRecording':
 				return (await this.ondiscardrecording?.()) ?? {};
+			case 'recommendationsReady': {
+				const ideas = message.params?.ideas;
+				if (Array.isArray(ideas)) this.onrecommendationsready?.(ideas as BrowserAutomationIdea[]);
+				return {};
+			}
+			case 'recommendationAcceptedResult': {
+				const accepted = message.params?.accepted;
+				const threadUrl = message.params?.threadUrl;
+				if (typeof accepted === 'boolean') {
+					this.onrecommendationacceptedresult?.(
+						accepted,
+						typeof threadUrl === 'string' ? threadUrl : undefined,
+					);
+				}
+				return {};
+			}
 			default:
 				log.debug(`unknown command: ${message.method}`);
 				return undefined;

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
@@ -131,8 +131,12 @@ export class RelayConnection {
 	onstopandsubmitrecording?: () => Promise<RecordingCommandResult>;
 	ondiscardrecording?: () => Promise<RecordingCommandResult>;
 	onnetworkrequest?: (request: CapturedNetworkRequest) => void;
-	onrecommendationsready?: (ideas: BrowserAutomationIdea[]) => void;
-	onrecommendationacceptedresult?: (accepted: boolean, threadUrl?: string) => void;
+	onrecommendationsready?: (requestId: string, ideas: BrowserAutomationIdea[]) => void;
+	onrecommendationacceptedresult?: (
+		requestId: string,
+		accepted: boolean,
+		threadUrl?: string,
+	) => void;
 
 	constructor(ws: WebSocket) {
 		this.ws = ws;
@@ -293,18 +297,22 @@ export class RelayConnection {
 	}
 
 	/** Ask the relay for automation ideas for the given page. Result arrives via
-	 *  `onrecommendationsready`. */
-	requestRecommendations(url: string, pageText: string): boolean {
+	 *  `onrecommendationsready`, tagged with `requestId` so a caller juggling more than one
+	 *  in-flight request can tell the answers apart. */
+	requestRecommendations(url: string, pageText: string, requestId: string): boolean {
 		if (this.ws.readyState !== WebSocket.OPEN) return false;
-		this.sendMessage({ method: 'recommendationsRequested', params: { url, pageText } });
+		this.sendMessage({ method: 'recommendationsRequested', params: { requestId, url, pageText } });
 		return true;
 	}
 
 	/** Tell the relay the user picked an idea to build. Result arrives via
-	 *  `onrecommendationacceptedresult`. */
-	sendRecommendationAccepted(idea: { title: string; description: string; url?: string }): boolean {
+	 *  `onrecommendationacceptedresult`, tagged with `requestId` — see `requestRecommendations`. */
+	sendRecommendationAccepted(
+		idea: { title: string; description: string; url?: string },
+		requestId: string,
+	): boolean {
 		if (this.ws.readyState !== WebSocket.OPEN) return false;
-		this.sendMessage({ method: 'recommendationAccepted', params: idea });
+		this.sendMessage({ method: 'recommendationAccepted', params: { requestId, ...idea } });
 		return true;
 	}
 
@@ -713,15 +721,20 @@ export class RelayConnection {
 			case 'discardRecording':
 				return (await this.ondiscardrecording?.()) ?? {};
 			case 'recommendationsReady': {
+				const requestId = message.params?.requestId;
 				const ideas = message.params?.ideas;
-				if (Array.isArray(ideas)) this.onrecommendationsready?.(ideas as BrowserAutomationIdea[]);
+				if (typeof requestId === 'string' && Array.isArray(ideas)) {
+					this.onrecommendationsready?.(requestId, ideas as BrowserAutomationIdea[]);
+				}
 				return {};
 			}
 			case 'recommendationAcceptedResult': {
+				const requestId = message.params?.requestId;
 				const accepted = message.params?.accepted;
 				const threadUrl = message.params?.threadUrl;
-				if (typeof accepted === 'boolean') {
+				if (typeof requestId === 'string' && typeof accepted === 'boolean') {
 					this.onrecommendationacceptedresult?.(
+						requestId,
 						accepted,
 						typeof threadUrl === 'string' ? threadUrl : undefined,
 					);

--- a/packages/@n8n/mcp-browser-extension/src/types.ts
+++ b/packages/@n8n/mcp-browser-extension/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+	BrowserAutomationIdea,
 	BrowserRecording as BrowserRecordingData,
 	BrowserRecordingActionType,
 	BrowserRecordingTarget,
@@ -127,6 +128,15 @@ export interface RecordingHeartbeatMessage {
 	type: 'recordingHeartbeat';
 }
 
+export interface GetRecommendationsMessage {
+	type: 'getRecommendations';
+}
+
+export interface SendRecommendationMessage {
+	type: 'sendRecommendation';
+	idea: BrowserAutomationIdea;
+}
+
 export type ExtensionMessage =
 	| GetTabsMessage
 	| ConnectMessage
@@ -145,7 +155,9 @@ export type ExtensionMessage =
 	| RemoveRecordingScreenshotMessage
 	| RemoveRecordingNetworkRequestMessage
 	| RecordingHeartbeatMessage
-	| RecordingActionMessage;
+	| RecordingActionMessage
+	| GetRecommendationsMessage
+	| SendRecommendationMessage;
 
 // ---------------------------------------------------------------------------
 // External messages (web page → background, via externally_connectable)
@@ -214,10 +226,19 @@ export interface RecordingChangedMessage {
 	error?: string;
 }
 
+export type RecommendationsStatus = 'loading' | 'ready' | 'unavailable' | 'sent';
+
+export interface RecommendationsChangedMessage {
+	type: 'recommendationsChanged';
+	status: RecommendationsStatus;
+	ideas?: BrowserAutomationIdea[];
+}
+
 export type BackgroundPushMessage =
 	| RelayUrlReadyMessage
 	| StatusChangedMessage
-	| RecordingChangedMessage;
+	| RecordingChangedMessage
+	| RecommendationsChangedMessage;
 
 // ---------------------------------------------------------------------------
 // Type guards

--- a/packages/@n8n/mcp-browser-extension/src/ui/App.vue
+++ b/packages/@n8n/mcp-browser-extension/src/ui/App.vue
@@ -9,7 +9,9 @@ import {
 	N8nLogo,
 } from '@n8n/design-system';
 import { useConnection } from './composables/useConnection';
+import { useRecommendations } from './composables/useRecommendations';
 import { useRecording } from './composables/useRecording';
+import AutomationIdeas from './components/AutomationIdeas.vue';
 import InfoRow from './components/InfoRow.vue';
 import RecordingCaptureSettings from './components/RecordingCaptureSettings.vue';
 import RecordingReview from './components/RecordingReview.vue';
@@ -53,11 +55,32 @@ const {
 	removeNetworkRequest,
 } = useRecording();
 
+const {
+	status: recommendationsStatus,
+	ideas: recommendationIdeas,
+	send: sendRecommendation,
+} = useRecommendations();
+
 const showTabSelection = ref(false);
 const showRecordingSettings = ref(false);
 const showSettings = ref(false);
 const showDestinations = ref(false);
 const instanceUrl = ref('');
+
+const ideaPitchCopy = computed(() => {
+	if (recommendationsStatus.value === 'ready' || recommendationsStatus.value === 'loading') {
+		return {
+			title: 'Automation ideas for this page',
+			subtitle: 'Pick one to have AI Assistant build it, or record the task yourself.',
+		};
+	}
+	return {
+		title: 'Record a browser task',
+		subtitle:
+			'Show AI Assistant how you complete a task. The extension records your clicks, typing, ' +
+			'and navigation so AI Assistant can build a workflow.',
+	};
+});
 
 const isConnected = computed(() => status.value === 'connected');
 const showConnectPrompt = computed(() => hasRelayUrl.value && isRelayAllowed.value);
@@ -209,30 +232,34 @@ async function submitToInstanceUrl() {
 					{{ recordingTitle }}
 				</h1>
 				<template v-if="!recording">
-					<h1 class="title">Record a browser task</h1>
-					<p class="subtitle">
-						Show AI Assistant how you complete a task. The extension records your clicks, typing,
-						and navigation so AI Assistant can build a workflow.
-					</p>
+					<template v-if="recommendationsStatus !== 'sent'">
+						<h1 class="title">{{ ideaPitchCopy.title }}</h1>
+						<p class="subtitle">{{ ideaPitchCopy.subtitle }}</p>
+					</template>
+					<AutomationIdeas
+						:status="recommendationsStatus"
+						:ideas="recommendationIdeas"
+						@pick="sendRecommendation"
+					/>
+					<div v-if="recommendationsStatus === 'unavailable'" class="panel">
+						<InfoRow
+							icon="mouse-pointer"
+							title="Demonstrate the task"
+							description="Complete the task in your browser as you usually do"
+						/>
+						<InfoRow
+							icon="shield"
+							title="Review before sharing"
+							description="Passwords and detected secrets are redacted. You can remove or mask other details before you send the recording."
+						/>
+					</div>
 				</template>
-				<div v-if="!recording" class="panel">
-					<InfoRow
-						icon="mouse-pointer"
-						title="Demonstrate the task"
-						description="Complete the task in your browser as you usually do"
-					/>
-					<InfoRow
-						icon="shield"
-						title="Review before sharing"
-						description="Passwords and detected secrets are redacted. You can remove or mask other details before you send the recording."
-					/>
-				</div>
 				<p v-else-if="recording.status === 'recording'" class="subtitle">
 					Complete the task in your browser. Return here when you're ready to review the recorded
 					actions.
 				</p>
 				<p v-else-if="recording.status === 'submitted'" class="subtitle">
-					AI Assistant is processing your recording in a new conversation.
+					AI Assistant is building this in a new conversation.
 				</p>
 				<p v-else-if="recording.status === 'submitting'" class="subtitle">
 					n8n is starting a new conversation from your recording.

--- a/packages/@n8n/mcp-browser-extension/src/ui/App.vue
+++ b/packages/@n8n/mcp-browser-extension/src/ui/App.vue
@@ -58,6 +58,7 @@ const {
 const {
 	status: recommendationsStatus,
 	ideas: recommendationIdeas,
+	isSending: isSendingRecommendation,
 	send: sendRecommendation,
 } = useRecommendations();
 
@@ -239,6 +240,7 @@ async function submitToInstanceUrl() {
 					<AutomationIdeas
 						:status="recommendationsStatus"
 						:ideas="recommendationIdeas"
+						:is-sending="isSendingRecommendation"
 						@pick="sendRecommendation"
 					/>
 					<div v-if="recommendationsStatus === 'unavailable'" class="panel">

--- a/packages/@n8n/mcp-browser-extension/src/ui/app.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/app.test.ts
@@ -26,6 +26,12 @@ const state = {
 	updateRecordingSetting: vi.fn(),
 };
 
+const recommendationsState = {
+	status: ref<'loading' | 'ready' | 'unavailable' | 'sent'>('unavailable'),
+	ideas: ref<Array<{ id: string; title: string; description: string }>>([]),
+	send: vi.fn(),
+};
+
 vi.mock('./composables/useConnection', () => ({ useConnection: () => state }));
 vi.mock('./composables/useRecording', () => ({
 	useRecording: () => ({
@@ -40,6 +46,9 @@ vi.mock('./composables/useRecording', () => ({
 		maskAction: vi.fn(),
 	}),
 }));
+vi.mock('./composables/useRecommendations', () => ({
+	useRecommendations: () => recommendationsState,
+}));
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -51,6 +60,8 @@ beforeEach(() => {
 	state.approvedHosts.value = [];
 	state.recordingSettings.networkRequests = false;
 	state.recordingSettings.screenshots = false;
+	recommendationsState.status.value = 'unavailable';
+	recommendationsState.ideas.value = [];
 });
 
 describe('connect prompt', () => {
@@ -90,5 +101,55 @@ describe('remembered hosts', () => {
 		await wrapper.vm.$nextTick();
 
 		expect(state.forgetHost).toHaveBeenCalledWith('localhost:5678');
+	});
+});
+
+describe('automation ideas', () => {
+	beforeEach(() => {
+		state.status.value = 'connected';
+	});
+
+	it('shows a skeleton while loading', () => {
+		recommendationsState.status.value = 'loading';
+
+		expect(mount(App).find('.skeleton').exists()).toBe(true);
+	});
+
+	it('swaps the pitch copy for an idea-oriented heading once ideas are showing', () => {
+		recommendationsState.status.value = 'ready';
+		recommendationsState.ideas.value = [
+			{ id: '1', title: 'Triage new issues', description: 'Label and route new GitHub issues' },
+		];
+
+		const wrapper = mount(App);
+		expect(wrapper.text()).toContain('Automation ideas for this page');
+		expect(wrapper.text()).not.toContain('Record a browser task');
+	});
+
+	it('shows the idea and sends it on click, without starting a recording', async () => {
+		recommendationsState.status.value = 'ready';
+		recommendationsState.ideas.value = [
+			{ id: '1', title: 'Triage new issues', description: 'Label and route new GitHub issues' },
+		];
+
+		const wrapper = mount(App);
+		expect(wrapper.text()).toContain('Triage new issues');
+
+		await wrapper.find('.idea-card').trigger('click');
+		expect(recommendationsState.send).toHaveBeenCalledWith(recommendationsState.ideas.value[0]);
+	});
+
+	it('falls back to the static instructional copy when unavailable', () => {
+		recommendationsState.status.value = 'unavailable';
+
+		expect(mount(App).text()).toContain('Record a browser task');
+	});
+
+	it('shows the sent confirmation instead of the recording pitch', () => {
+		recommendationsState.status.value = 'sent';
+
+		const wrapper = mount(App);
+		expect(wrapper.text()).toContain('AI Assistant is building this in a new conversation.');
+		expect(wrapper.text()).not.toContain('Record a browser task');
 	});
 });

--- a/packages/@n8n/mcp-browser-extension/src/ui/app.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/app.test.ts
@@ -26,26 +26,27 @@ const state = {
 	updateRecordingSetting: vi.fn(),
 };
 
+const recordingState = {
+	recording: ref(null),
+	errorMessage: ref(''),
+	start: vi.fn(),
+	stop: vi.fn(),
+	submit: vi.fn(),
+	discard: vi.fn(),
+	recordAgain: vi.fn(),
+	removeAction: vi.fn(),
+	maskAction: vi.fn(),
+};
+
 const recommendationsState = {
 	status: ref<'loading' | 'ready' | 'unavailable' | 'sent'>('unavailable'),
 	ideas: ref<Array<{ id: string; title: string; description: string }>>([]),
+	isSending: ref(false),
 	send: vi.fn(),
 };
 
 vi.mock('./composables/useConnection', () => ({ useConnection: () => state }));
-vi.mock('./composables/useRecording', () => ({
-	useRecording: () => ({
-		recording: ref(null),
-		errorMessage: ref(''),
-		start: vi.fn(),
-		stop: vi.fn(),
-		submit: vi.fn(),
-		discard: vi.fn(),
-		recordAgain: vi.fn(),
-		removeAction: vi.fn(),
-		maskAction: vi.fn(),
-	}),
-}));
+vi.mock('./composables/useRecording', () => ({ useRecording: () => recordingState }));
 vi.mock('./composables/useRecommendations', () => ({
 	useRecommendations: () => recommendationsState,
 }));
@@ -62,6 +63,7 @@ beforeEach(() => {
 	state.recordingSettings.screenshots = false;
 	recommendationsState.status.value = 'unavailable';
 	recommendationsState.ideas.value = [];
+	recommendationsState.isSending.value = false;
 });
 
 describe('connect prompt', () => {
@@ -137,6 +139,19 @@ describe('automation ideas', () => {
 
 		await wrapper.find('.idea-card').trigger('click');
 		expect(recommendationsState.send).toHaveBeenCalledWith(recommendationsState.ideas.value[0]);
+		expect(recordingState.start).not.toHaveBeenCalled();
+	});
+
+	it('disables the idea cards while a pick is in flight, so a second click cannot double-build', () => {
+		recommendationsState.status.value = 'ready';
+		recommendationsState.ideas.value = [
+			{ id: '1', title: 'Triage new issues', description: 'Label and route new GitHub issues' },
+		];
+		recommendationsState.isSending.value = true;
+
+		const wrapper = mount(App);
+
+		expect(wrapper.find('.idea-card').attributes('disabled')).toBeDefined();
 	});
 
 	it('falls back to the static instructional copy when unavailable', () => {

--- a/packages/@n8n/mcp-browser-extension/src/ui/components/AutomationIdeas.vue
+++ b/packages/@n8n/mcp-browser-extension/src/ui/components/AutomationIdeas.vue
@@ -12,6 +12,7 @@ const MAX_IDEAS = 3;
 defineProps<{
 	status: RecommendationsStatus;
 	ideas: BrowserAutomationIdea[];
+	isSending: boolean;
 }>();
 
 defineEmits<{ pick: [idea: BrowserAutomationIdea] }>();
@@ -22,7 +23,13 @@ defineEmits<{ pick: [idea: BrowserAutomationIdea] }>();
 		<div class="idea-card skeleton-card" v-for="n in MAX_IDEAS" :key="n" />
 	</div>
 	<div v-else-if="status === 'ready'" class="ideas">
-		<button v-for="idea in ideas" :key="idea.id" class="idea-card" @click="$emit('pick', idea)">
+		<button
+			v-for="idea in ideas"
+			:key="idea.id"
+			class="idea-card"
+			:disabled="isSending"
+			@click="$emit('pick', idea)"
+		>
 			<span class="marker">
 				<N8nIcon icon="lightbulb" size="large" />
 			</span>
@@ -61,6 +68,11 @@ defineEmits<{ pick: [idea: BrowserAutomationIdea] }>();
 
 	&:hover {
 		border-color: var(--color--foreground--shade-1);
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: default;
 	}
 }
 

--- a/packages/@n8n/mcp-browser-extension/src/ui/components/AutomationIdeas.vue
+++ b/packages/@n8n/mcp-browser-extension/src/ui/components/AutomationIdeas.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import type { BrowserAutomationIdea } from '@n8n/api-types';
+import { N8nIcon } from '@n8n/design-system';
+
+import type { RecommendationsStatus } from '../../types';
+
+// A plain literal, not `MAX_BROWSER_AUTOMATION_IDEAS` from `@n8n/api-types` — that package's
+// root barrel pulls in `n8n-workflow` (xml2js/sax), which assumes Node globals the extension
+// doesn't have. Only `import type` from `@n8n/api-types` is safe here.
+const MAX_IDEAS = 3;
+
+defineProps<{
+	status: RecommendationsStatus;
+	ideas: BrowserAutomationIdea[];
+}>();
+
+defineEmits<{ pick: [idea: BrowserAutomationIdea] }>();
+</script>
+
+<template>
+	<div v-if="status === 'loading'" class="ideas skeleton" aria-hidden="true">
+		<div class="idea-card skeleton-card" v-for="n in MAX_IDEAS" :key="n" />
+	</div>
+	<div v-else-if="status === 'ready'" class="ideas">
+		<button v-for="idea in ideas" :key="idea.id" class="idea-card" @click="$emit('pick', idea)">
+			<span class="marker">
+				<N8nIcon icon="lightbulb" size="large" />
+			</span>
+			<span class="idea-text">
+				<span class="idea-title">{{ idea.title }}</span>
+				<span class="idea-description">{{ idea.description }}</span>
+			</span>
+		</button>
+	</div>
+	<p v-else-if="status === 'sent'" class="sent">
+		AI Assistant is building this in a new conversation.
+	</p>
+</template>
+
+<style scoped lang="scss">
+.ideas {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+	margin-bottom: var(--spacing--md);
+}
+
+.idea-card {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--spacing--sm);
+	width: 100%;
+	padding: var(--spacing--sm);
+	background: var(--background--surface);
+	border: var(--border-width) var(--border-style) var(--color--foreground--tint-1);
+	border-radius: var(--radius--lg);
+	color: inherit;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+
+	&:hover {
+		border-color: var(--color--foreground--shade-1);
+	}
+}
+
+.marker {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--row-marker-size);
+	height: var(--row-marker-size);
+	border-radius: 50%;
+	background: var(--color--background);
+	color: var(--color--text--shade-1);
+}
+
+.idea-text {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--4xs);
+	min-width: 0;
+	padding-top: var(--spacing--4xs);
+}
+
+.idea-title {
+	font-size: var(--font-size--sm);
+	font-weight: var(--font-weight--medium);
+	color: var(--color--text--shade-1);
+}
+
+.idea-description {
+	font-size: var(--font-size--xs);
+	color: var(--text-color--subtler);
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	overflow: hidden;
+}
+
+.skeleton-card {
+	height: 52px;
+	background: var(--color--foreground--tint-2);
+	border-color: transparent;
+	animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}
+
+.sent {
+	font-size: var(--font-size--sm);
+	color: var(--text-color--subtler);
+	margin: 0 0 var(--spacing--sm);
+}
+</style>

--- a/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.test.ts
@@ -1,0 +1,89 @@
+import type { BrowserAutomationIdea } from '@n8n/api-types';
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+
+import { useRecommendations } from './useRecommendations';
+import type { BackgroundPushMessage } from '../../types';
+
+type MessageHandler = (message: BackgroundPushMessage) => void;
+
+const messageListeners: MessageHandler[] = [];
+
+const chromeMock = {
+	runtime: {
+		sendMessage: vi.fn(),
+		onMessage: {
+			addListener: vi.fn((fn: MessageHandler) => messageListeners.push(fn)),
+			removeListener: vi.fn((fn: MessageHandler) => {
+				const i = messageListeners.indexOf(fn);
+				if (i >= 0) messageListeners.splice(i, 1);
+			}),
+		},
+	},
+};
+
+Object.assign(globalThis, { chrome: chromeMock });
+
+function mountComposable() {
+	let result!: ReturnType<typeof useRecommendations>;
+	const TestComponent = defineComponent({
+		setup() {
+			result = useRecommendations();
+		},
+		template: '<div />',
+	});
+	const wrapper = mount(TestComponent);
+	return { wrapper, result: () => result };
+}
+
+function pushMessage(message: BackgroundPushMessage): void {
+	for (const fn of messageListeners) fn(message);
+}
+
+const flush = async () => await new Promise((resolve) => setTimeout(resolve, 0));
+
+const idea: BrowserAutomationIdea = {
+	id: '1',
+	title: 'Triage new issues',
+	description: 'Label and route new GitHub issues',
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	messageListeners.length = 0;
+	chromeMock.runtime.sendMessage.mockResolvedValue({ success: true });
+});
+
+describe('useRecommendations', () => {
+	it('asks the background for recommendations on mount', async () => {
+		const { wrapper } = mountComposable();
+		await flush();
+
+		expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({ type: 'getRecommendations' });
+		wrapper.unmount();
+	});
+
+	it('adopts the status and ideas pushed from the background', async () => {
+		const { wrapper, result } = mountComposable();
+		await flush();
+
+		pushMessage({ type: 'recommendationsChanged', status: 'ready', ideas: [idea] });
+
+		expect(result().status.value).toBe('ready');
+		expect(result().ideas.value).toEqual([idea]);
+		wrapper.unmount();
+	});
+
+	it('sends the picked idea to the background', async () => {
+		const { wrapper, result } = mountComposable();
+		await flush();
+
+		await result().send(idea);
+
+		expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({
+			type: 'sendRecommendation',
+			idea,
+		});
+		wrapper.unmount();
+	});
+});

--- a/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.test.ts
@@ -86,4 +86,31 @@ describe('useRecommendations', () => {
 		});
 		wrapper.unmount();
 	});
+
+	it('ignores a second pick while the first is still in flight', async () => {
+		const { wrapper, result } = mountComposable();
+		await flush();
+
+		let resolveSend!: (value: unknown) => void;
+		chromeMock.runtime.sendMessage.mockImplementation(
+			async (message: { type: string }) =>
+				await (message.type === 'sendRecommendation'
+					? new Promise((resolve) => {
+							resolveSend = resolve;
+						})
+					: Promise.resolve({ success: true })),
+		);
+		chromeMock.runtime.sendMessage.mockClear();
+
+		const firstSend = result().send(idea);
+		expect(result().isSending.value).toBe(true);
+
+		await result().send({ ...idea, id: '2' });
+		expect(chromeMock.runtime.sendMessage).toHaveBeenCalledTimes(1);
+
+		resolveSend(undefined);
+		await firstSend;
+		expect(result().isSending.value).toBe(false);
+		wrapper.unmount();
+	});
 });

--- a/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.ts
@@ -1,0 +1,29 @@
+import type { BrowserAutomationIdea } from '@n8n/api-types';
+import { onMounted, onUnmounted, ref } from 'vue';
+
+import type { BackgroundPushMessage, RecommendationsStatus } from '../../types';
+
+export function useRecommendations() {
+	const status = ref<RecommendationsStatus>('loading');
+	const ideas = ref<BrowserAutomationIdea[]>([]);
+
+	async function send(idea: BrowserAutomationIdea): Promise<void> {
+		await chrome.runtime.sendMessage({ type: 'sendRecommendation', idea });
+	}
+
+	function onMessage(message: BackgroundPushMessage): void {
+		if (message.type !== 'recommendationsChanged') return;
+		status.value = message.status;
+		ideas.value = message.ideas ?? [];
+	}
+
+	chrome.runtime.onMessage.addListener(onMessage);
+
+	onMounted(async () => {
+		await chrome.runtime.sendMessage({ type: 'getRecommendations' });
+	});
+
+	onUnmounted(() => chrome.runtime.onMessage.removeListener(onMessage));
+
+	return { status, ideas, send };
+}

--- a/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.ts
+++ b/packages/@n8n/mcp-browser-extension/src/ui/composables/useRecommendations.ts
@@ -6,9 +6,18 @@ import type { BackgroundPushMessage, RecommendationsStatus } from '../../types';
 export function useRecommendations() {
 	const status = ref<RecommendationsStatus>('loading');
 	const ideas = ref<BrowserAutomationIdea[]>([]);
+	// True for the duration of one `send()` call, so the UI can disable the other cards —
+	// picking a second idea before the first confirms would fire two independent builds.
+	const isSending = ref(false);
 
 	async function send(idea: BrowserAutomationIdea): Promise<void> {
-		await chrome.runtime.sendMessage({ type: 'sendRecommendation', idea });
+		if (isSending.value) return;
+		isSending.value = true;
+		try {
+			await chrome.runtime.sendMessage({ type: 'sendRecommendation', idea });
+		} finally {
+			isSending.value = false;
+		}
 	}
 
 	function onMessage(message: BackgroundPushMessage): void {
@@ -25,5 +34,5 @@ export function useRecommendations() {
 
 	onUnmounted(() => chrome.runtime.onMessage.removeListener(onMessage));
 
-	return { status, ideas, send };
+	return { status, ideas, isSending, send };
 }

--- a/packages/@n8n/mcp-browser/src/__tests__/cdp-relay.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/cdp-relay.test.ts
@@ -555,13 +555,17 @@ describe('CDPRelayServer', () => {
 					ext.send(
 						JSON.stringify({
 							method: 'recommendationsRequested',
-							params: { url: 'https://github.com/org/repo/pull/1', pageText: 'Pull request title' },
+							params: {
+								requestId: 'req-1',
+								url: 'https://github.com/org/repo/pull/1',
+								pageText: 'Pull request title',
+							},
 						}),
 					),
 				),
 			]);
 
-			expect(frame.params).toEqual({ ideas: [idea] });
+			expect(frame.params).toEqual({ requestId: 'req-1', ideas: [idea] });
 			ext.close();
 		});
 
@@ -579,13 +583,35 @@ describe('CDPRelayServer', () => {
 					ext.send(
 						JSON.stringify({
 							method: 'recommendationsRequested',
-							params: { url: 'https://example.com', pageText: 'text' },
+							params: { requestId: 'req-2', url: 'https://example.com', pageText: 'text' },
 						}),
 					),
 				),
 			]);
 
-			expect(frame.params).toEqual({ ideas: [] });
+			expect(frame.params).toEqual({ requestId: 'req-2', ideas: [] });
+			ext.close();
+		});
+
+		it('answers recommendationsRequested with no ideas when no handler is wired', async () => {
+			const ext = connectExtension();
+			await waitForOpen(ext);
+			createFakeExtension(ext);
+			await relay.waitForExtension();
+
+			const [frame] = await Promise.all([
+				nextFrame(ext, 'recommendationsReady'),
+				Promise.resolve(
+					ext.send(
+						JSON.stringify({
+							method: 'recommendationsRequested',
+							params: { requestId: 'req-3', url: 'https://example.com', pageText: 'text' },
+						}),
+					),
+				),
+			]);
+
+			expect(frame.params).toEqual({ requestId: 'req-3', ideas: [] });
 			ext.close();
 		});
 
@@ -606,16 +632,47 @@ describe('CDPRelayServer', () => {
 					ext.send(
 						JSON.stringify({
 							method: 'recommendationAccepted',
-							params: { title: 'Triage issues', description: 'Label new issues' },
+							params: {
+								requestId: 'req-4',
+								title: 'Triage issues',
+								description: 'Label new issues',
+							},
 						}),
 					),
 				),
 			]);
 
 			expect(frame.params).toEqual({
+				requestId: 'req-4',
 				accepted: true,
 				threadUrl: 'https://n8n.example.com/assistant/t1',
 			});
+			ext.close();
+		});
+
+		it('answers recommendationAccepted as not accepted when no handler is wired', async () => {
+			const ext = connectExtension();
+			await waitForOpen(ext);
+			createFakeExtension(ext);
+			await relay.waitForExtension();
+
+			const [frame] = await Promise.all([
+				nextFrame(ext, 'recommendationAcceptedResult'),
+				Promise.resolve(
+					ext.send(
+						JSON.stringify({
+							method: 'recommendationAccepted',
+							params: {
+								requestId: 'req-5',
+								title: 'Triage issues',
+								description: 'Label new issues',
+							},
+						}),
+					),
+				),
+			]);
+
+			expect(frame.params).toEqual({ requestId: 'req-5', accepted: false });
 			ext.close();
 		});
 	});

--- a/packages/@n8n/mcp-browser/src/__tests__/cdp-relay.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/cdp-relay.test.ts
@@ -517,4 +517,106 @@ describe('CDPRelayServer', () => {
 			ext.close();
 		});
 	});
+
+	describe('recommendations', () => {
+		async function nextFrame(ws: WebSocket, method: string): Promise<{ params?: unknown }> {
+			return await new Promise((resolve) => {
+				const handler = (data: unknown) => {
+					try {
+						const msg = JSON.parse(parseWsData(data)) as { method?: string; params?: unknown };
+						if (msg.method === method) {
+							ws.off('message', handler);
+							resolve(msg);
+						}
+					} catch {
+						// ignore malformed
+					}
+				};
+				ws.on('message', handler);
+			});
+		}
+
+		it('answers recommendationsRequested with the ideas from onRecommendationsRequested', async () => {
+			const ext = connectExtension();
+			await waitForOpen(ext);
+			createFakeExtension(ext);
+			await relay.waitForExtension();
+
+			const idea = { id: 'i1', title: 'Triage issues', description: 'Label new issues' };
+			relay.onRecommendationsRequested = async (url, pageText) => {
+				expect(url).toBe('https://github.com/org/repo/pull/1');
+				expect(pageText).toBe('Pull request title');
+				return await Promise.resolve([idea]);
+			};
+
+			const [frame] = await Promise.all([
+				nextFrame(ext, 'recommendationsReady'),
+				Promise.resolve(
+					ext.send(
+						JSON.stringify({
+							method: 'recommendationsRequested',
+							params: { url: 'https://github.com/org/repo/pull/1', pageText: 'Pull request title' },
+						}),
+					),
+				),
+			]);
+
+			expect(frame.params).toEqual({ ideas: [idea] });
+			ext.close();
+		});
+
+		it('answers recommendationsRequested with no ideas when onRecommendationsRequested rejects', async () => {
+			const ext = connectExtension();
+			await waitForOpen(ext);
+			createFakeExtension(ext);
+			await relay.waitForExtension();
+
+			relay.onRecommendationsRequested = async () => await Promise.reject(new Error('boom'));
+
+			const [frame] = await Promise.all([
+				nextFrame(ext, 'recommendationsReady'),
+				Promise.resolve(
+					ext.send(
+						JSON.stringify({
+							method: 'recommendationsRequested',
+							params: { url: 'https://example.com', pageText: 'text' },
+						}),
+					),
+				),
+			]);
+
+			expect(frame.params).toEqual({ ideas: [] });
+			ext.close();
+		});
+
+		it('answers recommendationAccepted with the thread from onRecommendationAccepted', async () => {
+			const ext = connectExtension();
+			await waitForOpen(ext);
+			createFakeExtension(ext);
+			await relay.waitForExtension();
+
+			relay.onRecommendationAccepted = async (idea) => {
+				expect(idea).toEqual({ title: 'Triage issues', description: 'Label new issues' });
+				return await Promise.resolve({ threadUrl: 'https://n8n.example.com/assistant/t1' });
+			};
+
+			const [frame] = await Promise.all([
+				nextFrame(ext, 'recommendationAcceptedResult'),
+				Promise.resolve(
+					ext.send(
+						JSON.stringify({
+							method: 'recommendationAccepted',
+							params: { title: 'Triage issues', description: 'Label new issues' },
+						}),
+					),
+				),
+			]);
+
+			expect(frame.params).toEqual({
+				accepted: true,
+				threadUrl: 'https://n8n.example.com/assistant/t1',
+			});
+			ext.close();
+		});
+	});
 });

--- a/packages/@n8n/mcp-browser/src/cdp-relay-protocol.ts
+++ b/packages/@n8n/mcp-browser/src/cdp-relay-protocol.ts
@@ -14,7 +14,7 @@ import type {
  */
 
 /** Version of the extension protocol. Bump when commands/events change. */
-export const PROTOCOL_VERSION = 6;
+export const PROTOCOL_VERSION = 7;
 
 // ---------------------------------------------------------------------------
 // Commands: relay → extension
@@ -79,12 +79,18 @@ export interface ExtensionCommands {
 	/** Deliver the automation ideas generated for the page the extension asked about. */
 	recommendationsReady: {
 		params: {
+			/** Echoes the requesting `recommendationsRequested` event, so a client juggling more
+			 *  than one in-flight request (e.g. the drawer and a connect window open at once) can
+			 *  route the answer back to the right caller. */
+			requestId: string;
 			ideas: BrowserAutomationIdea[];
 		};
 	};
 	/** Report whether an accepted idea started an Instance AI conversation. */
 	recommendationAcceptedResult: {
 		params: {
+			/** Echoes the requesting `recommendationAccepted` event — see `recommendationsReady`. */
+			requestId: string;
 			accepted: boolean;
 			threadUrl?: string;
 		};
@@ -145,6 +151,8 @@ export interface ExtensionEvents {
 	/** The popup opened on this page and wants automation ideas for it. */
 	recommendationsRequested: {
 		params: {
+			/** Unique per request, so more than one in-flight request can be told apart. */
+			requestId: string;
 			url: string;
 			pageText: string;
 		};
@@ -152,6 +160,8 @@ export interface ExtensionEvents {
 	/** The user picked one of the offered ideas to build. */
 	recommendationAccepted: {
 		params: {
+			/** Unique per request — see `recommendationsRequested`. */
+			requestId: string;
 			title: string;
 			description: string;
 			/** The page the idea was generated for, so Instance AI doesn't have to ask. */

--- a/packages/@n8n/mcp-browser/src/cdp-relay-protocol.ts
+++ b/packages/@n8n/mcp-browser/src/cdp-relay-protocol.ts
@@ -1,4 +1,5 @@
 import type {
+	BrowserAutomationIdea,
 	BrowserRecording,
 	BrowserRecordingAction,
 	BrowserRecordingScreenshot,
@@ -13,7 +14,7 @@ import type {
  */
 
 /** Version of the extension protocol. Bump when commands/events change. */
-export const PROTOCOL_VERSION = 5;
+export const PROTOCOL_VERSION = 6;
 
 // ---------------------------------------------------------------------------
 // Commands: relay → extension
@@ -75,6 +76,19 @@ export interface ExtensionCommands {
 	discardRecording: {
 		params: Record<string, never>;
 	};
+	/** Deliver the automation ideas generated for the page the extension asked about. */
+	recommendationsReady: {
+		params: {
+			ideas: BrowserAutomationIdea[];
+		};
+	};
+	/** Report whether an accepted idea started an Instance AI conversation. */
+	recommendationAcceptedResult: {
+		params: {
+			accepted: boolean;
+			threadUrl?: string;
+		};
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -126,6 +140,22 @@ export interface ExtensionEvents {
 		params: {
 			recordingId: string;
 			screenshot: BrowserRecordingScreenshot;
+		};
+	};
+	/** The popup opened on this page and wants automation ideas for it. */
+	recommendationsRequested: {
+		params: {
+			url: string;
+			pageText: string;
+		};
+	};
+	/** The user picked one of the offered ideas to build. */
+	recommendationAccepted: {
+		params: {
+			title: string;
+			description: string;
+			/** The page the idea was generated for, so Instance AI doesn't have to ask. */
+			url?: string;
 		};
 	};
 }

--- a/packages/@n8n/mcp-browser/src/cdp-relay.ts
+++ b/packages/@n8n/mcp-browser/src/cdp-relay.ts
@@ -12,6 +12,7 @@ import {
 	browserRecordingActionSchema,
 	browserRecordingScreenshotSchema,
 	browserRecordingSchema,
+	type BrowserAutomationIdea,
 	type BrowserRecording,
 	type BrowserRecordingAction,
 	type BrowserRecordingScreenshot,
@@ -120,6 +121,16 @@ export class CDPRelayServer {
 		recordingId: string,
 		screenshot: BrowserRecordingScreenshot,
 	) => void;
+
+	/** Called when the extension asks for automation ideas for its current page. */
+	onRecommendationsRequested?: (url: string, pageText: string) => Promise<BrowserAutomationIdea[]>;
+
+	/** Called after the user picks one of the offered ideas to build. */
+	onRecommendationAccepted?: (idea: {
+		title: string;
+		description: string;
+		url?: string;
+	}) => Promise<{ threadUrl?: string }>;
 
 	private readonly connectionTimeoutMs: number;
 
@@ -934,6 +945,35 @@ export class CDPRelayServer {
 				const parsed = browserRecordingScreenshotSchema.safeParse(eventParams.screenshot);
 				if (!parsed.success) return;
 				this.onRecordingScreenshotCaptured?.(eventParams.recordingId, parsed.data);
+			} else if (method === 'recommendationsRequested') {
+				const { url, pageText } = params as ExtensionEvents['recommendationsRequested']['params'];
+				if (!this.onRecommendationsRequested) return;
+				const connection = this.extensionConn;
+				void this.onRecommendationsRequested(url, pageText)
+					.then(async (ideas) => {
+						await connection?.send('recommendationsReady', { ideas });
+					})
+					.catch(async () => {
+						log.error('Could not generate automation ideas');
+						await connection?.send('recommendationsReady', { ideas: [] }).catch(() => {});
+					});
+			} else if (method === 'recommendationAccepted') {
+				const idea = params as ExtensionEvents['recommendationAccepted']['params'];
+				if (!this.onRecommendationAccepted) return;
+				const connection = this.extensionConn;
+				void this.onRecommendationAccepted(idea)
+					.then(async ({ threadUrl }) => {
+						await connection?.send('recommendationAcceptedResult', {
+							accepted: true,
+							threadUrl,
+						});
+					})
+					.catch(async () => {
+						log.error('Could not start a conversation from the accepted idea');
+						await connection
+							?.send('recommendationAcceptedResult', { accepted: false })
+							.catch(() => {});
+					});
 			}
 		};
 	}

--- a/packages/@n8n/mcp-browser/src/cdp-relay.ts
+++ b/packages/@n8n/mcp-browser/src/cdp-relay.ts
@@ -946,24 +946,37 @@ export class CDPRelayServer {
 				if (!parsed.success) return;
 				this.onRecordingScreenshotCaptured?.(eventParams.recordingId, parsed.data);
 			} else if (method === 'recommendationsRequested') {
-				const { url, pageText } = params as ExtensionEvents['recommendationsRequested']['params'];
-				if (!this.onRecommendationsRequested) return;
+				const { requestId, url, pageText } =
+					params as ExtensionEvents['recommendationsRequested']['params'];
 				const connection = this.extensionConn;
+				if (!this.onRecommendationsRequested) {
+					void connection?.send('recommendationsReady', { requestId, ideas: [] }).catch(() => {});
+					return;
+				}
 				void this.onRecommendationsRequested(url, pageText)
 					.then(async (ideas) => {
-						await connection?.send('recommendationsReady', { ideas });
+						await connection?.send('recommendationsReady', { requestId, ideas });
 					})
 					.catch(async () => {
 						log.error('Could not generate automation ideas');
-						await connection?.send('recommendationsReady', { ideas: [] }).catch(() => {});
+						await connection
+							?.send('recommendationsReady', { requestId, ideas: [] })
+							.catch(() => {});
 					});
 			} else if (method === 'recommendationAccepted') {
-				const idea = params as ExtensionEvents['recommendationAccepted']['params'];
-				if (!this.onRecommendationAccepted) return;
+				const { requestId, ...idea } =
+					params as ExtensionEvents['recommendationAccepted']['params'];
 				const connection = this.extensionConn;
+				if (!this.onRecommendationAccepted) {
+					void connection
+						?.send('recommendationAcceptedResult', { requestId, accepted: false })
+						.catch(() => {});
+					return;
+				}
 				void this.onRecommendationAccepted(idea)
 					.then(async ({ threadUrl }) => {
 						await connection?.send('recommendationAcceptedResult', {
+							requestId,
 							accepted: true,
 							threadUrl,
 						});
@@ -971,7 +984,7 @@ export class CDPRelayServer {
 					.catch(async () => {
 						log.error('Could not start a conversation from the accepted idea');
 						await connection
-							?.send('recommendationAcceptedResult', { accepted: false })
+							?.send('recommendationAcceptedResult', { requestId, accepted: false })
 							.catch(() => {});
 					});
 			}

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-browser-session.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-browser-session.service.test.ts
@@ -25,6 +25,11 @@ vi.mock('@n8n/mcp-browser', () => {
 		onRecordingCompleted?: (recording: unknown) => Promise<{ threadUrl?: string }>;
 		onRecordingActionAppended?: (recordingId: string, action: unknown) => void;
 		onRecordingScreenshotCaptured?: (recordingId: string, screenshot: unknown) => void;
+		onRecommendationsRequested?: (url: string, pageText: string) => Promise<unknown[]>;
+		onRecommendationAccepted?: (idea: {
+			title: string;
+			description: string;
+		}) => Promise<{ threadUrl?: string }>;
 		attachExtension = vi.fn();
 		attachController = vi.fn();
 		stop = vi.fn();
@@ -57,6 +62,11 @@ const mcpBrowserMock: {
 		onRecordingCompleted?: (recording: unknown) => Promise<{ threadUrl?: string }>;
 		onRecordingActionAppended?: (recordingId: string, action: unknown) => void;
 		onRecordingScreenshotCaptured?: (recordingId: string, screenshot: unknown) => void;
+		onRecommendationsRequested?: (url: string, pageText: string) => Promise<unknown[]>;
+		onRecommendationAccepted?: (idea: {
+			title: string;
+			description: string;
+		}) => Promise<{ threadUrl?: string }>;
 		attachExtension: Mock;
 		attachController: Mock;
 		stop: Mock;
@@ -72,6 +82,11 @@ const mcpBrowserMock: {
 		onRecordingCompleted?: (recording: unknown) => Promise<{ threadUrl?: string }>;
 		onRecordingActionAppended?: (recordingId: string, action: unknown) => void;
 		onRecordingScreenshotCaptured?: (recordingId: string, screenshot: unknown) => void;
+		onRecommendationsRequested?: (url: string, pageText: string) => Promise<unknown[]>;
+		onRecommendationAccepted?: (idea: {
+			title: string;
+			description: string;
+		}) => Promise<{ threadUrl?: string }>;
 		attachExtension: Mock;
 		attachController: Mock;
 		stop: Mock;
@@ -862,6 +877,67 @@ describe('InstanceAiBrowserSessionService', () => {
 			await relay.onRecordingCompleted?.(recording);
 
 			expect(push.sendToUsers).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('recommendations requested', () => {
+		it('returns the ideas from the handler', async () => {
+			const { relay } = await createSession(service);
+			const handler = vi.fn(async () => [{ id: 'i1', title: 'Triage issues', description: 'D' }]);
+			service.setRecommendationHandler(handler);
+
+			const ideas = await relay.onRecommendationsRequested?.('https://example.com', 'page text');
+
+			expect(handler).toHaveBeenCalledWith({
+				userId: USER_ID,
+				url: 'https://example.com',
+				pageText: 'page text',
+			});
+			expect(ideas).toEqual([{ id: 'i1', title: 'Triage issues', description: 'D' }]);
+		});
+
+		it('returns no ideas when no handler is set', async () => {
+			const { relay } = await createSession(service);
+
+			const ideas = await relay.onRecommendationsRequested?.('https://example.com', 'page text');
+
+			expect(ideas).toEqual([]);
+		});
+
+		it('returns no ideas and logs a warning when the handler throws', async () => {
+			const { relay } = await createSession(service);
+			service.setRecommendationHandler(vi.fn(async () => await Promise.reject(new Error('boom'))));
+
+			const ideas = await relay.onRecommendationsRequested?.('https://example.com', 'page text');
+
+			expect(ideas).toEqual([]);
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to generate automation ideas',
+				expect.objectContaining({ userId: USER_ID }),
+			);
+		});
+	});
+
+	describe('recommendation accepted', () => {
+		const idea = { title: 'Triage issues', description: 'Label and route new GitHub issues' };
+
+		it('starts a new thread via the handler and returns its URL', async () => {
+			const { relay } = await createConnectedSession(service, projectRepository);
+			const handler = vi.fn(async () => ({ threadId: 'thread-1' }));
+			service.setRecommendationAcceptedHandler(handler);
+
+			const result = await relay.onRecommendationAccepted?.(idea);
+
+			expect(handler).toHaveBeenCalledWith({ userId: USER_ID, projectId: 'project-1', idea });
+			expect(result).toEqual({ threadUrl: 'http://localhost:5678/assistant/thread-1' });
+		});
+
+		it('returns nothing when no handler is set', async () => {
+			const { relay } = await createConnectedSession(service, projectRepository);
+
+			const result = await relay.onRecommendationAccepted?.(idea);
+
+			expect(result).toEqual({});
 		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1797,6 +1797,16 @@ type BrowserRecordingServiceInternals = {
 		userId: string;
 		actions: unknown[];
 	}) => Promise<string | undefined>;
+	suggestAutomationIdeas: (input: {
+		userId: string;
+		url: string;
+		pageText: string;
+	}) => Promise<Array<{ id: string; title: string; description: string }>>;
+	launchIdeaThread: (input: {
+		userId: string;
+		projectId: string;
+		idea: { title: string; description: string; url?: string };
+	}) => Promise<{ threadId: string }>;
 	settingsService: {
 		isInstanceAiEnabled: Mock;
 		isBrowserUseEnabled: Mock;
@@ -1806,6 +1816,7 @@ type BrowserRecordingServiceInternals = {
 	memoryService: { ensureThread: Mock; deleteThread: Mock };
 	startRun: Mock;
 	resolveAgentModelConfig: Mock;
+	logger: { debug: Mock; warn: Mock };
 };
 
 function createBrowserRecordingService(): BrowserRecordingServiceInternals {
@@ -1817,6 +1828,7 @@ function createBrowserRecordingService(): BrowserRecordingServiceInternals {
 		isBrowserUseEnabled: vi.fn(() => true),
 		isModelConfigured: vi.fn(async () => true),
 	};
+	service.logger = { debug: vi.fn(), warn: vi.fn() };
 	service.revalidateActiveUser = vi.fn(async () => userWithScopes(['instanceAi:message']));
 	service.memoryService = {
 		ensureThread: vi.fn(async () => {}),
@@ -1879,6 +1891,85 @@ describe('InstanceAiService — summarizeRecordingActions', () => {
 		const result = await service.summarizeRecordingActions({ userId: 'user-1', actions: [] });
 
 		expect(result).toBeUndefined();
+	});
+});
+
+describe('InstanceAiService — suggestAutomationIdeas', () => {
+	it('returns no ideas when Instance AI is not enabled', async () => {
+		const service = createBrowserRecordingService();
+		service.settingsService.isInstanceAiEnabled.mockReturnValue(false);
+
+		const result = await service.suggestAutomationIdeas({
+			userId: 'user-1',
+			url: 'https://github.com/org/repo',
+			pageText: '',
+		});
+
+		expect(result).toEqual([]);
+	});
+
+	it('returns no ideas when the user can no longer be revalidated', async () => {
+		const service = createBrowserRecordingService();
+		service.revalidateActiveUser.mockResolvedValue(null);
+
+		const result = await service.suggestAutomationIdeas({
+			userId: 'user-1',
+			url: 'https://github.com/org/repo',
+			pageText: '',
+		});
+
+		expect(result).toEqual([]);
+	});
+});
+
+describe('InstanceAiService — launchIdeaThread', () => {
+	const IDEA = { title: 'Triage issues', description: 'Label and route new GitHub issues' };
+
+	it('throws when Instance AI is not enabled', async () => {
+		const service = createBrowserRecordingService();
+		service.settingsService.isInstanceAiEnabled.mockReturnValue(false);
+
+		await expect(
+			service.launchIdeaThread({ userId: 'user-1', projectId: 'project-1', idea: IDEA }),
+		).rejects.toThrow('The AI Assistant is not available');
+	});
+
+	it('starts a new thread seeded with the idea description', async () => {
+		const service = createBrowserRecordingService();
+
+		const result = await service.launchIdeaThread({
+			userId: 'user-1',
+			projectId: 'project-1',
+			idea: IDEA,
+		});
+
+		expect(service.memoryService.ensureThread).toHaveBeenCalledWith(
+			expect.any(String),
+			result.threadId,
+			'project-1',
+			expect.objectContaining({ source: 'browser_recommendation' }),
+		);
+		expect(service.startRun).toHaveBeenCalledWith(
+			expect.anything(),
+			result.threadId,
+			IDEA.description,
+		);
+	});
+
+	it('appends the source page to the message when the idea carries a url', async () => {
+		const service = createBrowserRecordingService();
+
+		const result = await service.launchIdeaThread({
+			userId: 'user-1',
+			projectId: 'project-1',
+			idea: { ...IDEA, url: 'https://github.com/n8n-io/n8n/pull/1' },
+		});
+
+		expect(service.startRun).toHaveBeenCalledWith(
+			expect.anything(),
+			result.threadId,
+			`${IDEA.description}\n\nThis was suggested for: https://github.com/n8n-io/n8n/pull/1`,
+		);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -188,6 +188,8 @@ vi.mock('@n8n/instance-ai', async () => {
 			}
 		},
 		resumeAgentRun: vi.fn(),
+		generateValidatedJson: vi.fn(),
+		HAIKU_MODEL: 'anthropic/claude-haiku-4-5-20251001',
 		createInstanceAiTraceContext: vi.fn(async () => ({ rootRun: { otelTraceId: undefined } })),
 		shutdownProductTelemetryProviders: vi.fn(async () => {}),
 		TerminalOutcomeStorage: class {
@@ -220,6 +222,7 @@ import {
 	shutdownProductTelemetryProviders,
 	emitAgentSnapshotTraceEvent,
 	threadProvenanceMetadata,
+	generateValidatedJson,
 	type BuilderUsageItem,
 	type ManagedBackgroundTask,
 	type InstanceAiTraceContext,
@@ -1919,6 +1922,47 @@ describe('InstanceAiService — suggestAutomationIdeas', () => {
 		});
 
 		expect(result).toEqual([]);
+	});
+
+	it('truncates an overlong description instead of rejecting the whole batch', async () => {
+		const service = createBrowserRecordingService();
+		const longDescription = 'x'.repeat(200);
+		vi.mocked(generateValidatedJson).mockResolvedValueOnce({
+			ok: true,
+			data: { ideas: [{ title: 'Triage issues', description: longDescription }] },
+		});
+
+		const result = await service.suggestAutomationIdeas({
+			userId: 'user-1',
+			url: 'https://github.com/org/repo',
+			pageText: '',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0].description).toHaveLength(140);
+		expect(result[0].description).toBe(longDescription.slice(0, 140));
+	});
+
+	it('drops an idea that comes out empty after trimming, without dropping the others', async () => {
+		const service = createBrowserRecordingService();
+		vi.mocked(generateValidatedJson).mockResolvedValueOnce({
+			ok: true,
+			data: {
+				ideas: [
+					{ title: '   ', description: 'Label new issues' },
+					{ title: 'Triage issues', description: 'Label new issues' },
+				],
+			},
+		});
+
+		const result = await service.suggestAutomationIdeas({
+			userId: 'user-1',
+			url: 'https://github.com/org/repo',
+			pageText: '',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0].title).toBe('Triage issues');
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/browser/instance-ai-browser-session.service.ts
+++ b/packages/cli/src/modules/instance-ai/browser/instance-ai-browser-session.service.ts
@@ -1,4 +1,5 @@
 import type {
+	BrowserAutomationIdea,
 	BrowserRecording,
 	BrowserRecordingAction,
 	BrowserRecordingScreenshot,
@@ -115,6 +116,21 @@ export class InstanceAiBrowserSessionService {
 		actions: BrowserRecordingAction[];
 	}) => Promise<string | undefined>;
 
+	/** Generates automation ideas for the extension's current page. Set from
+	 *  instance-ai.service.ts, which has the model resolution this needs. */
+	private recommendationHandler?: (input: {
+		userId: string;
+		url: string;
+		pageText: string;
+	}) => Promise<BrowserAutomationIdea[]>;
+
+	/** Starts a new Instance AI conversation from an accepted idea. */
+	private recommendationAcceptedHandler?: (input: {
+		userId: string;
+		projectId: string;
+		idea: { title: string; description: string; url?: string };
+	}) => Promise<{ threadId: string }>;
+
 	constructor(
 		logger: Logger,
 		private readonly urlService: UrlService,
@@ -141,6 +157,26 @@ export class InstanceAiBrowserSessionService {
 		}) => Promise<string | undefined>,
 	): void {
 		this.actionCaptionHandler = handler;
+	}
+
+	setRecommendationHandler(
+		handler: (input: {
+			userId: string;
+			url: string;
+			pageText: string;
+		}) => Promise<BrowserAutomationIdea[]>,
+	): void {
+		this.recommendationHandler = handler;
+	}
+
+	setRecommendationAcceptedHandler(
+		handler: (input: {
+			userId: string;
+			projectId: string;
+			idea: { title: string; description: string; url?: string };
+		}) => Promise<{ threadId: string }>,
+	): void {
+		this.recommendationAcceptedHandler = handler;
 	}
 
 	async createLink(userId: string): Promise<InstanceAiBrowserCreateLinkResponse> {
@@ -317,6 +353,10 @@ export class InstanceAiBrowserSessionService {
 			this.handleRecordingActionAppended(userId, action);
 		relay.onRecordingScreenshotCaptured = (_recordingId, screenshot) =>
 			this.handleRecordingScreenshotCaptured(userId, screenshot);
+		relay.onRecommendationsRequested = async (url, pageText) =>
+			await this.handleRecommendationsRequested(userId, url, pageText);
+		relay.onRecommendationAccepted = async (idea) =>
+			await this.handleRecommendationAccepted(userId, idea);
 
 		const toolkit = createBrowserTools(
 			{ mode: 'remote' },
@@ -403,6 +443,40 @@ export class InstanceAiBrowserSessionService {
 			session.completedRecordingIds.delete(recording.id);
 			throw error;
 		}
+	}
+
+	/** Generate automation ideas for the page the extension is currently on. Never throws —
+	 *  a failed or unconfigured generation just means no ideas are offered. */
+	private async handleRecommendationsRequested(
+		userId: string,
+		url: string,
+		pageText: string,
+	): Promise<BrowserAutomationIdea[]> {
+		const handler = this.recommendationHandler;
+		if (!handler) return [];
+		try {
+			return await handler({ userId, url, pageText });
+		} catch (error) {
+			this.logger.warn('Failed to generate automation ideas', {
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return [];
+		}
+	}
+
+	/** Start a new Instance AI conversation from an idea the user picked. */
+	private async handleRecommendationAccepted(
+		userId: string,
+		idea: { title: string; description: string; url?: string },
+	): Promise<{ threadUrl?: string }> {
+		const handler = this.recommendationAcceptedHandler;
+		if (!handler) return {};
+		const project = await this.projectRepository.getPersonalProjectForUserOrFail(userId);
+		const { threadId } = await handler({ userId, projectId: project.id, idea });
+		return {
+			threadUrl: `${this.urlService.getInstanceBaseUrl().replace(/\/$/, '')}/assistant/${threadId}`,
+		};
 	}
 
 	/** Reset the in-progress recording state — clears the caption tick, pending debounced

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -12,7 +12,9 @@ import {
 	mcpConnectRequestSchema,
 	credentialSetupHintSchema,
 	formatAttachmentSizeLimit,
+	MAX_BROWSER_AUTOMATION_IDEAS,
 	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
+	type BrowserAutomationIdea,
 	type BrowserRecording,
 	type BrowserRecordingAction,
 	type InstanceAiAttachment,
@@ -870,6 +872,12 @@ export class InstanceAiService {
 		this.browserSessionService.setActionCaptionHandler(
 			async (input) => await this.summarizeRecordingActions(input),
 		);
+		this.browserSessionService.setRecommendationHandler(
+			async (input) => await this.suggestAutomationIdeas(input),
+		);
+		this.browserSessionService.setRecommendationAcceptedHandler(
+			async (input) => await this.launchIdeaThread(input),
+		);
 		runProbe.registerActiveRunCountProvider(() => this.runState.activeRunCount());
 		this.workflowObligations = new WorkflowVerificationObligationService(this.agentMemory);
 		this.taskProjector = new WorkflowVerificationTaskProjector(
@@ -1607,6 +1615,100 @@ export class InstanceAiService {
 			fallbackModelConfig,
 		});
 		return result.ok ? result.data.summary : undefined;
+	}
+
+	private static readonly automationIdeasSchema = z.object({
+		ideas: z
+			.array(z.object({ title: z.string().max(80), description: z.string().max(250) }))
+			.max(MAX_BROWSER_AUTOMATION_IDEAS),
+	});
+
+	/** Suggest a few automations for the page the extension's popup is open on. Never
+	 *  throws — a failed or unconfigured generation just means no ideas are offered. */
+	private async suggestAutomationIdeas(input: {
+		userId: string;
+		url: string;
+		pageText: string;
+	}): Promise<BrowserAutomationIdea[]> {
+		this.logger.debug('Generating automation ideas', { userId: input.userId, url: input.url });
+		if (
+			!this.settingsService.isInstanceAiEnabled() ||
+			!this.settingsService.isBrowserUseEnabled() ||
+			!(await this.settingsService.isModelConfigured())
+		) {
+			this.logger.debug(
+				'Skipped automation idea generation: Instance AI is not enabled or configured',
+			);
+			return [];
+		}
+		const user = await this.revalidateActiveUser(input.userId);
+		if (!user) {
+			this.logger.warn('Skipped automation idea generation: user could not be revalidated', {
+				userId: input.userId,
+			});
+			return [];
+		}
+
+		const fallbackModelConfig = await this.resolveAgentModelConfig(user);
+		const result = await generateValidatedJson('automation-idea-suggester', {
+			model: HAIKU_MODEL,
+			instructions:
+				`Suggest up to ${MAX_BROWSER_AUTOMATION_IDEAS} n8n automations for the page described ` +
+				'below. Each idea needs a short title (a few words) and a crisp one-clause description ' +
+				'(under 15 words, no sub-clauses) of what it would do — this is shown on a small card, ' +
+				'so brevity matters more than completeness. Base ideas on what this specific page is ' +
+				'(e.g. a GitHub pull request, an inbox, a spreadsheet), not generic advice. Output a ' +
+				'single JSON object {"ideas": [{"title": string, "description": string}]}. Return only ' +
+				'the JSON object — no prose, no markdown fences.',
+			userText: JSON.stringify({ url: input.url, pageText: redactString(input.pageText) }),
+			schema: InstanceAiService.automationIdeasSchema,
+			fallbackModelConfig,
+			thinking: false,
+		});
+		if (!result.ok) {
+			this.logger.warn('Automation idea generation failed', {
+				userId: input.userId,
+				reason: result.reason,
+			});
+			return [];
+		}
+		this.logger.debug('Generated automation ideas', { count: result.data.ideas.length });
+		return result.data.ideas.map((idea) => ({ id: randomUUID(), ...idea }));
+	}
+
+	/** Start a new Instance AI conversation from an idea the user picked in the extension —
+	 *  the same shape as sending that idea as a chat message, no recording involved. */
+	private async launchIdeaThread(input: {
+		userId: string;
+		projectId: string;
+		idea: { title: string; description: string; url?: string };
+	}): Promise<{ threadId: string }> {
+		if (
+			!this.settingsService.isInstanceAiEnabled() ||
+			!this.settingsService.isBrowserUseEnabled() ||
+			!(await this.settingsService.isModelConfigured())
+		) {
+			throw new UserError('The AI Assistant is not available');
+		}
+		const user = await this.revalidateActiveUser(input.userId);
+		if (!user) throw new UserError('The AI Assistant is not available for this user');
+
+		const threadId = randomUUID();
+		await this.memoryService.ensureThread(user.id, threadId, input.projectId, {
+			source: 'browser_recommendation',
+			origin: 'external',
+			sourceContext: { title: input.idea.title },
+		});
+		const message = input.idea.url
+			? `${input.idea.description}\n\nThis was suggested for: ${input.idea.url}`
+			: input.idea.description;
+		try {
+			this.startRun(user, threadId, message);
+		} catch (error) {
+			await this.memoryService.deleteThread(threadId);
+			throw error;
+		}
+		return { threadId };
 	}
 
 	/** Get the current messageGroupId for a thread (used by SSE sync). */

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -11,7 +11,10 @@ import {
 	buildProxyHeaders,
 	mcpConnectRequestSchema,
 	credentialSetupHintSchema,
+	browserAutomationIdeaSchema,
 	formatAttachmentSizeLimit,
+	MAX_BROWSER_AUTOMATION_IDEA_DESCRIPTION_LENGTH,
+	MAX_BROWSER_AUTOMATION_IDEA_TITLE_LENGTH,
 	MAX_BROWSER_AUTOMATION_IDEAS,
 	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
 	type BrowserAutomationIdea,
@@ -1617,9 +1620,18 @@ export class InstanceAiService {
 		return result.ok ? result.data.summary : undefined;
 	}
 
+	// Deliberately looser than `browserAutomationIdeaSchema` (the actual contract): zod
+	// validates this array all-or-nothing, so a tight bound here would throw away every idea
+	// in the batch over one slightly-long description. `suggestAutomationIdeas` normalizes
+	// each surviving idea down to the contract's real limits before returning it.
 	private static readonly automationIdeasSchema = z.object({
 		ideas: z
-			.array(z.object({ title: z.string().max(80), description: z.string().max(250) }))
+			.array(
+				z.object({
+					title: z.string().max(MAX_BROWSER_AUTOMATION_IDEA_TITLE_LENGTH),
+					description: z.string().max(250),
+				}),
+			)
 			.max(MAX_BROWSER_AUTOMATION_IDEAS),
 	});
 
@@ -1630,7 +1642,7 @@ export class InstanceAiService {
 		url: string;
 		pageText: string;
 	}): Promise<BrowserAutomationIdea[]> {
-		this.logger.debug('Generating automation ideas', { userId: input.userId, url: input.url });
+		this.logger.debug('Generating automation ideas', { userId: input.userId });
 		if (
 			!this.settingsService.isInstanceAiEnabled() ||
 			!this.settingsService.isBrowserUseEnabled() ||
@@ -1672,8 +1684,20 @@ export class InstanceAiService {
 			});
 			return [];
 		}
-		this.logger.debug('Generated automation ideas', { count: result.data.ideas.length });
-		return result.data.ideas.map((idea) => ({ id: randomUUID(), ...idea }));
+		// Normalize each idea down to the actual `BrowserAutomationIdea` contract, then validate
+		// against it — trims whitespace and truncates an overlong description rather than
+		// rejecting the whole batch, but still drops an idea that comes out empty.
+		const ideas = result.data.ideas
+			.map((idea) => ({
+				id: randomUUID(),
+				title: idea.title.trim(),
+				description: idea.description
+					.trim()
+					.slice(0, MAX_BROWSER_AUTOMATION_IDEA_DESCRIPTION_LENGTH),
+			}))
+			.filter((idea) => browserAutomationIdeaSchema.safeParse(idea).success);
+		this.logger.debug('Generated automation ideas', { count: ideas.length });
+		return ideas;
 	}
 
 	/** Start a new Instance AI conversation from an idea the user picked in the extension —


### PR DESCRIPTION
## Summary

Show up to 3 automation ideas in the browser extension popup, generated from
the current tab's URL and page text — similar to how Claude's browser
extension suggests actions for the page you're on.

- The popup asks the backend for ideas when it opens (connected, idle).
- The backend generates ideas with one non-agentic Haiku call (same pattern
  as the existing recording action-caption summarizer), with extended
  thinking disabled — that call otherwise took ~9-10s for this small task.
- A skeleton shows while loading; a silent fallback to the existing static
  copy covers failure, an unconfigured instance, or an ineligible page.
- Clicking an idea opens a new Instance AI conversation seeded with the
  idea's description and source URL — no recording step involved.

### Changed
- `@n8n/api-types`: new `BrowserAutomationIdea` schema, new
  `browser_recommendation` thread source.
- `@n8n/mcp-browser`: extends the relay protocol with
  `recommendationsRequested`/`recommendationAccepted` events and their
  paired commands.
- `packages/cli`: `InstanceAiService.suggestAutomationIdeas` and
  `launchIdeaThread`, wired through `InstanceAiBrowserSessionService`.
- `@n8n/mcp-browser-extension`: background message handlers,
  `RelayConnection` methods, `useRecommendations` composable, and the
  `AutomationIdeas.vue` popup UI.
- `@n8n/instance-ai`: adds a `thinking: false` opt-out to the shared
  eval-agent helper, for latency-sensitive calls that don't need extended
  reasoning (this call was the first user of that helper for a
  user-facing, wait-on-it request rather than a background task).

## How to test

1. Connect the extension to a local n8n instance with Instance AI /
   Browser Use enabled and a model configured.
2. Open the popup on a page with clear intent (e.g. a GitHub PR or issue
   list) while idle (not recording). After a brief skeleton, up to 3
   ideas should appear.
3. Click an idea — a new AI Assistant conversation should open, already
   building that automation, referencing the source page.
4. Open the popup on an ineligible page (`chrome://`, a blank tab) or while
   disconnected — it should fall back to the existing static instructional
   copy with no error shown.

## Related Linear tickets, Github issues, and Community forum posts

None — hackweek exploration, no ticket.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

