### PR TITLE
fix: Bump task-runner-launcher to 1.5.0

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -91,7 +91,7 @@ RUN uv pip install . && rm -rf /app/task-runner-python/src
 # ==============================================================================
 FROM alpine:3.22 AS launcher-downloader
 ARG TARGETPLATFORM
-ARG LAUNCHER_VERSION=1.4.7
+ARG LAUNCHER_VERSION=1.5.0
 
 RUN set -e; \
     case "$TARGETPLATFORM" in \

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -120,7 +120,7 @@ RUN uv pip install . && rm -rf /app/task-runner-python/src
 # ==============================================================================
 FROM debian:bookworm-slim AS launcher-downloader
 ARG TARGETPLATFORM
-ARG LAUNCHER_VERSION=1.4.7
+ARG LAUNCHER_VERSION=1.5.0
 
 RUN set -e; \
     apt-get update && apt-get install -y --no-install-recommends wget ca-certificates && \


### PR DESCRIPTION
## Summary

Bump `task-runner-launcher` from `1.4.7` to `1.5.0` in the Alpine and distroless runner images.

This release adds graceful runner shutdown, retries failed WebSocket connections, and makes broker readiness polling configurable.

Release: https://github.com/n8n-io/task-runner-launcher/releases/tag/1.5.0

## How to test

Built the `launcher-downloader` stage for these combinations:

- Alpine, linux/amd64
- Alpine, linux/arm64
- Distroless, linux/amd64
- Distroless, linux/arm64

Each build downloaded the matching `1.5.0` archive, verified its published SHA-256 checksum, and extracted it successfully.

## Related Linear tickets, Github issues, and Community forum posts

Upstream change: https://github.com/n8n-io/task-runner-launcher/pull/106

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs are not required for this version bump.
- [x] The relevant four-platform Docker build matrix passed.
- [x] A backport label is not required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

