### PR TITLE
feat(core): Warn MCP builders when the canvas is over the top-level ceiling (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -1334,5 +1334,44 @@ describe('create-workflow-from-code MCP tool', () => {
 				]);
 			});
 		});
+
+		describe('top-level ceiling warning', () => {
+			const wideNodes: INode[] = Array.from({ length: 8 }, (_, i) => ({
+				id: `node-${i}`,
+				name: `Step ${i}`,
+				type: 'n8n-nodes-base.set',
+				typeVersion: 1,
+				position: [i * 200, 0],
+				parameters: {},
+			}));
+
+			test('flag on: a saved canvas over the ceiling with no groups gets a warning', async () => {
+				mockParseAndValidate.mockResolvedValue({
+					workflow: { ...mockWorkflowJson, nodes: wideNodes },
+					warnings: [],
+				});
+
+				const result = await callHandler(
+					{ code: 'const wf = ...' },
+					createTool({ canvasGroupsEnabled: true }),
+				);
+
+				const response = parseResult(result);
+				expect(response.warnings).toEqual([
+					expect.objectContaining({ code: 'TOP_LEVEL_ITEMS_OVER_CEILING' }),
+				]);
+			});
+
+			test('flag off: no ceiling warning, groups cannot be kept anyway', async () => {
+				mockParseAndValidate.mockResolvedValue({
+					workflow: { ...mockWorkflowJson, nodes: wideNodes },
+					warnings: [],
+				});
+
+				const result = await callHandler({ code: 'const wf = ...' }, createTool());
+
+				expect(parseResult(result)).not.toHaveProperty('warnings');
+			});
+		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/top-level-items-warning.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/top-level-items-warning.test.ts
@@ -1,0 +1,42 @@
+import type { IConnections, INode } from 'n8n-workflow';
+
+import { topLevelItemsWarning } from '../tools/workflow-builder/top-level-items-warning';
+
+const makeNodes = (count: number): INode[] =>
+	Array.from({ length: count }, (_, i) => ({
+		id: `n${i}`,
+		name: `Node ${i}`,
+		type: 'n8n-nodes-base.set',
+		typeVersion: 1,
+		position: [i * 200, 0],
+		parameters: {},
+	}));
+
+describe('topLevelItemsWarning', () => {
+	test('returns nothing when the canvas is within the ceiling', () => {
+		expect(topLevelItemsWarning({ nodes: makeNodes(7), connections: {} })).toBeUndefined();
+	});
+
+	test('returns one warning naming the loose nodes when the canvas is over the ceiling', () => {
+		const warning = topLevelItemsWarning({ nodes: makeNodes(8), connections: {} });
+
+		expect(warning?.code).toBe('TOP_LEVEL_ITEMS_OVER_CEILING');
+		expect(warning?.message).toContain('Node 0');
+	});
+
+	test('counts a collapsed group as one box', () => {
+		const nodes = makeNodes(8);
+		const nodeGroups = [{ id: 'g1', name: 'Stage', nodeIds: nodes.slice(0, 4).map((n) => n.id) }];
+
+		expect(topLevelItemsWarning({ nodes, connections: {}, nodeGroups })).toBeUndefined();
+	});
+
+	test('does not count a sub-node as a box', () => {
+		const nodes = makeNodes(8);
+		const connections: IConnections = {
+			'Node 7': { ai_tool: [[{ node: 'Node 0', type: 'ai_tool', index: 0 }]] },
+		};
+
+		expect(topLevelItemsWarning({ nodes, connections })).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -1282,6 +1282,30 @@ describe('update-workflow MCP tool', () => {
 					);
 				});
 
+				test('swapping one loose node for a new one keeps the box count but is not pre-existing', async () => {
+					findWorkflowMock.mockResolvedValue(
+						Object.assign(buildExistingWorkflow(), { nodes: looseNodes(9), connections: {} }),
+					);
+
+					const result = await callHandler(
+						{
+							workflowId: 'wf-1',
+							operations: [{ type: 'removeNode', nodeName: 'Step 8' }, ...addNodeOps(9, 10)],
+						},
+						createOnTool(),
+					);
+
+					const response = parseResult(result);
+					expect(response.validationWarnings).toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({ code: 'TOP_LEVEL_ITEMS_OVER_CEILING' }),
+						]),
+					);
+					expect(response.validationWarnings).not.toEqual(
+						expect.arrayContaining([expect.objectContaining({ preExisting: true })]),
+					);
+				});
+
 				test('a canvas already over the ceiling that this update adds loose nodes to is not marked pre-existing', async () => {
 					findWorkflowMock.mockResolvedValue(
 						Object.assign(buildExistingWorkflow(), { nodes: looseNodes(9), connections: {} }),

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -1251,13 +1251,22 @@ describe('update-workflow MCP tool', () => {
 					);
 				});
 
-				test('a canvas that was already over the ceiling gets the warning marked pre-existing', async () => {
+				test('a canvas already over the ceiling, with no box added, gets the warning marked pre-existing', async () => {
 					findWorkflowMock.mockResolvedValue(
 						Object.assign(buildExistingWorkflow(), { nodes: looseNodes(9), connections: {} }),
 					);
 
 					const result = await callHandler(
-						{ workflowId: 'wf-1', operations: addNodeOps(9, 10) },
+						{
+							workflowId: 'wf-1',
+							operations: [
+								{
+									type: 'updateNodeParameters',
+									nodeName: 'Step 1',
+									parameters: { url: 'https://new' },
+								},
+							],
+						},
 						createOnTool(),
 					);
 
@@ -1270,6 +1279,27 @@ describe('update-workflow MCP tool', () => {
 								message: expect.stringContaining('[pre-existing]') as string,
 							}),
 						]),
+					);
+				});
+
+				test('a canvas already over the ceiling that this update adds loose nodes to is not marked pre-existing', async () => {
+					findWorkflowMock.mockResolvedValue(
+						Object.assign(buildExistingWorkflow(), { nodes: looseNodes(9), connections: {} }),
+					);
+
+					const result = await callHandler(
+						{ workflowId: 'wf-1', operations: addNodeOps(9, 11) },
+						createOnTool(),
+					);
+
+					const response = parseResult(result);
+					expect(response.validationWarnings).toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({ code: 'TOP_LEVEL_ITEMS_OVER_CEILING' }),
+						]),
+					);
+					expect(response.validationWarnings).not.toEqual(
+						expect.arrayContaining([expect.objectContaining({ preExisting: true })]),
 					);
 				});
 			});

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -1218,6 +1218,61 @@ describe('update-workflow MCP tool', () => {
 					]),
 				);
 			});
