### PR TITLE
feat(Microsoft Teams Node): Add the app-only path for Online Meeting operations

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.test.ts
@@ -1,0 +1,20 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+// Runs the real transport: Graph's access-policy 403 must reach the item as the
+// actionable message, not the sanitised generic one.
+describe('Test MicrosoftTeamsV2, onlineMeeting => create (Service Principal, no access policy)', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.post('/v1.0/users/11111111-2222-3333-4444-555555555555/onlineMeetings')
+		.reply(403, {
+			error: { code: 'Forbidden', message: 'No application access policy found for this app' },
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['create.servicePrincipal.forbidden.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.workflow.json
@@ -1,0 +1,91 @@
+{
+	"name": "onlineMeeting create (Service Principal, no access policy)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "onlineMeeting",
+				"operation": "create",
+				"subject": "Standup",
+				"startDateTime": "2026-09-11T09:00:00Z",
+				"endDateTime": "2026-09-11T09:15:00Z",
+				"organizerId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "11111111-2222-3333-4444-555555555555"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "spCredId",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			},
+			"onError": "continueRegularOutput"
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"error": "Microsoft Graph refused the app-only meeting request"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0a5f7c1e-6c5f-4a1b-9c1e-1f2e3d4c5b6a",
+	"id": "onlineMeetingCreateSp403",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.test.ts
@@ -1,0 +1,36 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+// App-only create lands under the organizer, never under /me. The harness no-ops
+// preAuthentication and takes the Bearer from the inline fixture, so nock only Graph.
+describe('Test MicrosoftTeamsV2, onlineMeeting => create (Service Principal)', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.post('/v1.0/users/11111111-2222-3333-4444-555555555555/onlineMeetings', {
+			subject: 'Standup',
+			startDateTime: '2026-09-11T09:00:00Z',
+			endDateTime: '2026-09-11T09:15:00Z',
+		})
+		.reply(201, {
+			id: 'MSpTdGFuZHVwLWFwcC1vbmx5',
+			startDateTime: '2026-09-11T09:00:00Z',
+			endDateTime: '2026-09-11T09:15:00Z',
+			joinWebUrl: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YXBwb25seQ%40thread.v2/0',
+			subject: 'Standup',
+			participants: {
+				organizer: {
+					upn: 'alex@contoso.com',
+					identity: {
+						user: { id: '11111111-2222-3333-4444-555555555555', displayName: 'Alex Wilber' },
+					},
+				},
+			},
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['create.servicePrincipal.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.workflow.json
@@ -1,0 +1,105 @@
+{
+	"name": "onlineMeeting create (Service Principal)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "onlineMeeting",
+				"operation": "create",
+				"subject": "Standup",
+				"startDateTime": "2026-09-11T09:00:00Z",
+				"endDateTime": "2026-09-11T09:15:00Z",
+				"organizerId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "11111111-2222-3333-4444-555555555555"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "spCredId",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MSpTdGFuZHVwLWFwcC1vbmx5",
+					"startDateTime": "2026-09-11T09:00:00Z",
+					"endDateTime": "2026-09-11T09:15:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_YXBwb25seQ%40thread.v2/0",
+					"subject": "Standup",
+					"participants": {
+						"organizer": {
+							"upn": "alex@contoso.com",
+							"identity": {
+								"user": {
+									"id": "11111111-2222-3333-4444-555555555555",
+									"displayName": "Alex Wilber"
+								}
+							}
+						}
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0a5f7c1e-6c5f-4a1b-9c1e-1f2e3d4c5b6a",
+	"id": "onlineMeetingCreateSp01",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.test.ts
@@ -1,0 +1,30 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+const joinWebUrl =
+	'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d';
+
+describe('Test MicrosoftTeamsV2, onlineMeeting => get by join URL (Service Principal)', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.get('/v1.0/users/11111111-2222-3333-4444-555555555555/onlineMeetings')
+		.query({ $filter: `JoinWebUrl eq '${joinWebUrl}'` })
+		.reply(200, {
+			value: [
+				{
+					id: 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+					startDateTime: '2026-09-10T10:00:00Z',
+					endDateTime: '2026-09-10T10:30:00Z',
+					joinWebUrl,
+					subject: 'Quarterly Sync',
+				},
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['get.servicePrincipal.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.workflow.json
@@ -1,0 +1,96 @@
+{
+	"name": "onlineMeeting get by join URL (Service Principal)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "onlineMeeting",
+				"operation": "get",
+				"meetingId": {
+					"__rl": true,
+					"mode": "url",
+					"value": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d"
+				},
+				"organizerId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "11111111-2222-3333-4444-555555555555"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "spCredId",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi",
+					"startDateTime": "2026-09-10T10:00:00Z",
+					"endDateTime": "2026-09-10T10:30:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d",
+					"subject": "Quarterly Sync"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0a5f7c1e-6c5f-4a1b-9c1e-1f2e3d4c5b6a",
+	"id": "onlineMeetingGetSp01",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
@@ -1,0 +1,301 @@
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import type { IExecuteFunctions, NodeParameterValueType } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+
+import { createExecuteContext, meetingHeaders, setParams } from '../helpers';
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import { SERVICE_PRINCIPAL_AUTH } from '../../../../v2/transport';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const ORGANIZER = '11111111-2222-3333-4444-555555555555';
+const MEETING = 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi';
+const JOIN_URL = 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0';
+const MEETINGS = `/v1.0/users/${ORGANIZER}/onlineMeetings`;
+
+const byId = { meetingId: { __rl: true, mode: 'id', value: MEETING } };
+const byUrl = { meetingId: { __rl: true, mode: 'url', value: JOIN_URL } };
+const createParams = {
+	subject: 'Sync',
+	startDateTime: '2026-09-10T10:00:00Z',
+	endDateTime: '2026-09-10T10:30:00Z',
+	options: {},
+};
+
+describe('Microsoft Teams V2 — onlineMeeting under the Service Principal credential', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = createExecuteContext();
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: MEETING });
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const run = async (operation: string, params: Record<string, unknown>) => {
+		setParams(ctx, {
+			authentication: SERVICE_PRINCIPAL_AUTH,
+			resource: 'onlineMeeting',
+			operation,
+			organizerId: ORGANIZER,
+			...params,
+		});
+		return await node.execute.call(ctx);
+	};
+
+	it.each([
+		['create', createParams, 'POST', MEETINGS],
+		['createOrGet', { externalId: 'order-4711', options: {} }, 'POST', `${MEETINGS}/createOrGet`],
+		['get', byId, 'GET', `${MEETINGS}/${MEETING}`],
+		['deleteMeeting', byId, 'DELETE', `${MEETINGS}/${MEETING}`],
+		[
+			'update',
+			{ ...byId, updateFields: { subject: 'Renamed' } },
+			'PATCH',
+			`${MEETINGS}/${MEETING}`,
+		],
+	])(
+		"%s addresses the organizer's meetings instead of /me",
+		async (operation, params, method, path) => {
+			await run(operation, params);
+
+			expect(transport.microsoftApiRequest).toHaveBeenCalledTimes(1);
+			expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+				method,
+				path,
+				expect.anything(),
+				expect.anything(),
+				undefined,
+				meetingHeaders,
+			);
+		},
+	);
+
+	it("get by join URL filters the organizer's meetings", async () => {
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ value: [{ id: MEETING }] });
+
+		await run('get', byUrl);
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'GET',
+			MEETINGS,
+			{},
+			{ $filter: `JoinWebUrl eq '${JOIN_URL}'` },
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it.each([
+		['deleteMeeting', {}, 'DELETE'],
+		['update', { updateFields: { subject: 'Renamed' } }, 'PATCH'],
+	])('%s resolves a join URL against the organizer first', async (operation, params, method) => {
+		(transport.microsoftApiRequest as Mock)
+			.mockResolvedValueOnce({ value: [{ id: MEETING }] })
+			.mockResolvedValueOnce({});
+
+		await run(operation, { ...byUrl, ...params });
+
+		const calls = (transport.microsoftApiRequest as Mock).mock.calls.map((call) => [
+			call[0],
+			call[1],
+		]);
+		expect(calls).toEqual([
+			['GET', MEETINGS],
+			[method, `${MEETINGS}/${MEETING}`],
+		]);
+	});
+
+	describe('a user principal name as the organizer', () => {
+		it('is resolved to the object ID before the meeting request', async () => {
+			(transport.microsoftApiRequest as Mock)
+				.mockResolvedValueOnce({ id: ORGANIZER })
+				.mockResolvedValueOnce({ id: MEETING });
+
+			await run('get', { ...byId, organizerId: 'alex@contoso.com' });
+
+			expect(transport.microsoftApiRequest).toHaveBeenNthCalledWith(
+				1,
+				'GET',
+				'/v1.0/users/alex@contoso.com',
+				{},
+				{ $select: 'id' },
+			);
+			expect(transport.microsoftApiRequest).toHaveBeenNthCalledWith(
+				2,
+				'GET',
+				`${MEETINGS}/${MEETING}`,
+				expect.anything(),
+				expect.anything(),
+				undefined,
+				meetingHeaders,
+			);
+		});
+
+		it('reports an unknown principal name as an organizer problem', async () => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Not Found' }, { httpCode: '404' }),
+			);
+
+			await expect(
+				run('create', { ...createParams, organizerId: 'nobody@contoso.com' }),
+			).rejects.toThrow('Organizer not found');
+			expect(transport.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		});
+
+		it('names User.Read.All when the lookup is forbidden', async () => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' }),
+			);
+
+			const thrown: unknown = await run('create', {
+				...createParams,
+				organizerId: 'alex@contoso.com',
+			}).catch((error: unknown) => error);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect((thrown as NodeApiError).message).toBe(
+				'Resolving the organizer needs the User.Read.All application permission',
+			);
+			expect((thrown as NodeApiError).description).toContain('object ID');
+		});
+	});
+
+	it('resolves the organizer per item and isolates a blank one under continueOnFail', async () => {
+		const organizers = [ORGANIZER, '', '22222222-3333-4444-5555-666666666666'];
+		ctx.getInputData.mockReturnValue(organizers.map(() => ({ json: {} })));
+		ctx.continueOnFail.mockReturnValue(true);
+		const params: Record<string, unknown> = {
+			authentication: SERVICE_PRINCIPAL_AUTH,
+			resource: 'onlineMeeting',
+			operation: 'create',
+			...createParams,
+		};
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, itemIndex?: number, fallback?: unknown): NodeParameterValueType => {
+				if (name === 'organizerId') return organizers[itemIndex ?? 0];
+				return (name in params ? params[name] : fallback) as NodeParameterValueType;
+			},
+		);
+
+		const [output] = await node.execute.call(ctx);
+
+		expect(output.map((item) => item.json)).toEqual([
+			{ id: MEETING },
+			{ error: 'The Organizer is required with the Service Principal credential' },
+			{ id: MEETING },
+		]);
+		const paths = (transport.microsoftApiRequest as Mock).mock.calls.map((call) => call[1]);
+		expect(paths).toEqual([MEETINGS, `/v1.0/users/${organizers[2]}/onlineMeetings`]);
+	});
+
+	it.each([
+		['missing', undefined],
+		['blank', '   '],
+	])('rejects a %s organizer before any request', async (_label, organizerId) => {
+		const thrown: unknown = await run('create', { ...createParams, organizerId }).catch(
+			(error: unknown) => error,
+		);
+
+		expect(thrown).toBeInstanceOf(NodeOperationError);
+		expect((thrown as NodeOperationError).message).toBe(
+			'The Organizer is required with the Service Principal credential',
+		);
+		expect((thrown as NodeOperationError).context.itemIndex).toBe(0);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects a separator-bearing organizer before any request', async () => {
+		await expect(run('get', { ...byId, organizerId: 'x/../../me' })).rejects.toThrow(
+			'The ID is not valid',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it.each(['create', 'get'])(
+		'%s names the access policy setup when Graph answers 403',
+		async (operation) => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' }),
+			);
+
+			const thrown: unknown = await run(operation, { ...createParams, ...byId }).catch(
+				(error: unknown) => error,
+			);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect((thrown as NodeApiError).message).toBe(
+				'Microsoft Graph refused the app-only meeting request',
+			);
+			expect((thrown as NodeApiError).httpCode).toBe('403');
+			const description = (thrown as NodeApiError).description ?? '';
+			expect(description).toContain('OnlineMeetings.ReadWrite.All');
+			expect(description).toContain('New-CsApplicationAccessPolicy');
+			expect(description).toContain('Grant-CsApplicationAccessPolicy');
+			expect(description).toContain('30 minutes');
+		},
+	);
+
+	it.each([
+		['create', createParams],
+		['get by join URL', byUrl],
+	])(
+		'%s reports a 404 on the meetings collection as an unknown organizer',
+		async (label, params) => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Not Found' }, { httpCode: '404' }),
+			);
+
+			await expect(run(label === 'create' ? 'create' : 'get', params)).rejects.toThrow(
+				'Organizer not found',
+			);
+		},
+	);
+
+	it('keeps the not-found rewrite for a 404 on a meeting, naming both parameters', async () => {
+		(transport.microsoftApiRequest as Mock).mockRejectedValue(
+			new NodeApiError(ctx.getNode(), { message: 'Not Found' }, { httpCode: '404' }),
+		);
+
+		const thrown: unknown = await run('deleteMeeting', byId).catch((error: unknown) => error);
+
+		expect(thrown).toBeInstanceOf(NodeOperationError);
+		expect((thrown as NodeOperationError).message).toBe(
+			"The meeting you are trying to delete doesn't exist",
+		);
+		expect((thrown as NodeOperationError).description).toBe(
+			"Check that the 'Meeting' and 'Organizer' parameters are correctly set",
+		);
+	});
+
+	it('leaves a delegated 403 unchanged', async () => {
+		(transport.microsoftApiRequest as Mock).mockRejectedValue(
+			new NodeApiError(
+				ctx.getNode(),
+				{ message: 'Insufficient privileges to complete the operation' },
+				{ httpCode: '403', message: 'Insufficient privileges to complete the operation' },
+			),
+		);
+		setParams(ctx, { resource: 'onlineMeeting', operation: 'get', ...byId });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Insufficient privileges to complete the operation',
+		);
+		const calledPath = (transport.microsoftApiRequest as Mock).mock.calls[0][1] as string;
+		expect(calledPath).toBe(`/v1.0/me/onlineMeetings/${MEETING}`);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -94,31 +94,6 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		},
 	);
 
-	it.each([
-		['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }],
-		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
-		['createOrGet', { externalId: 'order-4711', options: {} }],
-		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
-		[
-			'update',
-			{
-				meetingId: { __rl: true, mode: 'id', value: 'meeting-id' },
-				updateFields: { subject: 'Renamed' },
-			},
-		],
-	])(
-		'onlineMeeting:%s throws a static error and issues no request under SP',
-		async (op, params) => {
-			selectSp({ resource: 'onlineMeeting', operation: op, ...params });
-
-			await expect(node.execute.call(ctx)).rejects.toThrow(
-				'Online meetings are not available with the Service Principal credential',
-			);
-			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
-			expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
-		},
-	);
-
 	it('chatMessage:sendAndWait throws under SP and NEVER calls putExecutionToWait', async () => {
 		selectSp({
 			resource: 'chatMessage',

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -32,7 +32,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
-	describe.each(['chatMessage', 'chatMember', 'onlineMeeting'])(
+	describe.each(['chatMessage', 'chatMember'])(
 		'%s - hidden under SP via the slash-prefixed field-level key',
 		(resource) => {
 			it('operation selector carries hide["/authentication"] = [SP]', () => {
@@ -66,6 +66,58 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 			});
 		},
 	);
+
+	describe('onlineMeeting — available under SP with an organizer picker', () => {
+		const fields = actionProps.filter((p) =>
+			p.displayOptions?.show?.resource?.includes('onlineMeeting'),
+		);
+
+		it('operation selector is not hidden under SP', () => {
+			const op = fields.find((p) => p.name === 'operation');
+			expect(op).toBeDefined();
+			expect(isSpHidden(op)).toBe(false);
+		});
+
+		it('no operation field is hidden under SP', () => {
+			const gated = fields.filter((p) => p.type !== 'notice' && p.name !== 'operation');
+			expect(gated.length).toBeGreaterThan(0);
+			for (const field of gated) {
+				expect(isSpHidden(field)).toBe(false);
+			}
+		});
+
+		it('an SP-shown required organizer picker exists with list and By-ID modes', () => {
+			const organizer = fields.find((p) => p.name === 'organizerId');
+			expect(organizer).toBeDefined();
+			expect(organizer?.displayOptions).toEqual({
+				show: { resource: ['onlineMeeting'], '/authentication': [SERVICE_PRINCIPAL_AUTH] },
+			});
+			expect(organizer?.required).toBe(true);
+			expect(organizer?.modes?.map((m) => m.name)).toEqual(['list', 'id']);
+			// no extractValue: an expression that resolves to a UPN must reach the node
+			expect(organizer?.modes?.every((m) => m.extractValue === undefined)).toBe(true);
+		});
+
+		it('shows an SP notice for the resource', () => {
+			const notice = fields.find(
+				(p) =>
+					p.type === 'notice' &&
+					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+			);
+			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+		});
+
+		it('the Service Principal authentication option no longer lists online meetings as unavailable', () => {
+			const authentication = actionProps.find((p) => p.name === 'authentication');
+			const spOption = (authentication?.options ?? []).find(
+				(option) => 'value' in option && option.value === SERVICE_PRINCIPAL_AUTH,
+			);
+			expect(spOption).toBeDefined();
+			expect(
+				'description' in (spOption ?? {}) ? (spOption as { description?: string }).description : '',
+			).not.toContain('online meetings are unavailable');
+		});
+	});
 
 	describe('channelMessage — only the sending operations are hidden under SP', () => {
 		const fieldsFor = (operation: string) =>

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
@@ -3,13 +3,7 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { applyMeetingSettings, withMeetingSettings } from './meetingSettings';
-import {
-	meetingRequest,
-	requiredText,
-	throwIfOnlineMeetingUnsupported,
-	toGraphUtc,
-} from './shared';
-import { SP_HIDE } from '../../transport';
+import { meetingRequest, meetingsPath, requiredText, toGraphUtc } from './shared';
 
 const properties: INodeProperties[] = [
 	{
@@ -61,17 +55,12 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['create'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/application-post-onlinemeetings?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const options = this.getNodeParameter('options', i);
 	const body: IDataObject = {
 		subject: requiredText.call(this, 'subject', i, 'Subject'),
@@ -83,5 +72,5 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		body.joinMeetingIdSettings = { isPasscodeRequired: options.passcodeRequired };
 	}
 
-	return await meetingRequest.call(this, 'POST', '/v1.0/me/onlineMeetings', body);
+	return await meetingRequest.call(this, 'POST', await meetingsPath.call(this, i), body);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
@@ -7,14 +7,7 @@ import {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
-import {
-	meetingRequest,
-	optionalText,
-	requiredText,
-	throwIfOnlineMeetingUnsupported,
-	toGraphUtc,
-} from './shared';
-import { SP_HIDE } from '../../transport';
+import { meetingRequest, meetingsPath, optionalText, requiredText, toGraphUtc } from './shared';
 
 const properties: INodeProperties[] = [
 	{
@@ -25,7 +18,7 @@ const properties: INodeProperties[] = [
 		default: '',
 		placeholder: 'e.g. order-4711-kickoff',
 		description:
-			'Your own ID for the meeting. Running the node again with the same ID returns the existing meeting instead of creating another one.',
+			'Your own ID for the meeting. Running the node again with the same ID for the same organizer returns the existing meeting instead of creating another one.',
 	},
 	{
 		displayName: 'Options',
@@ -66,17 +59,12 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['createOrGet'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-createorget?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const externalId = requiredText.call(this, 'externalId', i, 'External ID');
 	const options = this.getNodeParameter('options', i);
 	if (options.endDateTime && !options.startDateTime) {
@@ -98,5 +86,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		body.endDateTime = toGraphUtc.call(this, options.endDateTime, 'End Time');
 	}
 
-	return await meetingRequest.call(this, 'POST', '/v1.0/me/onlineMeetings/createOrGet', body);
+	return await meetingRequest.call(
+		this,
+		'POST',
+		await meetingsPath.call(this, i, ['/createOrGet']),
+		body,
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
@@ -3,9 +3,9 @@ import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { resolveMeetingId } from './meetingLocator';
-import { MEETING_HINT, meetingRequest, throwIfOnlineMeetingUnsupported } from './shared';
+import { meetingHint, meetingRequest, meetingsPath } from './shared';
 import { meetingRLC } from '../../descriptions';
-import { buildTeamsPath, rewriteNotFound, SP_HIDE } from '../../transport';
+import { rewriteNotFound } from '../../transport';
 
 const properties: INodeProperties[] = [meetingRLC];
 
@@ -14,19 +14,14 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['deleteMeeting'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-delete?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const meetingId = await resolveMeetingId.call(this, i);
-	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: meetingId }]);
+	const endpoint = await meetingsPath.call(this, i, ['/', { id: meetingId }]);
 
 	try {
 		await meetingRequest.call(this, 'DELETE', endpoint);
@@ -36,7 +31,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			error,
 			"The meeting you are trying to delete doesn't exist",
-			MEETING_HINT,
+			meetingHint.call(this),
 		);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/get.operation.ts
@@ -3,9 +3,9 @@ import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { fetchMeetingByJoinUrl, readMeetingLocator } from './meetingLocator';
-import { MEETING_HINT, meetingRequest, throwIfOnlineMeetingUnsupported } from './shared';
+import { meetingHint, meetingRequest, meetingsPath } from './shared';
 import { meetingRLC } from '../../descriptions';
-import { buildTeamsPath, rewriteNotFound, SP_HIDE } from '../../transport';
+import { rewriteNotFound } from '../../transport';
 
 const properties: INodeProperties[] = [meetingRLC];
 
@@ -14,23 +14,18 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['get'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const { mode, value } = readMeetingLocator.call(this, i);
 	if (mode === 'url') {
-		return await fetchMeetingByJoinUrl.call(this, value);
+		return await fetchMeetingByJoinUrl.call(this, i, value);
 	}
 
-	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: value }]);
+	const endpoint = await meetingsPath.call(this, i, ['/', { id: value }]);
 	try {
 		return await meetingRequest.call(this, 'GET', endpoint);
 	} catch (error) {
@@ -38,7 +33,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			error,
 			"The meeting you are trying to get doesn't exist",
-			MEETING_HINT,
+			meetingHint.call(this),
 		);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -4,25 +4,27 @@ import * as create from './create.operation';
 import * as createOrGet from './createOrGet.operation';
 import * as deleteMeeting from './deleteMeeting.operation';
 import * as get from './get.operation';
-import { SERVICE_PRINCIPAL_UNSUPPORTED } from './shared';
 import * as update from './update.operation';
-import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
+import { userRLC } from '../../descriptions';
+import { SERVICE_PRINCIPAL_AUTH } from '../../transport';
 
 export { create, createOrGet, deleteMeeting, get, update };
 
-export const description: INodeProperties[] = [
-	{
-		displayName: `Online meetings are not available with the Service Principal credential. ${SERVICE_PRINCIPAL_UNSUPPORTED}`,
-		name: 'onlineMeetingServicePrincipalNotice',
-		type: 'notice',
-		default: '',
-		displayOptions: {
-			show: {
-				resource: ['onlineMeeting'],
-				authentication: [SERVICE_PRINCIPAL_AUTH],
-			},
+const organizerRLC: INodeProperties = {
+	...userRLC,
+	displayName: 'Organizer',
+	name: 'organizerId',
+	description:
+		'The user whose meetings the app creates and manages. From List and user principal names need the User.Read.All application permission; an object ID needs none.',
+	displayOptions: {
+		show: {
+			resource: ['onlineMeeting'],
+			'/authentication': [SERVICE_PRINCIPAL_AUTH],
 		},
 	},
+};
+
+export const description: INodeProperties[] = [
 	{
 		displayName: 'Operation',
 		name: 'operation',
@@ -31,9 +33,6 @@ export const description: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['onlineMeeting'],
-			},
-			hide: {
-				...SP_HIDE,
 			},
 		},
 		options: [
@@ -71,6 +70,20 @@ export const description: INodeProperties[] = [
 		],
 		default: 'create',
 	},
+	{
+		displayName:
+			'With the Service Principal credential, online meetings need the OnlineMeetings.ReadWrite.All application permission (Read.All is enough for Get) and a Teams application access policy that grants this app access to the organizer\'s meetings. <a href="https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal/#allow-app-only-online-meetings" target="_blank">Learn more</a>.',
+		name: 'onlineMeetingServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['onlineMeeting'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+	},
+	organizerRLC,
 
 	...create.description,
 	...createOrGet.description,

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
@@ -2,7 +2,7 @@ import { type IDataObject, type IExecuteFunctions, NodeOperationError } from 'n8
 
 import { odataStringLiteral } from '@utils/microsoft/odata';
 
-import { meetingRequest } from './shared';
+import { meetingRequest, meetingsPath } from './shared';
 
 const isLocator = (value: unknown): value is { mode: unknown; value: unknown } =>
 	typeof value === 'object' && value !== null && 'mode' in value && 'value' in value;
@@ -21,6 +21,7 @@ export function readMeetingLocator(
 
 export async function fetchMeetingByJoinUrl(
 	this: IExecuteFunctions,
+	i: number,
 	joinWebUrl: string,
 ): Promise<IDataObject> {
 	if (!joinWebUrl) {
@@ -31,7 +32,7 @@ export async function fetchMeetingByJoinUrl(
 	const response = await meetingRequest.call(
 		this,
 		'GET',
-		'/v1.0/me/onlineMeetings',
+		await meetingsPath.call(this, i),
 		{},
 		{
 			$filter: `JoinWebUrl eq ${odataStringLiteral(joinWebUrl)}`,
@@ -49,6 +50,6 @@ export async function fetchMeetingByJoinUrl(
 export async function resolveMeetingId(this: IExecuteFunctions, i: number): Promise<string> {
 	const { mode, value } = readMeetingLocator.call(this, i);
 	if (mode !== 'url') return value;
-	const meeting = await fetchMeetingByJoinUrl.call(this, value);
+	const meeting = await fetchMeetingByJoinUrl.call(this, i, value);
 	return asText(meeting.id);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/shared.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/shared.ts
@@ -1,26 +1,92 @@
 import { DateTime } from 'luxon';
 import type { IDataObject, IExecuteFunctions, IHttpRequestMethods } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import {
+	buildTeamsPath,
 	getTeamsCredentialType,
 	microsoftApiRequest,
+	type MicrosoftGraphPathSegment,
+	rewriteForbiddenUnderSp,
 	SERVICE_PRINCIPAL_AUTH,
 } from '../../transport';
 
-export const MEETING_HINT = "Check that the 'Meeting' parameter is correctly set";
+const ACCESS_POLICY_SETUP =
+	'Grant the app registration the OnlineMeetings.ReadWrite.All application permission (OnlineMeetings.Read.All is enough for Get) with admin consent, and create a Teams application access policy that includes this app and grant it to the organizer (New-CsApplicationAccessPolicy, then Grant-CsApplicationAccessPolicy). Policy changes can take up to 30 minutes to apply.';
 
-export const SERVICE_PRINCIPAL_UNSUPPORTED =
-	'Online meeting operations run on the signed-in user. Use an OAuth2 credential instead.';
+const ORGANIZER_HINT = "Check that the 'Organizer' parameter is a user in the tenant";
 
-export function throwIfOnlineMeetingUnsupported(this: IExecuteFunctions): void {
-	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+const GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+
+function isServicePrincipal(this: IExecuteFunctions): boolean {
+	return getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
+}
+
+export function meetingHint(this: IExecuteFunctions): string {
+	return isServicePrincipal.call(this)
+		? "Check that the 'Meeting' and 'Organizer' parameters are correctly set"
+		: "Check that the 'Meeting' parameter is correctly set";
+}
+
+// Graph addresses app-only meetings by the organizer's object ID, not the principal name.
+async function resolveOrganizer(this: IExecuteFunctions, i: number): Promise<string> {
+	const raw = this.getNodeParameter('organizerId', i, '', { extractValue: true });
+	const organizer = typeof raw === 'string' ? raw.trim() : '';
+	if (!organizer) {
 		throw new NodeOperationError(
 			this.getNode(),
-			'Online meetings are not available with the Service Principal credential',
-			{ description: SERVICE_PRINCIPAL_UNSUPPORTED },
+			'The Organizer is required with the Service Principal credential',
+			{
+				description:
+					'App-only Microsoft Graph has no signed-in user. Select the user whose meetings the node should act on.',
+				itemIndex: i,
+			},
 		);
 	}
+	if (GUID.test(organizer)) return organizer;
+
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/users/', { id: organizer }]);
+	let user: IDataObject;
+	try {
+		user = (await microsoftApiRequest.call(
+			this,
+			'GET',
+			endpoint,
+			{},
+			{ $select: 'id' },
+		)) as IDataObject;
+	} catch (error) {
+		if (error instanceof NodeApiError && error.httpCode === '404') {
+			throw new NodeOperationError(this.getNode(), 'Organizer not found', {
+				description: ORGANIZER_HINT,
+				itemIndex: i,
+			});
+		}
+		throw rewriteForbiddenUnderSp.call(
+			this,
+			error,
+			'Resolving the organizer needs the User.Read.All application permission',
+			"Grant User.Read.All to the app registration with admin consent, or enter the organizer's object ID instead.",
+		);
+	}
+	if (typeof user.id !== 'string' || user.id === '') {
+		throw new NodeOperationError(this.getNode(), 'Organizer not found', {
+			description: ORGANIZER_HINT,
+			itemIndex: i,
+		});
+	}
+	return user.id;
+}
+
+export async function meetingsPath(
+	this: IExecuteFunctions,
+	i: number,
+	segments: MicrosoftGraphPathSegment[] = [],
+): Promise<string> {
+	const root: MicrosoftGraphPathSegment[] = isServicePrincipal.call(this)
+		? ['/v1.0/users/', { id: await resolveOrganizer.call(this, i) }, '/onlineMeetings']
+		: ['/v1.0/me/onlineMeetings'];
+	return buildTeamsPath.call(this, [...root, ...segments]);
 }
 
 export function optionalText(this: IExecuteFunctions, value: unknown, label: string) {
@@ -56,6 +122,27 @@ export function toGraphUtc(this: IExecuteFunctions, value: unknown, label: strin
 	return parsed.toUTC().toISO({ suppressMilliseconds: true });
 }
 
+// A 404 on the meetings collection (POST, or the join-URL search) can only be the organizer.
+function rewriteAppOnlyError(
+	this: IExecuteFunctions,
+	error: unknown,
+	method: IHttpRequestMethods,
+	endpoint: string,
+): unknown {
+	if (!isServicePrincipal.call(this) || !(error instanceof NodeApiError)) return error;
+	if (error.httpCode === '404' && (method === 'POST' || endpoint.endsWith('/onlineMeetings'))) {
+		return new NodeOperationError(this.getNode(), 'Organizer not found', {
+			description: ORGANIZER_HINT,
+		});
+	}
+	return rewriteForbiddenUnderSp.call(
+		this,
+		error,
+		'Microsoft Graph refused the app-only meeting request',
+		ACCESS_POLICY_SETUP,
+	);
+}
+
 export async function meetingRequest(
 	this: IExecuteFunctions,
 	method: IHttpRequestMethods,
@@ -63,7 +150,11 @@ export async function meetingRequest(
 	body: IDataObject = {},
 	qs: IDataObject = {},
 ) {
-	return await microsoftApiRequest.call(this, method, endpoint, body, qs, undefined, {
-		Prefer: 'include-unknown-enum-members',
-	});
+	try {
+		return await microsoftApiRequest.call(this, method, endpoint, body, qs, undefined, {
+			Prefer: 'include-unknown-enum-members',
+		});
+	} catch (error) {
+		throw rewriteAppOnlyError.call(this, error, method, endpoint);
+	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/update.operation.ts
@@ -9,15 +9,9 @@ import { updateDisplayOptions } from '@utils/utilities';
 
 import { resolveMeetingId } from './meetingLocator';
 import { applyMeetingSettings, withMeetingSettings } from './meetingSettings';
-import {
-	MEETING_HINT,
-	meetingRequest,
-	optionalText,
-	throwIfOnlineMeetingUnsupported,
-	toGraphUtc,
-} from './shared';
+import { meetingHint, meetingRequest, meetingsPath, optionalText, toGraphUtc } from './shared';
 import { meetingRLC } from '../../descriptions';
-import { buildTeamsPath, rewriteNotFound, SP_HIDE } from '../../transport';
+import { rewriteNotFound } from '../../transport';
 
 const properties: INodeProperties[] = [
 	meetingRLC,
@@ -60,17 +54,12 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['update'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-update?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const updateFields = this.getNodeParameter('updateFields', i);
 
 	const hasStart = Boolean(updateFields.startDateTime);
@@ -103,7 +92,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	}
 
 	const meetingId = await resolveMeetingId.call(this, i);
-	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: meetingId }]);
+	const endpoint = await meetingsPath.call(this, i, ['/', { id: meetingId }]);
 
 	try {
 		return await meetingRequest.call(this, 'PATCH', endpoint, body);
@@ -112,7 +101,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			error,
 			"The meeting you are trying to update doesn't exist",
-			MEETING_HINT,
+			meetingHint.call(this),
 		);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
@@ -76,7 +76,7 @@ export const versionDescription: INodeTypeDescription = {
 					name: 'Service Principal (App-Only)',
 					value: SERVICE_PRINCIPAL_AUTH,
 					description:
-						'App-only access via a Microsoft Entra app registration. App-only Graph cannot act as a signed-in user, so chat actions, chat triggers, and online meetings are unavailable. Grant the relevant application permissions (e.g. Team.ReadBasic.All, Channel.ReadBasic.All, Tasks.ReadWrite.All) and admin consent on the credential.',
+						'App-only access via a Microsoft Entra app registration. App-only Graph cannot act as a signed-in user, so chat actions and chat triggers are unavailable. Online meetings act on the user chosen under "Organizer". Grant the relevant application permissions (e.g. Team.ReadBasic.All, Channel.ReadBasic.All, Tasks.ReadWrite.All, OnlineMeetings.ReadWrite.All, User.Read.All) and admin consent on the credential.',
 				},
 			],
 			default: 'microsoftTeamsOAuth2Api',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
@@ -14,6 +14,7 @@ import {
 	joinedTeamsEndpoint,
 	microsoftApiRequest,
 	microsoftApiRequestAllItems,
+	rewriteForbiddenUnderSp,
 	SERVICE_PRINCIPAL_AUTH,
 } from '../transport';
 
@@ -133,34 +134,31 @@ export async function getUsers(
 	// ConsistencyLevel is sent on every call: directory paging drops custom headers on
 	// nextLink requests, so the token branch needs it too or Graph rejects the $search.
 	const headers: IDataObject = { ConsistencyLevel: 'eventual' };
+	const qs: IDataObject = paginationToken ? {} : { $select: 'id,displayName,userPrincipalName' };
+	if (!paginationToken && filter) {
+		// `$search` escaping is NOT `$filter`'s quote-doubling: backslash-escape `\`
+		// first, then `"`, and the OR operator is uppercase and outside the quotes.
+		const escaped = filter.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+		qs.$search = `"displayName:${escaped}" OR "userPrincipalName:${escaped}"`;
+	}
 	let response: IDataObject;
-	if (paginationToken) {
+	try {
 		response = (await microsoftApiRequest.call(
 			this,
 			'GET',
-			'',
+			paginationToken ? '' : '/v1.0/users',
 			{},
-			{},
+			qs,
 			paginationToken,
 			headers,
 		)) as IDataObject;
-	} else {
-		const qs: IDataObject = { $select: 'id,displayName,userPrincipalName' };
-		if (filter) {
-			// `$search` escaping is NOT `$filter`'s quote-doubling: backslash-escape `\`
-			// first, then `"`, and the OR operator is uppercase and outside the quotes.
-			const escaped = filter.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
-			qs.$search = `"displayName:${escaped}" OR "userPrincipalName:${escaped}"`;
-		}
-		response = (await microsoftApiRequest.call(
+	} catch (error) {
+		throw rewriteForbiddenUnderSp.call(
 			this,
-			'GET',
-			'/v1.0/users',
-			{},
-			qs,
-			undefined,
-			headers,
-		)) as IDataObject;
+			error,
+			'The user list needs the User.Read.All application permission',
+			'Grant User.Read.All to the app registration with admin consent, or switch the field to By ID and enter a user principal name or object ID.',
+		);
 	}
 
 	const returnData: INodeListSearchItems[] = (response.value as IDataObject[]).map((user) => ({

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
@@ -1,10 +1,11 @@
-import { UserError, type ILoadOptionsFunctions, type INode } from 'n8n-workflow';
+import { NodeApiError, UserError, type ILoadOptionsFunctions, type INode } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
 import type { Mock } from 'vitest';
 import type { DeepMockProxy } from 'vitest-mock-extended';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
 import { getChats, getUsers } from '../../methods/listSearch';
+import { SERVICE_PRINCIPAL_AUTH } from '../../transport';
 import * as transport from '../../transport';
 import type * as _importType0 from '../../transport';
 
@@ -329,5 +330,40 @@ describe('Microsoft Teams v2 - getUsers', () => {
 			{ name: 'Ann Smith (ann@contoso.com)', value: 'u1' },
 			{ name: 'Zoe Brown (zoe@contoso.com)', value: 'u2' },
 		]);
+	});
+
+	describe('403 handling', () => {
+		const forbidden = () =>
+			new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' });
+
+		it('names the User.Read.All application permission under the Service Principal credential', async () => {
+			ctx.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+			apiRequest.mockRejectedValue(forbidden());
+
+			const thrown: unknown = await getUsers.call(ctx).catch((error: unknown) => error);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect((thrown as NodeApiError).message).toBe(
+				'The user list needs the User.Read.All application permission',
+			);
+			expect((thrown as NodeApiError).httpCode).toBe('403');
+			expect((thrown as NodeApiError).description).toContain('By ID');
+		});
+
+		it('also maps a 403 on a pagination request under the Service Principal credential', async () => {
+			ctx.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+			apiRequest.mockRejectedValue(forbidden());
+
+			await expect(
+				getUsers.call(ctx, undefined, 'https://graph.microsoft.com/v1.0/users?$skiptoken=abc'),
+			).rejects.toThrow('The user list needs the User.Read.All application permission');
+		});
+
+		it('leaves a delegated 403 unchanged', async () => {
+			ctx.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
+			apiRequest.mockRejectedValue(forbidden());
+
+			await expect(getUsers.call(ctx)).rejects.toThrow('Forbidden');
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -1,9 +1,11 @@
 import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 
 import {
 	buildMicrosoftGraphPath,
 	createMicrosoftGraphTransport,
 	type MicrosoftGraphCredentialType,
+	type MicrosoftGraphPathSegment,
 	rewriteNotFound,
 	SERVICE_PRINCIPAL_AUTH,
 	SP_HIDE,
@@ -16,6 +18,7 @@ import {
 export {
 	SERVICE_PRINCIPAL_AUTH,
 	SP_HIDE,
+	type MicrosoftGraphPathSegment,
 	buildMicrosoftGraphPath as buildTeamsPath,
 	rewriteNotFound,
 	validateMicrosoftGraphId as validateTeamsId,
@@ -65,4 +68,20 @@ export function validateTaskBodyIdsUnderSp(
 	const node = this.getNode();
 	if (ids.planId !== undefined) validateMicrosoftGraphId(ids.planId, node);
 	if (ids.bucketId !== undefined) validateMicrosoftGraphId(ids.bucketId, node);
+}
+
+// The kernel's app-only 403 is generic; call sites name the missing permission or policy.
+export function rewriteForbiddenUnderSp(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+	error: unknown,
+	message: string,
+	description: string,
+): unknown {
+	if (getTeamsCredentialType.call(this) !== SERVICE_PRINCIPAL_AUTH) return error;
+	if (!(error instanceof NodeApiError) || error.httpCode !== '403') return error;
+	return new NodeApiError(
+		this.getNode(),
+		{ message, description },
+		{ message, description, httpCode: '403' },
+	);
 }

--- a/packages/nodes-base/utils/microsoft/test/transport.test.ts
+++ b/packages/nodes-base/utils/microsoft/test/transport.test.ts
@@ -314,6 +314,7 @@ describe('Microsoft Graph transport kernel', () => {
 						// proves the SPECIFIC 401/402/403 messages fire in production (the status
 						// is read from NodeApiError.httpCode, not the absent statusCode/error.error)
 						expect(error.message).toBe(expectedMessage);
+						expect((error as NodeApiError).httpCode).toBe(String(statusCode));
 						// The raw body must not leak through the surfaced message…
 						expect(error.message).not.toContain('request-id');
 						expect(error.message).not.toContain('token=');


### PR DESCRIPTION
## Summary

The Online Meeting resource shipped delegated-only: under the Service Principal (App-Only) credential the node hid it and threw. Microsoft Graph does support app-only meeting operations under `/users/{id}/onlineMeetings`, and this is the one Teams surface where app-only auth pays off, since Graph forbids app-only message sends.

This PR un-gates the resource for the Service Principal credential and adds what the app-only path needs:

- An **Organizer** field, shown only under the Service Principal credential. It reuses the org-wide user picker (From List via `getUsers`, or By ID with a user principal name or object ID). Graph documents the path parameter as the user's object ID, so a principal name is resolved once through `GET /v1.0/users/{upn}?$select=id` before the meeting call. All five operations (Create, Create or Get, Delete, Get, Update) run against the organizer's `/v1.0/users/{id}/onlineMeetings`; delegated OAuth2 keeps `/v1.0/me/onlineMeetings`.
- The organizer goes through `buildTeamsPath`, so it is validated before it is interpolated into any path. A missing organizer fails before any request with a message that says what to set, stamped with the item index. A 404 on the meetings collection (create, create or get, or the join URL search) can only be the organizer, so it is reported as "Organizer not found"; a 404 on a meeting keeps the existing not-found message, with a hint that now names both the Meeting and the Organizer parameter.
- An app-only 403 on a meeting call becomes "Microsoft Graph refused the app-only meeting request", with a description that names both causes: the `OnlineMeetings.ReadWrite.All` application permission (`Read.All` is enough for Get) and the Teams application access policy (`New-CsApplicationAccessPolicy`, `Grant-CsApplicationAccessPolicy`, up to 30 minutes to apply). The shared transport strips Graph's error body under this credential, so the two causes can't be told apart and both are named. One `rewriteForbiddenUnderSp` helper in the Teams transport facade does this for the meeting calls, the organizer lookup, and the user picker; it throws a fresh `NodeApiError` so the description and status reach the editor.
- An app-only 403 on the user picker becomes "The user list needs the User.Read.All application permission", with By ID offered as the fallback that needs no directory permission.
- A notice under the resource explains the access policy prerequisite and deep-links to the setup section in the credential docs. The Service Principal option in the Authentication selector no longer says online meetings are unavailable.

No version bump: the resource was hidden and blocked under this credential, so no existing workflow runs it app-only.

Linear: https://linear.app/n8n/issue/ENT-352

### Graph references

- [Create onlineMeeting](https://learn.microsoft.com/en-us/graph/api/application-post-onlinemeetings?view=graph-rest-1.0), [createOrGet](https://learn.microsoft.com/en-us/graph/api/onlinemeeting-createorget?view=graph-rest-1.0), [Get](https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get?view=graph-rest-1.0), [Update](https://learn.microsoft.com/en-us/graph/api/onlinemeeting-update?view=graph-rest-1.0), [Delete](https://learn.microsoft.com/en-us/graph/api/onlinemeeting-delete?view=graph-rest-1.0): each lists `OnlineMeetings.ReadWrite.All` (application) with the access policy note.
- [Allow applications to access online meetings on behalf of a user](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy): the policy cmdlets, the 30-minute propagation, and the 403 `No application access policy found for this app`.

### Tests

- `test/v2/servicePrincipalDisplayOptions.test.ts`: Online Meeting is no longer in the hidden set; the operation selector and fields are shown under the Service Principal credential, the Organizer picker is required with list and By ID modes and no `extractValue`, and the resource notice exists.
- `test/v2/node/onlineMeeting/servicePrincipal.test.ts` (new): each operation addresses `/v1.0/users/{organizer}/onlineMeetings…`; join URL lookups filter the organizer's meetings for get, delete, and update; a principal name is resolved to the object ID first, with its own 404 and 403 messages; the organizer is resolved per item and a blank one is isolated under continueOnFail; a missing, blank, or separator-bearing organizer fails before any request; a 403 carries the policy cmdlets in its description; a collection 404 is an unknown organizer; a meeting 404 keeps the not-found message with the widened hint; a delegated 403 is unchanged.
- `test/v2/node/onlineMeeting/create.servicePrincipal.test.ts`, `get.servicePrincipal.test.ts`, and `create.servicePrincipal.forbidden.test.ts` (new): workflow-harness runs with the Service Principal credential pinned to the exact `/users/{id}` paths, plus a real 403 through the transport that lands on the item as the actionable message under continueRegularOutput.
- `utils/microsoft/test/transport.test.ts`: pins that the sanitised app-only error carries `httpCode` as a string, which the three rewrites key on.
- `v2/test/methods/listSearch.test.ts`: 403 mapping for `getUsers` under the Service Principal credential, including on a pagination request, and unchanged under OAuth2.
- `test/v2/node/servicePrincipal.test.ts`: the "throws under SP" cases for online meetings are removed, since they now run.

### Not in this PR

- Cloud check with the Service Principal credential and a tenant access policy (ticket requirement before closing).
- Attendance reports, transcripts, recordings, RSVP.

## How to test

1. Create a **Microsoft Entra Service Principal** credential for an app registration that has the `OnlineMeetings.ReadWrite.All` application permission with admin consent. Add `User.Read.All` if you want the **Organizer** list or want to enter a user principal name instead of an object ID.
2. As a Teams administrator, create and grant the application access policy for the app and a test user, then wait up to 30 minutes:

   ```powershell
   New-CsApplicationAccessPolicy -Identity n8n-online-meetings -AppIds "<application-client-id>"
   Grant-CsApplicationAccessPolicy -PolicyName n8n-online-meetings -Identity "<user-object-id>"
   ```

3. Add a **Microsoft Teams** node, set **Authentication** to **Service Principal (App-Only)**, **Resource** to **Online Meeting**, and pick the test user under **Organizer**. Run **Create**: the output carries a `joinWebUrl` and the organizer is the test user. Run **Get** with that join URL, **Update** the subject, **Create or Get** twice with the same External ID (one meeting), and **Delete**.
4. Repeat step 3 with a user that has no policy: every operation fails with "Microsoft Graph refused the app-only meeting request" and a description that names the permission and the two PowerShell cmdlets.
5. Enter a made-up principal name under **Organizer** By ID: the node fails with "Organizer not found" before any meeting call.
6. Switch **Authentication** to a **Teams OAuth2** credential: the **Organizer** field disappears and the operations run against `/me` as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-352

The docs update (credential page setup section, permission rows, Teams page) is drafted and will be opened in n8n-docs after this ships, together with the `status:awaiting-release` convention.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

