### PR TITLE
fix(AI Agent Node): Preserve Anthropic thinking blocks with empty text across tool calls

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -147,7 +147,8 @@ function buildMessageContent(
 	const { thinkingContent, thinkingType, thinkingSignature } = providerMetadata;
 
 	// Anthropic thinking mode: build content blocks
-	if (thinkingContent && thinkingType) {
+	// Empty thinking text is valid because the signature carries the reasoning.
+	if (thinkingContent !== undefined && thinkingType) {
 		return buildAnthropicContentBlocks(
 			thinkingContent,
 			thinkingType,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -172,7 +172,7 @@ function extractThinkingMetadata(
 					if (typeof rc === 'string' && rc.length > 0) reasoningContent = rc;
 				}
 
-				if (thoughtSignature || thinkingContent || reasoningContent) break;
+				if (thoughtSignature || thinkingContent !== undefined || reasoningContent) break;
 			}
 		}
 	}
@@ -182,7 +182,8 @@ function extractThinkingMetadata(
 		result.google = { thoughtSignature };
 	}
 
-	if (thinkingContent && thinkingType) {
+	// Empty thinking text is valid because the signature carries the reasoning.
+	if (thinkingContent !== undefined && thinkingType) {
 		result.anthropic = {
 			thinkingContent,
 			thinkingType,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -822,6 +822,59 @@ describe('buildSteps', () => {
 			});
 		});
 
+		it('should reconstruct thinking blocks with empty thinking text', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_omitted_1',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_omitted_1',
+							metadata: {
+								itemIndex: 0,
+								anthropic: {
+									thinkingContent: '',
+									thinkingType: 'thinking',
+									thinkingSignature: 'encrypted_signature_abc',
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result[0].action.messageLog?.[0].content).toEqual([
+				{
+					type: 'thinking',
+					thinking: '',
+					signature: 'encrypted_signature_abc',
+				},
+				{
+					type: 'tool_use',
+					id: 'call_omitted_1',
+					name: 'Calculator',
+					input: { expression: '2+2' },
+				},
+			]);
+		});
+
 		it('should reconstruct AIMessage with redacted_thinking content blocks', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
@@ -631,6 +631,42 @@ describe('createEngineRequests', () => {
 			expect(result[0].metadata.anthropic?.thinkingSignature).toBe('test_signature_123');
 		});
 
+		it('should preserve thinking blocks with empty thinking text', async () => {
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_omitted_1',
+					messageLog: [
+						{
+							content: [
+								{
+									type: 'thinking',
+									thinking: '',
+									signature: 'encrypted_signature_abc',
+								},
+								{
+									type: 'tool_use',
+									id: 'call_omitted_1',
+									name: 'calculator',
+									input: { expression: '2+2' },
+								},
+							],
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result[0].metadata.anthropic).toEqual({
+				thinkingContent: '',
+				thinkingType: 'thinking',
+				thinkingSignature: 'encrypted_signature_abc',
+			});
+		});
+
 		it('should extract redacted_thinking content from Anthropic message', async () => {
 			const tools = [createMockTool('search', { sourceNodeName: 'Search' })];
 


### PR DESCRIPTION
## Summary

An AI Agent with tools returned `{"output": ""}` with every node green when the Anthropic Chat Model used a model whose thinking display is `omitted`. This is the API default on Claude Fable 5/5.1, Mythos 5/5.1, Opus 5, Sonnet 5, Opus 4.8, and Opus 4.7. Tool-less agents on the same models worked.

**Root cause.** With `display: "omitted"`, Anthropic returns thinking blocks whose `thinking` field is an empty string while `signature` carries the encrypted reasoning. Anthropic requires the block to be echoed back unchanged next to its `tool_use`. Two truthiness checks (`if (thinkingContent && thinkingType)`) treated the empty string as "no thinking" during the engine tool round-trip:

- `utils/agent-execution/createEngineRequests.ts` (`extractThinkingMetadata`) dropped the block and its signature from the engine action metadata.
- `utils/agent-execution/buildSteps.ts` (`buildMessageContent`) rebuilt the assistant turn as `content: []` + `tool_calls` instead of `[thinking, tool_use]` content blocks.

The follow-up request reached the API without the thinking block, and the agent finished with empty output.

**Fix.** Test for presence (`thinkingContent !== undefined`) instead of truthiness at both sites, and in the early-`break` of the messageLog scan. `isThinkingBlock` already accepted empty strings; only these conditions discarded them. Non-empty thinking, `redacted_thinking`, Gemini thought signatures, and DeepSeek `reasoning_content` are unchanged.

**Verification.** A runtime probe against the built `dist` before the change reproduced the drop (`metadata.anthropic` was `undefined` for `thinking: ''` + signature; `buildSteps` rebuilt `content: []`). Two regression tests now pin the behaviour; both fail on `master` and pass with this change. All 74 tests in the two touched test files pass.

## How to test

1. Create a workflow: Manual Trigger → **AI Agent** with one tool (for example Calculator) and an **Anthropic Chat Model** sub-node set to `claude-sonnet-5` or `claude-fable-5` with **Thinking Mode: Adaptive**.
2. Prompt it with something that forces a tool call, for example "Use the calculator to compute 2+2, then tell me the result in one sentence."
3. On `master`: the agent finishes green in a few seconds with `{"output": ""}`.
4. With this PR: the agent returns real output. In the Anthropic model sub-node's second call, the previous assistant turn contains the `thinking` block (empty text, populated signature) followed by the `tool_use` block.

Unit tests:

```bash
cd packages/@n8n/nodes-langchain
pnpm test utils/agent-execution/test/createEngineRequests.test.ts utils/agent-execution/test/buildSteps.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-853
- Supersedes community PR https://github.com/n8n-io/n8n/pull/32085 by @cthorner, which identified the root cause and the same fix. That PR has merge conflicts with `master` after #33640 and #34924 changed the surrounding lines; this PR re-applies the fix on top of them.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