+
+			describe('top-level ceiling warning', () => {
+				const looseNodes = (count: number) =>
+					Array.from({ length: count }, (_, i) =>
+						makeNode({ id: `n${i}`, name: `Step ${i}`, position: [i * 200, 0] }),
+					);
+				const addNodeOps = (from: number, to: number) =>
+					Array.from({ length: to - from }, (_, i) => ({
+						type: 'addNode',
+						node: makeNode({ id: `n${from + i}`, name: `Step ${from + i}` }),
+					}));
+
+				test('an update that pushes the canvas over the ceiling gets a warning', async () => {
+					findWorkflowMock.mockResolvedValue(
+						Object.assign(buildExistingWorkflow(), { nodes: looseNodes(6), connections: {} }),
+					);
+
+					const result = await callHandler(
+						{ workflowId: 'wf-1', operations: addNodeOps(6, 8) },
+						createOnTool(),
+					);
+
+					const response = parseResult(result);
+					expect(response.validationWarnings).toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({ code: 'TOP_LEVEL_ITEMS_OVER_CEILING' }),
+						]),
+					);
+					expect(response.validationWarnings).not.toEqual(
+						expect.arrayContaining([expect.objectContaining({ preExisting: true })]),
+					);
+				});
+
+				test('a canvas that was already over the ceiling gets the warning marked pre-existing', async () => {
+					findWorkflowMock.mockResolvedValue(
+						Object.assign(buildExistingWorkflow(), { nodes: looseNodes(9), connections: {} }),
+					);
+
+					const result = await callHandler(
+						{ workflowId: 'wf-1', operations: addNodeOps(9, 10) },
+						createOnTool(),
+					);
+
+					const response = parseResult(result);
+					expect(response.validationWarnings).toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({
+								code: 'TOP_LEVEL_ITEMS_OVER_CEILING',
+								preExisting: true,
+								message: expect.stringContaining('[pre-existing]') as string,
+							}),
+						]),
+					);
+				});
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -21,6 +21,7 @@ import {
 } from './credentials-auto-assign';
 import { validateDataTableReferencesForWorkflow } from './data-table-validation';
 import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
