### PR TITLE
docs(API): State the {resource}Id path param convention in Public API skill

### DIFF
--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -118,9 +118,15 @@ model; reuse only what applies. Decorators, all from `@n8n/decorators`:
 
 - `@ApiKeyScope` (what the API key is granted) and `@ProjectScope`/`@GlobalScope`
   (what the user may do) are independent. Use both when the model needs both.
-- `@ProjectScope` reads `req.params` as-is and does not remap `id` — name the path
-  param what the resolver expects (`workflowId`, `credentialId`, `projectId`,
-  `dataTableId`, …). A generic `id` often fails.
+- Name every path param `{resource}Id` (`workflowId`, `credentialId`, `projectId`,
+  `promotionConnectionId`, …) — never a generic `:id` / `{id}`. This is the Public
+  API's naming convention for every route, not only where `@ProjectScope` needs it:
+  it keeps the API self-documenting and gives typed SDK codegen a real argument
+  name instead of `id`. `@ProjectScope` also reads `req.params` as-is and does not
+  remap `id` — it resolves authorization by exact key name (`workflowId`,
+  `credentialId`, `projectId`, `dataTableId`, …), so a generic `id` on a
+  `@ProjectScope` route often fails outright; a `@GlobalScope` or unscoped route
+  won't fail the same way, but still follow the convention.
 - `@ApiKeyScope` takes a string, `{ anyOf: [...] }`, or `{ allOf: [...] }` — never
   a bare array. The scope must exist in the permissions registry
   (`API_KEY_RESOURCES` in `@n8n/permissions`); `scope-parity.test.ts` fails on an

--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -118,15 +118,15 @@ model; reuse only what applies. Decorators, all from `@n8n/decorators`:
 
 - `@ApiKeyScope` (what the API key is granted) and `@ProjectScope`/`@GlobalScope`
   (what the user may do) are independent. Use both when the model needs both.
-- Name every path param `{resource}Id` (`workflowId`, `credentialId`, `projectId`,
-  `promotionConnectionId`, …) — never a generic `:id` / `{id}`. This is the Public
-  API's naming convention for every route, not only where `@ProjectScope` needs it:
-  it keeps the API self-documenting and gives typed SDK codegen a real argument
-  name instead of `id`. `@ProjectScope` also reads `req.params` as-is and does not
-  remap `id` — it resolves authorization by exact key name (`workflowId`,
-  `credentialId`, `projectId`, `dataTableId`, …), so a generic `id` on a
-  `@ProjectScope` route often fails outright; a `@GlobalScope` or unscoped route
-  won't fail the same way, but still follow the convention.
+- Name every path param `{resource}Id` (e.g. `workflowId`, `credentialId`,
+  `projectId`, …) — never a generic `:id` / `{id}`. This is the Public API's
+  naming convention: it keeps the API self-documenting and gives typed SDK
+  codegen a real argument name instead of `id`. `@ProjectScope` also reads
+  `req.params` as-is and does not remap `id` — it resolves authorization by
+  exact key name (`workflowId`, `credentialId`, `projectId`, `dataTableId`,
+  …), so a generic `id` on a `@ProjectScope` route often fails outright; a
+  `@GlobalScope` or unscoped route won't fail the same way, but still follow
+  the convention.
 - `@ApiKeyScope` takes a string, `{ anyOf: [...] }`, or `{ allOf: [...] }` — never
   a bare array. The scope must exist in the permissions registry
   (`API_KEY_RESOURCES` in `@n8n/permissions`); `scope-parity.test.ts` fails on an


### PR DESCRIPTION
## Summary

New Public API endpoints are being added with a generic `:id` path parameter instead of a resource-named one (`workflowId`, `credentialId`, ...), most recently the promotion connection and provider routes (see #38288). The Public API skill only warned about this for `@ProjectScope`-gated routes, where a generic `id` can silently fail authorization resolution. Routes gated by `@GlobalScope`, or with no scope decorator, got no signal at all, so the convention wasn't being caught at authoring or review time for those routes.

This PR states the `{resource}Id` naming convention as a general rule for every Public API route in `.agents/skills/public-api/SKILL.md`, and keeps the `@ProjectScope` failure mode as supporting detail rather than the whole rule.

No code changes. `.claude/plugins/n8n/skills/public-api` is a symlink to the edited file, so it picks up the change automatically; `pnpm check:skill-links` passes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-304

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. <!-- this PR is the docs update -->
- [ ] Tests included. <!-- Docs-only change; no test surface. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

