### PR TITLE
fix(editor): Show renamed credentials in the AI Assistant setup picker

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -391,6 +391,29 @@ describe('NodeCredentials', () => {
 		expect(screen.queryByText('Scout')).not.toBeInTheDocument();
 	});
 
+	it('should keep the current list when the refetch on open fails', async () => {
+		ndvStore.activeNode = httpNode;
+		credentialsStore.state.credentials = {
+			c8vqdPpPClh4TgIO: createCredential({ name: 'Scout' }),
+		};
+
+		renderComponent();
+
+		// A plain function, not vi.fn(): the spy attaches its own handlers to the returned
+		// promise and would hide a missing catch. Vitest fails the run on an unhandled rejection.
+		let requestedScope: unknown;
+		credentialsStore.fetchUsableCredentials = async (scope) => {
+			requestedScope = scope;
+			throw new Error('offline');
+		};
+
+		const select = screen.getByTestId('node-credentials-select');
+		await userEvent.click(select.querySelector('input') as HTMLElement);
+
+		expect(requestedScope).toEqual({ workflowId: '1' });
+		expect(screen.getByText('Scout')).toBeInTheDocument();
+	});
+
 	it('should not fetch credentials on mount when skipCredentialsFetch is set', () => {
 		// Hosts with a synthetic workflow document (e.g. the tool config modal)
 		// own the credential fetch themselves; the component's own fetch would

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -366,6 +366,31 @@ describe('NodeCredentials', () => {
 		});
 	});
 
+	it('should refetch credentials when the dropdown opens so a rename from another tab shows up', async () => {
+		ndvStore.activeNode = httpNode;
+		credentialsStore.state.credentials = {
+			c8vqdPpPClh4TgIO: createCredential({ name: 'Scout' }),
+		};
+
+		renderComponent();
+
+		// The rename happened in another tab: only a fresh fetch can bring the new name.
+		credentialsStore.fetchUsableCredentials = vi.fn().mockImplementation(async () => {
+			credentialsStore.state.credentials = {
+				c8vqdPpPClh4TgIO: createCredential({ name: 'Scout renamed' }),
+			};
+			return Object.values(credentialsStore.state.credentials);
+		});
+
+		// Click the input: the dropdown only opens from inside the select trigger.
+		const select = screen.getByTestId('node-credentials-select');
+		await userEvent.click(select.querySelector('input') as HTMLElement);
+
+		expect(credentialsStore.fetchUsableCredentials).toHaveBeenCalledWith({ workflowId: '1' });
+		expect(await screen.findByText('Scout renamed')).toBeInTheDocument();
+		expect(screen.queryByText('Scout')).not.toBeInTheDocument();
+	});
+
 	it('should not fetch credentials on mount when skipCredentialsFetch is set', () => {
 		// Hosts with a synthetic workflow document (e.g. the tool config modal)
 		// own the credential fetch themselves; the component's own fetch would

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -401,8 +401,9 @@ describe('NodeCredentials', () => {
 
 		// A plain function, not vi.fn(): the spy attaches its own handlers to the returned
 		// promise and would hide a missing catch. Vitest fails the run on an unhandled rejection.
+		// The mocked store type only accepts mocks, so assign through the plain store type.
 		let requestedScope: unknown;
-		credentialsStore.fetchUsableCredentials = async (scope) => {
+		useCredentialsStore().fetchUsableCredentials = async (scope) => {
 			requestedScope = scope;
 			throw new Error('offline');
 		};

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -1015,7 +1015,11 @@ function onSelectVisibleChange(credentialType: string, isVisible: boolean) {
 	// from another tab stays stale until remount. Refetch when the user opens the list.
 	// Cost: one GET per open. A cross-tab push channel would remove it.
 	const scope = props.skipCredentialsFetch ? undefined : getCredentialFetchScope();
-	if (scope) void credentialsStore.fetchUsableCredentials(scope);
+	if (scope) {
+		credentialsStore.fetchUsableCredentials(scope).catch(() => {
+			// A failed refetch keeps whatever the store already holds.
+		});
+	}
 }
 
 function matches(needle: string, haystack: string) {

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -1007,7 +1007,15 @@ function setFilter(newFilter = '') {
 
 function onSelectVisibleChange(credentialType: string, isVisible: boolean) {
 	openCredentialSelectType.value = isVisible ? credentialType : null;
-	if (!isVisible) setFilter();
+	if (!isVisible) {
+		setFilter();
+		return;
+	}
+	// The store only learns about credential changes made in this tab, so a rename
+	// from another tab stays stale until remount. Refetch when the user opens the list.
+	// Cost: one GET per open. A cross-tab push channel would remove it.
+	const scope = props.skipCredentialsFetch ? undefined : getCredentialFetchScope();
+	if (scope) void credentialsStore.fetchUsableCredentials(scope);
 }
 
 function matches(needle: string, haystack: string) {


### PR DESCRIPTION
## Summary

In the AI Assistant, the credential setup step shows a credential picker. The picker fills its list from the credentials store. The store only learns about credential changes made in the same tab. When a user renamed a credential in another tab, the open setup step kept the old name. A search for the new name found nothing until the step remounted.

The picker component (`NodeCredentials.vue`) is shared. The AI Assistant setup step and the node details view both render it. This PR fixes the shared component: it refetches the usable credentials for its scope each time the dropdown opens. The fetch respects `skipCredentialsFetch`, like the fetch on mount. Cost: one credentials request per open. A failed refetch keeps the list the picker already shows. The node details view gets the same fix as a by-product.

Not reproduced: the ticket says the picker also stays stale after a refresh. A browser reload remounts the picker and fetches again, so that part did not reproduce locally.

### Evidence

Checked on a local backend with the AI Assistant "Set up Slack" card open in one tab. The card was staged from a stored credential confirmation request in a local thread, because the assistant needs an LLM run to produce one. The credential was renamed with the same credentials API request that the credential modal sends from a second tab.

- Before: with the card already open, the dropdown still listed "Slack account renamed 2" while the server already had "Slack account renamed 3".
- After: the dropdown listed "Slack account renamed 4", a name set after the card had loaded. The network log showed one `GET /rest/credentials/for-workflow?projectId=...` at the moment the dropdown opened.

## How to test

1. Ask the AI Assistant to build a workflow with a Slack node. When the credential setup step appears, open the credential dropdown. It lists your Slack credential.
2. In a second tab, open Credentials, open the same credential, rename it, and save.
3. Back in the assistant tab, open the credential dropdown again.

Before this change, the list still showed the old name. Now the list shows the new name, and the network tab shows one credentials request when the dropdown opens. The same steps work in the node details view.

Unit tests: `NodeCredentials.test.ts` passes (97 tests). Two new tests: "should refetch credentials when the dropdown opens so a rename from another tab shows up" and "should keep the current list when the refetch on open fails".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1105

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. Not needed for this bug fix.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