+import { topLevelItemsWarning } from './top-level-items-warning';
 import {
 	buildCreateVersionMetadata,
 	resolveVersionMetadata,
@@ -449,8 +450,14 @@ export const createCreateWorkflowFromCodeTool = (
 				note: notes.length ? notes.join(' ') : undefined,
 				skippedGroups: skippedGroups.length > 0 ? skippedGroups : undefined,
 			};
-			const output =
-				result.warnings.length > 0 ? { ...baseOutput, warnings: result.warnings } : baseOutput;
+
+			// Groups are dropped on save when the flag is off, so only warn when they can be kept.
+			const ceilingWarning = options.canvasGroupsEnabled
+				? topLevelItemsWarning(savedWorkflow)
+				: undefined;
+
+			const warnings = ceilingWarning ? [...result.warnings, ceilingWarning] : result.warnings;
+			const output = warnings.length > 0 ? { ...baseOutput, warnings } : baseOutput;
 
 			return {
 				content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -173,7 +173,9 @@ const outputSchema = {
 			}),
 		)
 		.optional()
-		.describe('Node groups that were invalid and skipped instead of failing the whole creation.'),
+		.describe(
+			'Node groups that were invalid and skipped instead of failing the whole creation. Repair them with update_workflow before you report the workflow as done.',
+		),
 	hint: z
 		.string()
 		.optional()

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -65,7 +65,7 @@ export function getMcpInstructions(options: McpInstructionsOptions): string {
 	const GROUPS_HINT = canvasGroupsEnabled
 		? `
 
-Node groups: when a workflow has several distinct stages, organise it into named groups so it is readable on the canvas. Before creating groups, call ${MCP_GET_SDK_REFERENCE_TOOL.toolName} with section "groups" for the rules, and ${MCP_GET_WORKFLOW_BEST_PRACTICES_TOOL.toolName} (technique "list") for when to group. The save never fails because of groups, so read its result: when it reports TOP_LEVEL_ITEMS_OVER_CEILING, skippedGroups or removedGroups, repair the groups with ${MCP_UPDATE_WORKFLOW_TOOL.toolName} before you tell the user the workflow is done.`
+Node groups: when a workflow has several distinct stages, organise it into named groups so it is readable on the canvas. Before creating groups, call ${MCP_GET_SDK_REFERENCE_TOOL.toolName} with section "groups" for the rules, and ${MCP_GET_WORKFLOW_BEST_PRACTICES_TOOL.toolName} (technique "list") for when to group. The save never fails because of groups, so read its result: when it reports TOP_LEVEL_ITEMS_OVER_CEILING, skippedGroups or removedGroups, repair the groups with ${MCP_UPDATE_WORKFLOW_TOOL.toolName} before you tell the user the workflow is done. A warning marked [pre-existing] describes a canvas that was already like that before your update; you do not need to repair it before you report done.`
 		: '';
 
 	const N8N_CONNECT_HINT = isN8nConnectAvailable

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -65,7 +65,7 @@ export function getMcpInstructions(options: McpInstructionsOptions): string {
 	const GROUPS_HINT = canvasGroupsEnabled
 		? `
 
-Node groups: when a workflow has several distinct stages, organise it into named groups so it is readable on the canvas. Before creating groups, call ${MCP_GET_SDK_REFERENCE_TOOL.toolName} with section "groups" for the rules, and ${MCP_GET_WORKFLOW_BEST_PRACTICES_TOOL.toolName} (technique "list") for when to group.`
+Node groups: when a workflow has several distinct stages, organise it into named groups so it is readable on the canvas. Before creating groups, call ${MCP_GET_SDK_REFERENCE_TOOL.toolName} with section "groups" for the rules, and ${MCP_GET_WORKFLOW_BEST_PRACTICES_TOOL.toolName} (technique "list") for when to group. The save never fails because of groups, so read its result: when it reports TOP_LEVEL_ITEMS_OVER_CEILING, skippedGroups or removedGroups, repair the groups with ${MCP_UPDATE_WORKFLOW_TOOL.toolName} before you tell the user the workflow is done.`
 		: '';
 
 	const N8N_CONNECT_HINT = isN8nConnectAvailable

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/top-level-items-warning.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/top-level-items-warning.ts
@@ -20,9 +20,9 @@ const summarize = (workflow: CanvasShape) =>
 		connectionsBySourceNode: workflow.connections,
 	});
 
