### PR TITLE
chore: Remove unnecessary comment in DataTableAggregateService (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/data-table-aggregate.service.ts
+++ b/packages/cli/src/modules/data-table/data-table-aggregate.service.ts
@@ -26,9 +26,6 @@ export class DataTableAggregateService {
 			return await this.dataTableRepository.getManyAndCount(options);
 		}
 
-		// Membership alone isn't enough — a project role without dataTable:listProject
-		// (e.g. project:chatUser, or a custom role missing dataTable:read) grants no
-		// data table access, so it must not surface that project's tables here either.
 		const roles = await this.roleService.rolesWithScope('project', ['dataTable:listProject']);
 		let projectIds = await this.projectRelationRepository.getAccessibleProjectsByRoles(
 			user.id,


### PR DESCRIPTION
## Summary

- Remove the comment block flagged in [review feedback](https://github.com/n8n-io/n8n/pull/37676#discussion_r3972413243) on n8n-io/n8n#37676.
- The reviewer questioned the need for the comment after the PR merged.

## How to test

- Not applicable. Comment-only change, no behavior change.

## Related Linear tickets, Github issues, and Community forum posts

- Follow-up to n8n-io/n8n#37676

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

