### PR TITLE
Turn on encryption key rotation by defaul

### DIFF
--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -9,6 +9,7 @@ import { InstanceSettings, BinaryDataConfig, ErrorReporter } from 'n8n-core';
 import http from 'node:http';
 import https from 'node:https';
 
+import { EncryptionBootstrapService } from '@/encryption/encryption-bootstrap.service';
 import { MultiMainSetup } from '@/scaling/multi-main-setup.ee';
 import { Start } from '../start';
 import { WaitTracker } from '@/wait-tracker';
@@ -41,6 +42,9 @@ authRolesService.init.mockResolvedValue(undefined);
 const deploymentKeyRepository = mockInstance(DeploymentKeyRepository);
 deploymentKeyRepository.findActiveByType.mockResolvedValue(null);
 deploymentKeyRepository.insertOrIgnore.mockResolvedValue(undefined);
+
+const encryptionBootstrapService = mockInstance(EncryptionBootstrapService);
+encryptionBootstrapService.run.mockResolvedValue(undefined);
 
 const loadNodesAndCredentials = mockInstance(LoadNodesAndCredentials);
 loadNodesAndCredentials.init.mockResolvedValue(undefined);
@@ -132,6 +136,7 @@ describe('Start - AuthRolesService initialization', () => {
 		Container.set(CommunityPackagesService, communityPackagesService);
 		Container.set(TaskRunnerModule, taskRunnerModule);
 		Container.set(DeploymentKeyRepository, deploymentKeyRepository);
+		Container.set(EncryptionBootstrapService, encryptionBootstrapService);
 		Container.set(
 			JwtService,
 			mockInstance(JwtService, { initialize: vi.fn().mockResolvedValue(undefined) }),

--- a/packages/cli/src/commands/__tests__/worker.test.ts
+++ b/packages/cli/src/commands/__tests__/worker.test.ts
@@ -16,6 +16,7 @@ import { ActiveExecutions } from '@/active-executions';
 import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { DeprecationService } from '@/deprecation/deprecation.service';
+import { EncryptionBootstrapService } from '@/encryption/encryption-bootstrap.service';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import type { EventService } from '@/events/event.service';
 import { ActivityEventRelay } from '@/events/relays/activity.event-relay';
@@ -46,6 +47,9 @@ dbConnection.migrate.mockResolvedValue(undefined);
 const deploymentKeyRepository = mockInstance(DeploymentKeyRepository);
 deploymentKeyRepository.findActiveByType.mockResolvedValue(null);
 deploymentKeyRepository.insertOrIgnore.mockResolvedValue(undefined);
+
+const encryptionBootstrapService = mockInstance(EncryptionBootstrapService);
+encryptionBootstrapService.run.mockResolvedValue(undefined);
 
 mockInstance(RedisClientService);
 mockInstance(PubSubRegistry);

--- a/packages/cli/src/encryption/__tests__/encryption-bootstrap.service.integration.test.ts
+++ b/packages/cli/src/encryption/__tests__/encryption-bootstrap.service.integration.test.ts
@@ -95,7 +95,7 @@ describe('EncryptionBootstrapService (integration)', () => {
 
 	describe('end-to-end write path (real key store, real cipher)', () => {
 		beforeEach(() => {
-			delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'false';
 		});
 
 		it('writes the legacy no-prefix format while rotation is off', async () => {

--- a/packages/cli/src/encryption/__tests__/encryption-bootstrap.service.test.ts
+++ b/packages/cli/src/encryption/__tests__/encryption-bootstrap.service.test.ts
@@ -94,11 +94,16 @@ describe('EncryptionBootstrapService', () => {
 		const seedError = new Error('no write access');
 
 		it('does not crash the instance while the rotation flag is off, and still sets the provider', async () => {
-			keyManager.bootstrapLegacyCbcKey.mockRejectedValue(seedError);
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'false';
+			try {
+				keyManager.bootstrapLegacyCbcKey.mockRejectedValue(seedError);
 
-			await expect(createService().run()).resolves.toBeUndefined();
+				await expect(createService().run()).resolves.toBeUndefined();
 
-			expect(encryptionKeyProxy.setProvider).toHaveBeenCalledWith(keyManager);
+				expect(encryptionKeyProxy.setProvider).toHaveBeenCalledWith(keyManager);
+			} finally {
+				delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+			}
 		});
 
 		it('rethrows while the rotation flag is on, because the keys are load-bearing', async () => {

--- a/packages/cli/src/encryption/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/encryption/__tests__/key-manager.service.test.ts
@@ -101,7 +101,7 @@ describe('KeyManagerService', () => {
 	describe('getActiveKey() with rotation disabled', () => {
 		beforeEach(() => {
 			// The disabled path must not depend on the ambient environment.
-			delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'false';
 		});
 
 		// Fresh instances: the legacy descriptor is memoized per service instance.

--- a/packages/cli/src/encryption/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/encryption/__tests__/key-manager.service.test.ts
@@ -104,6 +104,10 @@ describe('KeyManagerService', () => {
 			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'false';
 		});
 
+		afterEach(() => {
+			delete process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION;
+		});
+
 		// Fresh instances: the legacy descriptor is memoized per service instance.
 		const createService = () =>
 			new KeyManagerService(repository, cipher, instanceSettings, mock<Logger>());

--- a/packages/cli/src/encryption/key-rotation-flag.ts
+++ b/packages/cli/src/encryption/key-rotation-flag.ts
@@ -1,5 +1,3 @@
-import { isEnvFeatureEnabled } from '@n8n/backend-common';
-
 /**
  * Whether encryption-key rotation is enabled: with it on, `getActiveKey()`
  * hands the cipher the active data-encryption key (prefixed output) instead
@@ -9,7 +7,10 @@ import { isEnvFeatureEnabled } from '@n8n/backend-common';
  * module folds it into the write descriptor and into its module settings.
  * Module load, key seeding, and the provider wiring stay unconditional (see
  * `EncryptionKeyManagerModule`).
+ *
+ * On by default. Set `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=false` to revert
+ * new writes to the legacy format. Reads of both formats are unaffected.
  */
 export function isKeyRotationEnabled(): boolean {
-	return isEnvFeatureEnabled('N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION');
+	return process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION !== 'false';
 }

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key-manager.module.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-key-manager.module.test.ts
@@ -20,18 +20,18 @@ describe('EncryptionKeyManagerModule', () => {
 	});
 
 	describe('settings()', () => {
-		it('reports rotation as disabled by default', async () => {
-			const settings = await new EncryptionKeyManagerModule().settings();
-
-			expect(settings).toEqual({ rotationEnabled: false });
-		});
-
-		it('reports rotation as enabled when the flag is set', async () => {
-			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'true';
-
+		it('reports rotation as enabled by default', async () => {
 			const settings = await new EncryptionKeyManagerModule().settings();
 
 			expect(settings).toEqual({ rotationEnabled: true });
+		});
+
+		it('reports rotation as disabled when the flag is set to false', async () => {
+			process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION = 'false';
+
+			const settings = await new EncryptionKeyManagerModule().settings();
+
+			expect(settings).toEqual({ rotationEnabled: false });
 		});
 	});
 

--- a/packages/cli/test/integration/shared/utils/test-command.ts
+++ b/packages/cli/test/integration/shared/utils/test-command.ts
@@ -3,6 +3,7 @@ import { CommandMetadata, type CommandClass } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import argvParser from 'yargs-parser';
 
+import { KeyManagerService } from '@/encryption/key-manager.service';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { TelemetryEventRelay } from '@/events/relays/telemetry.event-relay';
 
@@ -15,6 +16,9 @@ export const setupTestCommand = <T extends CommandClass>(Command: T) => {
 
 	beforeAll(async () => {
 		await testDb.init();
+		// A command's base init wires the real key manager, which needs an active
+		// data-encryption key. Seed it here as production does at startup.
+		await Container.get(KeyManagerService).bootstrapGcmKey();
 	});
 
 	beforeEach(() => {


### PR DESCRIPTION
## Summary

New and edited data now encrypts in the authenticated format by default —
`keyId`-prefixed, AES-256-GCM. Set `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=false`
to send new writes back to the legacy format. Reads of both formats are
unaffected, so existing data stays readable in either mode.

This delivers authenticated encryption for new data. The flip is safe now: the
whole fleet reads both formats, keys are seeded, and the key-lifecycle guard is
in place. It is a single setting default, reversible at any time.

One flag, `isKeyRotationEnabled()`, gates the write format, the key-management
REST API, whether a failed key seed is fatal at startup, and the frontend
`rotationEnabled` setting. This PR defaults that flag to on, so all four turn on
together. Key seeding and the read-path provider already run unconditionally, so
a fresh instance seeds its key and reads the new format without extra steps.

### How to test manually

Prerequisite: start the instance once so it seeds the encryption keys.

1. Start n8n with defaults. Create or edit a credential.
2. Read the credential row in the database. Confirm the stored value starts with
   a `keyId:` prefix.
3. Confirm the credential still runs (open it, execute a node that uses it).
4. Restart n8n with `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=false`. Edit a
   credential again.
5. Confirm the new stored value has no prefix (legacy format).
6. Confirm the prefixed value from step 2 still decrypts and runs.

Automated coverage: unit tests for the flag default and the write descriptor,
plus integration tests that write in both modes and read mixed data
(`encryption-bootstrap.service.integration.test.ts`,
`key-rotation-cycle.integration.test.ts`, `cipher.test.ts`).

## Related

- https://linear.app/n8n/issue/IAM-1293

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