-/** Boxes the canvas shows with every group collapsed: groups plus loose nodes. */
-export function topLevelBoxCount(workflow: CanvasShape): number {
-	return summarize(workflow).total;
+/** Names of the nodes that draw a box of their own: not in a group, not a sub-node. */
+export function summarizeUngroupedNodeNames(workflow: CanvasShape): string[] {
+	return summarize(workflow).ungroupedNodeNames;
 }
 
 /**

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/top-level-items-warning.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/top-level-items-warning.ts
@@ -1,0 +1,33 @@
+import type { IConnections, INode, IWorkflowGroup } from 'n8n-workflow';
+import {
+	formatTopLevelItemsMessage,
+	summarizeTopLevelItems,
+	TOP_LEVEL_ITEMS_OVER_CEILING_CODE,
+} from 'n8n-workflow';
+
+export type TopLevelItemsWarning = { code: string; message: string };
+
+/**
+ * One warning when the saved canvas shows more boxes than the ceiling. A box is a
+ * node or a collapsed group. Returns nothing when the canvas is within the ceiling.
+ */
+export function topLevelItemsWarning(workflow: {
+	nodes: INode[];
+	connections: IConnections;
+	nodeGroups?: IWorkflowGroup[];
+}): TopLevelItemsWarning | undefined {
+	const summary = summarizeTopLevelItems({
+		nodes: workflow.nodes,
+		nodeGroups: workflow.nodeGroups,
+		connectionsBySourceNode: workflow.connections,
+	});
+
+	if (!summary.overCeiling) {
+		return undefined;
+	}
+
+	return {
+		code: TOP_LEVEL_ITEMS_OVER_CEILING_CODE,
+		message: formatTopLevelItemsMessage(summary),
+	};
+}

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/top-level-items-warning.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/top-level-items-warning.ts
@@ -7,20 +7,30 @@ import {
 
 export type TopLevelItemsWarning = { code: string; message: string };
 
-/**
- * One warning when the saved canvas shows more boxes than the ceiling. A box is a
- * node or a collapsed group. Returns nothing when the canvas is within the ceiling.
- */
-export function topLevelItemsWarning(workflow: {
+type CanvasShape = {
 	nodes: INode[];
 	connections: IConnections;
 	nodeGroups?: IWorkflowGroup[];
-}): TopLevelItemsWarning | undefined {
-	const summary = summarizeTopLevelItems({
+};
+
+const summarize = (workflow: CanvasShape) =>
+	summarizeTopLevelItems({
 		nodes: workflow.nodes,
 		nodeGroups: workflow.nodeGroups,
 		connectionsBySourceNode: workflow.connections,
 	});
+
+/** Boxes the canvas shows with every group collapsed: groups plus loose nodes. */
+export function topLevelBoxCount(workflow: CanvasShape): number {
+	return summarize(workflow).total;
+}
+
+/**
+ * One warning when the saved canvas shows more boxes than the ceiling. A box is a
+ * node or a collapsed group. Returns nothing when the canvas is within the ceiling.
+ */
+export function topLevelItemsWarning(workflow: CanvasShape): TopLevelItemsWarning | undefined {
+	const summary = summarize(workflow);
 
 	if (!summary.overCeiling) {
 		return undefined;

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -351,7 +351,10 @@ const outputSchema = {
 				reason: z.string(),
 			}),
 		)
-		.optional(),
+		.optional()
+		.describe(
+			'Existing groups this update made invalid and removed. Repair them before you report the workflow as done.',
+		),
 	settings: z
 		.record(z.string(), z.unknown())
 		.optional()

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -34,7 +34,7 @@ import {
 } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
 import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
-import { topLevelItemsWarning } from './top-level-items-warning';
+import { topLevelBoxCount, topLevelItemsWarning } from './top-level-items-warning';
 import {
 	buildUpdateVersionMetadata,
 	resolveVersionMetadata,
@@ -1360,9 +1360,15 @@ export const createUpdateWorkflowTool = (
 					: undefined;
 
 				if (ceilingWarning) {
-					const wasWideBefore = topLevelItemsWarning(existingWorkflow) !== undefined;
+					// The warning is pre-existing only when the canvas was already over the ceiling and
+					// this update did not add any box. When the update added boxes, the agent must
+					// group them, so the warning is a normal one.
+					const boxesBefore = topLevelBoxCount(existingWorkflow);
+					const boxesAfter = topLevelBoxCount(updatedWorkflow);
+					const wasOverCeilingBefore = topLevelItemsWarning(existingWorkflow) !== undefined;
+					const preExisting = wasOverCeilingBefore && boxesAfter <= boxesBefore;
 					validationWarnings.push(
-						wasWideBefore
+						preExisting
 							? {
 									...ceilingWarning,
 									message: `[pre-existing] ${ceilingWarning.message}`,

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -34,7 +34,7 @@ import {
 } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
 import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
-import { topLevelBoxCount, topLevelItemsWarning } from './top-level-items-warning';
+import { summarizeUngroupedNodeNames, topLevelItemsWarning } from './top-level-items-warning';
 import {
 	buildUpdateVersionMetadata,
 	resolveVersionMetadata,
@@ -1360,13 +1360,16 @@ export const createUpdateWorkflowTool = (
 					: undefined;
 
 				if (ceilingWarning) {
-					// The warning is pre-existing only when the canvas was already over the ceiling and
-					// this update did not add any box. When the update added boxes, the agent must
-					// group them, so the warning is a normal one.
-					const boxesBefore = topLevelBoxCount(existingWorkflow);
-					const boxesAfter = topLevelBoxCount(updatedWorkflow);
+					const preExistingUngroupedNodeNames = new Set(
+						summarizeUngroupedNodeNames(existingWorkflow),
+					);
+
+					const hasNewlyAddedUngroupedNodeNames = summarizeUngroupedNodeNames(updatedWorkflow).some(
+						(name) => !preExistingUngroupedNodeNames.has(name),
+					);
+
 					const wasOverCeilingBefore = topLevelItemsWarning(existingWorkflow) !== undefined;
-					const preExisting = wasOverCeilingBefore && boxesAfter <= boxesBefore;
+					const preExisting = wasOverCeilingBefore && !hasNewlyAddedUngroupedNodeNames;
 					validationWarnings.push(
 						preExisting
 							? {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -34,6 +34,7 @@ import {
 } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
 import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
+import { topLevelItemsWarning } from './top-level-items-warning';
 import {
 	buildUpdateVersionMetadata,
 	resolveVersionMetadata,
@@ -1347,6 +1348,26 @@ export const createUpdateWorkflowTool = (
 					skippedOperations,
 					result.groupOperations,
 				);
+
+				// Groups are dropped on save when the flag is off, so only warn when they can be kept.
+				// A canvas that was already this wide before the update is marked pre-existing,
+				// so the agent does not rework a layout it did not make.
+				const ceilingWarning = canvasGroupsEnabled
+					? topLevelItemsWarning(updatedWorkflow)
+					: undefined;
+
+				if (ceilingWarning) {
+					const wasWideBefore = topLevelItemsWarning(existingWorkflow) !== undefined;
+					validationWarnings.push(
+						wasWideBefore
+							? {
+									...ceilingWarning,
+									message: `[pre-existing] ${ceilingWarning.message}`,
+									preExisting: true,
+								}
+							: ceilingWarning,
+					);
+				}
 
 				const output: UpdateWorkflowOutput = {
 					workflowId: updatedWorkflow.id,


### PR DESCRIPTION
## Summary

Two changes for the MCP path, on top of #38235. The save never fails because of groups. That rule stays.

**A warning after the save.** `create_workflow_from_code` and `update_workflow` add a `TOP_LEVEL_ITEMS_OVER_CEILING` warning when the saved canvas shows more than 7 boxes with every group collapsed. The message names the loose nodes and asks the agent to group them or say why it cannot. On update, a canvas that was already over the ceiling before the update gets the warning marked `preExisting`, so the agent does not rework a layout it did not make. The count comes from `summarizeTopLevelItems` in `n8n-workflow`, the same function the AI Assistant uses. Only when canvas groups are enabled.

**Text the agent reads.** The MCP session instructions now say: the save never fails because of groups, so read its result, and when it reports `TOP_LEVEL_ITEMS_OVER_CEILING`, `skippedGroups` or `removedGroups`, repair the groups with `update_workflow` before you tell the user the workflow is done. The `skippedGroups` and `removedGroups` fields say the same in one sentence.

## How to test

1. Run n8n with `N8N_MCP_CANVAS_GROUPS_ENABLED=true`.
2. From an MCP client, create a workflow with 9 or more nodes and no groups.
3. Check the tool result has a `warnings` entry with code `TOP_LEVEL_ITEMS_OVER_CEILING`.
4. Update a workflow that already had 9 loose nodes. Check the warning is marked `preExisting`.
5. Unit tests: `pnpm test src/modules/mcp` in `packages/cli`.

Eval run with the warning only (suite `node-groups`, tier `mcp`, 3 iterations): https://github.com/n8n-io/n8n/actions/runs/34374056456 — 83/108 checks. In 2 of 3 builds over the ceiling the agent read the warning and explained the loose nodes. A second run with the instruction text is in progress: https://github.com/n8n-io/n8n/actions/runs/34466367183.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5802

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

