### PR TITLE
fix(core): Preserve link URLs in inbound agent chat messages

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -17,6 +17,7 @@ import {
 	type AgentChatIntegrationContext,
 } from '../agent-chat-integration';
 import type { ComponentMapper } from '../component-mapper';
+import * as esmLoader from '../esm-loader';
 import type { IntegrationMessageContextService } from '../integration-message-context.service';
 import { SlackIntegration } from '../platforms/slack/slack-integration';
 import type { AgentIntegrationConfig } from '@n8n/api-types';
@@ -690,6 +691,68 @@ describe('AgentChatBridge — consumeStream', () => {
 
 			expect(thread.post).not.toHaveBeenCalled();
 		});
+	});
+
+	it('preserves labelled link URLs without duplicating bare URLs', async () => {
+		const chatSdk = await import('chat');
+		const loadChatSdkSpy = vi.spyOn(esmLoader, 'loadChatSdk').mockResolvedValue(chatSdk);
+		try {
+			const { bot, handlers } = makeBot();
+			const agentExecutor = makeAgentExecutor([finishChunk]);
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				streamingIntegration,
+			);
+			await handlers.mention!(makeThread(), {
+				text: 'In this PRD, see https://a.example.com or mail user@example.com',
+				formatted: chatSdk.parseMarkdown(
+					'In [this](https://notion.so/x) PRD, see https://a.example.com or mail user@example.com',
+				),
+				author: { userId: 'u1', userName: 'user1' },
+			});
+			expect(agentExecutor.executeForChatPublished).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message:
+						'In [this](https://notion.so/x) PRD, see https://a.example.com or mail user@example.com',
+				}),
+			);
+		} finally {
+			loadChatSdkSpy.mockRestore();
+		}
+	});
+
+	it('keeps adapter text unchanged when it is not the plain-text projection', async () => {
+		const chatSdk = await import('chat');
+		const loadChatSdkSpy = vi.spyOn(esmLoader, 'loadChatSdk').mockResolvedValue(chatSdk);
+		try {
+			const raw = '<@123> see **x** and `code` at [y](https://u)';
+			const { bot, handlers } = makeBot();
+			const agentExecutor = makeAgentExecutor([finishChunk]);
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				streamingIntegration,
+			);
+			await handlers.mention!(makeThread(), {
+				text: raw,
+				formatted: chatSdk.parseMarkdown(raw),
+				author: { userId: 'u1', userName: 'user1' },
+			});
+			expect(agentExecutor.executeForChatPublished).toHaveBeenCalledWith(
+				expect.objectContaining({ message: raw }),
+			);
+		} finally {
+			loadChatSdkSpy.mockRestore();
+		}
 	});
 
 	describe('when deriving memory scope', () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/channel-integration-contract.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/channel-integration-contract.test.ts
@@ -12,6 +12,17 @@ import {
 	type TelegramReplayFixtures,
 } from './helpers/telegram/replay-test-context';
 
+// The chat SDK + adapters are ESM-only. Production loads them via esm-loader's
+// `new Function()` hack to dodge the CJS transform, which can't run under vitest;
+// redirect the loaders to native dynamic imports so the real adapters are used.
+vi.mock('../esm-loader', () => ({
+	loadChatSdk: async () => await import('chat'),
+	loadMemoryState: async () => await import('@chat-adapter/state-memory'),
+	loadTelegramAdapter: async () => await import('@chat-adapter/telegram'),
+	loadSlackAdapter: async () => await import('@chat-adapter/slack'),
+	loadLinearAdapter: async () => await import('@chat-adapter/linear'),
+}));
+
 const slackFixtures = jsonParse<SlackReplayFixtures>(
 	readFileSync(join(__dirname, 'fixtures/slack/basic.json'), 'utf8'),
 );

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -42,6 +42,7 @@ import {
 import { buildSuspendCardPayload, isApprovalSuspendPayload } from './agent-chat-suspension-cards';
 import { CallbackStore, type CallbackMetadata } from './callback-store';
 import type { ComponentMapper, ShortenCallback } from './component-mapper';
+import { loadChatSdk } from './esm-loader';
 import { IntegrationMessageContextService } from './integration-message-context.service';
 import type { ReplyExpectation } from './integration-tools';
 import { N8NCheckpointStorage } from './n8n-checkpoint-storage';
@@ -598,7 +599,10 @@ export class AgentChatBridge {
 	): Promise<void> {
 		const { isNewMention } = options;
 		const platformAgentContext = this.getPlatformAgentContext();
-		const text = this.prepareInboundText(message.text, platformAgentContext).trim();
+		const text = this.prepareInboundText(
+			await this.getInboundText(message),
+			platformAgentContext,
+		).trim();
 		// `?? []` guards rehydrated/serialized messages that predate the field.
 		const inboundAttachments = message.attachments ?? [];
 		if (!text && inboundAttachments.length === 0) return;
@@ -961,6 +965,22 @@ export class AgentChatBridge {
 
 	private getPlatformAgentContext(): PlatformAgentContext {
 		return this.integrationImpl?.getPlatformAgentContext?.(this.chat) ?? {};
+	}
+
+	/** Keep labelled-link URLs because the Chat SDK plain-text projection removes them. */
+	private async getInboundText(message: Message): Promise<string> {
+		if (!message.formatted) return message.text;
+		const { isLinkNode, text, toPlainText, walkAst } = await loadChatSdk();
+		// Keep raw platform markdown when the adapter does not use the SDK projection.
+		if (toPlainText(message.formatted) !== message.text) return message.text;
+		const formatted = walkAst(structuredClone(message.formatted), (node) => {
+			if (!isLinkNode(node)) return node;
+			const label = toPlainText({ type: 'root', children: [node] });
+			// Keep GFM autolinks because their labels already contain the URL.
+			if ([label, `http://${label}`, `mailto:${label}`].includes(node.url)) return node;
+			return text(`[${label}](${node.url})`);
+		});
+		return toPlainText(formatted);
 	}
 
 	private prepareInboundText(text: string | undefined, context: PlatformAgentContext): string {

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/linear/recorded-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/linear/recorded-integration.test.ts
@@ -9,6 +9,17 @@ import {
 } from '../../../__tests__/helpers/linear/replay-test-context';
 import type { ChannelIntegrationRecord } from '../../../recording/channel-integration-recorder';
 
+// The chat SDK + adapters are ESM-only. Production loads them via esm-loader's
+// `new Function()` hack to dodge the CJS transform, which can't run under vitest;
+// redirect the loaders to native dynamic imports so the real adapters are used.
+vi.mock('../../../esm-loader', () => ({
+	loadChatSdk: async () => await import('chat'),
+	loadMemoryState: async () => await import('@chat-adapter/state-memory'),
+	loadTelegramAdapter: async () => await import('@chat-adapter/telegram'),
+	loadSlackAdapter: async () => await import('@chat-adapter/slack'),
+	loadLinearAdapter: async () => await import('@chat-adapter/linear'),
+}));
+
 const recordedSession = jsonParse<ChannelIntegrationRecord[]>(
 	readFileSync(join(__dirname, '../../../__tests__/fixtures/linear/recorded-session.json'), 'utf8'),
 );

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/recorded-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/recorded-integration.test.ts
@@ -8,6 +8,17 @@ import {
 } from '../../../__tests__/helpers/slack/replay-test-context';
 import type { ChannelIntegrationRecord } from '../../../recording/channel-integration-recorder';
 
+// The chat SDK + adapters are ESM-only. Production loads them via esm-loader's
+// `new Function()` hack to dodge the CJS transform, which can't run under vitest;
+// redirect the loaders to native dynamic imports so the real adapters are used.
+vi.mock('../../../esm-loader', () => ({
+	loadChatSdk: async () => await import('chat'),
+	loadMemoryState: async () => await import('@chat-adapter/state-memory'),
+	loadTelegramAdapter: async () => await import('@chat-adapter/telegram'),
+	loadSlackAdapter: async () => await import('@chat-adapter/slack'),
+	loadLinearAdapter: async () => await import('@chat-adapter/linear'),
+}));
+
 const recordedSession = jsonParse<ChannelIntegrationRecord[]>(
 	readFileSync(join(__dirname, '../../../__tests__/fixtures/slack/recorded-session.json'), 'utf8'),
 );

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/synthetic-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/slack/synthetic-integration.test.ts
@@ -9,6 +9,17 @@ import {
 } from '../../../__tests__/helpers/slack/synthetic-fixtures';
 import { SlackIntegration } from '../../slack/slack-integration';
 
+// The chat SDK + adapters are ESM-only. Production loads them via esm-loader's
+// `new Function()` hack to dodge the CJS transform, which can't run under vitest;
+// redirect the loaders to native dynamic imports so the real adapters are used.
+vi.mock('../../../esm-loader', () => ({
+	loadChatSdk: async () => await import('chat'),
+	loadMemoryState: async () => await import('@chat-adapter/state-memory'),
+	loadTelegramAdapter: async () => await import('@chat-adapter/telegram'),
+	loadSlackAdapter: async () => await import('@chat-adapter/slack'),
+	loadLinearAdapter: async () => await import('@chat-adapter/linear'),
+}));
+
 describe('Slack channel integration scenarios', () => {
 	it('handles Slack URL verification without an active connection', () => {
 		const integration = new SlackIntegration(mock<AgentRepository>());


### PR DESCRIPTION
## Summary

When a user chats with an Agent through a chat channel such as Slack and writes a hyperlink with custom text (Slack mrkdwn `<https://…|this>`), the Agent received only the label ("this"). The URL was lost, so the Agent asked the user to paste the link.

**Root cause:** `AgentChatBridge` passed `message.text` to the Agent. The Chat SDK builds `message.text` as a plain-text projection of the message. That projection renders a link node as its label only, so the URL was dropped before the Agent saw the message.

**Fix:** when `message.text` is exactly the SDK plain-text projection of `message.formatted` (the Slack adapter builds it that way), rebuild the inbound text from `message.formatted` (mdast). A link whose label differs from its URL now reaches the Agent as `[label](url)`. Bare URLs, `www.` hosts, emails, and all other text are unchanged.

Adapters that hand over raw platform markdown as `text` (Discord, Telegram, Linear) already carry link URLs and keep their text byte-identical. Messages without `formatted` fall back to `message.text` as before.

## How to test

Requires `N8N_ENABLED_MODULES=agents`.

1. Connect an Agent to Slack (Agent → Channels → Slack).
2. In Slack, send the bot a message that contains a hyperlink with custom text. For example, type "check this doc", select "this", and add a link. A pasted Notion or Google Docs link that Slack renders as a title also works.
3. Ask the Agent what the link is.
   - Before: the Agent does not know the URL and asks you to paste it.
   - After: the Agent repeats the URL (it receives `check [this](https://…) doc`).
4. Regression test: `cd packages/cli && pnpm test src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-849

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

