### PR TITLE
feat(Microsoft Teams Node): Add the Service Principal path for Online Meeting Create

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.test.ts
@@ -1,0 +1,20 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+// Runs the real transport: Graph's access-policy 403 must reach the item as the
+// actionable message, not the sanitised generic one.
+describe('Test MicrosoftTeamsV2, onlineMeeting => create (Service Principal, no access policy)', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.post('/v1.0/users/11111111-2222-3333-4444-555555555555/onlineMeetings')
+		.reply(403, {
+			error: { code: 'Forbidden', message: 'No application access policy found for this app' },
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['create.servicePrincipal.forbidden.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.forbidden.workflow.json
@@ -1,0 +1,91 @@
+{
+	"name": "onlineMeeting create (Service Principal, no access policy)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "onlineMeeting",
+				"operation": "create",
+				"subject": "Standup",
+				"startDateTime": "2026-09-11T09:00:00Z",
+				"endDateTime": "2026-09-11T09:15:00Z",
+				"organizerId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "11111111-2222-3333-4444-555555555555"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "spCredId",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			},
+			"onError": "continueRegularOutput"
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"error": "Microsoft Graph refused the app-only meeting request. Grant the OnlineMeetings.ReadWrite.All application permission and a Teams application access policy for the organizer (New-CsApplicationAccessPolicy, then Grant-CsApplicationAccessPolicy)."
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0a5f7c1e-6c5f-4a1b-9c1e-1f2e3d4c5b6a",
+	"id": "onlineMeetingCreateSp403",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.test.ts
@@ -1,0 +1,36 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+// App-only create lands under the organizer, never under /me. The harness no-ops
+// preAuthentication and takes the Bearer from the inline fixture, so nock only Graph.
+describe('Test MicrosoftTeamsV2, onlineMeeting => create (Service Principal)', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.post('/v1.0/users/11111111-2222-3333-4444-555555555555/onlineMeetings', {
+			subject: 'Standup',
+			startDateTime: '2026-09-11T09:00:00Z',
+			endDateTime: '2026-09-11T09:15:00Z',
+		})
+		.reply(201, {
+			id: 'MSpTdGFuZHVwLWFwcC1vbmx5',
+			startDateTime: '2026-09-11T09:00:00Z',
+			endDateTime: '2026-09-11T09:15:00Z',
+			joinWebUrl: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YXBwb25seQ%40thread.v2/0',
+			subject: 'Standup',
+			participants: {
+				organizer: {
+					upn: 'alex@contoso.com',
+					identity: {
+						user: { id: '11111111-2222-3333-4444-555555555555', displayName: 'Alex Wilber' },
+					},
+				},
+			},
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['create.servicePrincipal.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/create.servicePrincipal.workflow.json
@@ -1,0 +1,105 @@
+{
+	"name": "onlineMeeting create (Service Principal)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "onlineMeeting",
+				"operation": "create",
+				"subject": "Standup",
+				"startDateTime": "2026-09-11T09:00:00Z",
+				"endDateTime": "2026-09-11T09:15:00Z",
+				"organizerId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "11111111-2222-3333-4444-555555555555"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "spCredId",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MSpTdGFuZHVwLWFwcC1vbmx5",
+					"startDateTime": "2026-09-11T09:00:00Z",
+					"endDateTime": "2026-09-11T09:15:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_YXBwb25seQ%40thread.v2/0",
+					"subject": "Standup",
+					"participants": {
+						"organizer": {
+							"upn": "alex@contoso.com",
+							"identity": {
+								"user": {
+									"id": "11111111-2222-3333-4444-555555555555",
+									"displayName": "Alex Wilber"
+								}
+							}
+						}
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0a5f7c1e-6c5f-4a1b-9c1e-1f2e3d4c5b6a",
+	"id": "onlineMeetingCreateSp01",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
@@ -1,0 +1,237 @@
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import type { IExecuteFunctions, NodeParameterValueType } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+
+import { createExecuteContext, meetingHeaders, setParams } from '../helpers';
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import { SERVICE_PRINCIPAL_AUTH } from '../../../../v2/transport';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const ORGANIZER = '11111111-2222-3333-4444-555555555555';
+const MEETING = 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi';
+const MEETINGS = `/v1.0/users/${ORGANIZER}/onlineMeetings`;
+
+const createParams = {
+	subject: 'Sync',
+	startDateTime: '2026-09-10T10:00:00Z',
+	endDateTime: '2026-09-10T10:30:00Z',
+	options: {},
+};
+
+describe('Microsoft Teams V2 — onlineMeeting under the Service Principal credential', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = createExecuteContext();
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: MEETING });
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const run = async (operation: string, params: Record<string, unknown>) => {
+		setParams(ctx, {
+			authentication: SERVICE_PRINCIPAL_AUTH,
+			resource: 'onlineMeeting',
+			operation,
+			organizerId: ORGANIZER,
+			...params,
+		});
+		return await node.execute.call(ctx);
+	};
+
+	it.each([['create', createParams, 'POST', MEETINGS]])(
+		"%s addresses the organizer's meetings instead of /me",
+		async (operation, params, method, path) => {
+			await run(operation, params);
+
+			expect(transport.microsoftApiRequest).toHaveBeenCalledTimes(1);
+			expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+				method,
+				path,
+				expect.anything(),
+				expect.anything(),
+				undefined,
+				meetingHeaders,
+			);
+		},
+	);
+
+	describe('a user principal name as the organizer', () => {
+		it('is resolved to the object ID before the meeting request', async () => {
+			(transport.microsoftApiRequest as Mock)
+				.mockResolvedValueOnce({ id: ORGANIZER })
+				.mockResolvedValueOnce({ id: MEETING });
+
+			await run('create', { ...createParams, organizerId: 'alex@contoso.com' });
+
+			expect(transport.microsoftApiRequest).toHaveBeenNthCalledWith(
+				1,
+				'GET',
+				'/v1.0/users/alex@contoso.com',
+				{},
+				{ $select: 'id' },
+			);
+			expect(transport.microsoftApiRequest).toHaveBeenNthCalledWith(
+				2,
+				'POST',
+				MEETINGS,
+				expect.anything(),
+				expect.anything(),
+				undefined,
+				meetingHeaders,
+			);
+		});
+
+		it('reports an unknown principal name as an organizer problem', async () => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Not Found' }, { httpCode: '404' }),
+			);
+
+			await expect(
+				run('create', { ...createParams, organizerId: 'nobody@contoso.com' }),
+			).rejects.toThrow('Organizer not found');
+			expect(transport.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		});
+
+		it('names User.Read.All when the lookup is forbidden', async () => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' }),
+			);
+
+			const thrown: unknown = await run('create', {
+				...createParams,
+				organizerId: 'alex@contoso.com',
+			}).catch((error: unknown) => error);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect((thrown as NodeApiError).message).toContain('User.Read.All');
+			expect((thrown as NodeApiError).message).toContain('object ID');
+		});
+
+		it('stamps the failing item on a lookup error for a later item', async () => {
+			const organizers = [ORGANIZER, 'alex@contoso.com'];
+			ctx.getInputData.mockReturnValue(organizers.map(() => ({ json: {} })));
+			const params: Record<string, unknown> = {
+				authentication: SERVICE_PRINCIPAL_AUTH,
+				resource: 'onlineMeeting',
+				operation: 'create',
+				...createParams,
+			};
+			ctx.getNodeParameter.mockImplementation(
+				(name: string, itemIndex?: number, fallback?: unknown): NodeParameterValueType => {
+					if (name === 'organizerId') return organizers[itemIndex ?? 0];
+					return (name in params ? params[name] : fallback) as NodeParameterValueType;
+				},
+			);
+			(transport.microsoftApiRequest as Mock)
+				.mockResolvedValueOnce({ id: MEETING })
+				.mockRejectedValueOnce(
+					new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' }),
+				);
+
+			const thrown: unknown = await node.execute.call(ctx).catch((error: unknown) => error);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect((thrown as NodeApiError).context.itemIndex).toBe(1);
+		});
+	});
+
+	it('resolves the organizer per item and isolates a blank one under continueOnFail', async () => {
+		const organizers = [ORGANIZER, '', '22222222-3333-4444-5555-666666666666'];
+		ctx.getInputData.mockReturnValue(organizers.map(() => ({ json: {} })));
+		ctx.continueOnFail.mockReturnValue(true);
+		const params: Record<string, unknown> = {
+			authentication: SERVICE_PRINCIPAL_AUTH,
+			resource: 'onlineMeeting',
+			operation: 'create',
+			...createParams,
+		};
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, itemIndex?: number, fallback?: unknown): NodeParameterValueType => {
+				if (name === 'organizerId') return organizers[itemIndex ?? 0];
+				return (name in params ? params[name] : fallback) as NodeParameterValueType;
+			},
+		);
+
+		const [output] = await node.execute.call(ctx);
+
+		expect(output.map((item) => item.json)).toEqual([
+			{ id: MEETING },
+			{ error: 'The Organizer is required with the Service Principal credential' },
+			{ id: MEETING },
+		]);
+		const paths = (transport.microsoftApiRequest as Mock).mock.calls.map((call) => call[1]);
+		expect(paths).toEqual([MEETINGS, `/v1.0/users/${organizers[2]}/onlineMeetings`]);
+	});
+
+	it.each([
+		['missing', undefined],
+		['blank', '   '],
+	])('rejects a %s organizer before any request', async (_label, organizerId) => {
+		const thrown: unknown = await run('create', { ...createParams, organizerId }).catch(
+			(error: unknown) => error,
+		);
+
+		expect(thrown).toBeInstanceOf(NodeOperationError);
+		expect((thrown as NodeOperationError).message).toBe(
+			'The Organizer is required with the Service Principal credential',
+		);
+		expect((thrown as NodeOperationError).context.itemIndex).toBe(0);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects a separator-bearing organizer before any request', async () => {
+		await expect(run('create', { ...createParams, organizerId: 'x/../../me' })).rejects.toThrow(
+			'The ID is not valid',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it.each([['create', createParams]])(
+		'%s names the access policy setup when Graph answers 403',
+		async (operation, params) => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' }),
+			);
+
+			const thrown: unknown = await run(operation, params).catch((error: unknown) => error);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect((thrown as NodeApiError).httpCode).toBe('403');
+			expect((thrown as NodeApiError).context.itemIndex).toBe(0);
+			// the message alone must be actionable: continueOnFail emits only the message
+			const message = (thrown as NodeApiError).message;
+			expect(message).toContain('Microsoft Graph refused the app-only meeting request');
+			expect(message).toContain('OnlineMeetings.ReadWrite.All');
+			expect(message).toContain('New-CsApplicationAccessPolicy');
+			expect(message).toContain('Grant-CsApplicationAccessPolicy');
+			expect((thrown as NodeApiError).description).toContain('30 minutes');
+		},
+	);
+
+	it.each([['create', createParams]])(
+		'%s reports a 404 on the meetings collection as an unknown organizer',
+		async (operation, params) => {
+			(transport.microsoftApiRequest as Mock).mockRejectedValue(
+				new NodeApiError(ctx.getNode(), { message: 'Not Found' }, { httpCode: '404' }),
+			);
+
+			await expect(run(operation, params)).rejects.toThrow('Organizer not found');
+		},
+	);
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -95,7 +95,6 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 	);
 
 	it.each([
-		['create', { subject: 'Sync', startDateTime: '2026-09-01T10:00:00Z' }],
 		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 		['createOrGet', { externalId: 'order-4711', options: {} }],
 		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
@@ -112,7 +111,7 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 			selectSp({ resource: 'onlineMeeting', operation: op, ...params });
 
 			await expect(node.execute.call(ctx)).rejects.toThrow(
-				'Online meetings are not available with the Service Principal credential',
+				'This online meeting operation is not available with the Service Principal credential yet',
 			);
 			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 			expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -32,7 +32,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
-	describe.each(['chatMessage', 'chatMember', 'onlineMeeting'])(
+	describe.each(['chatMessage', 'chatMember'])(
 		'%s - hidden under SP via the slash-prefixed field-level key',
 		(resource) => {
 			it('operation selector carries hide["/authentication"] = [SP]', () => {
@@ -66,6 +66,75 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 			});
 		},
 	);
+
+	describe('onlineMeeting — un-gated under SP one operation at a time', () => {
+		const spOperations = ['create'];
+		const allOperations = ['create', 'createOrGet', 'deleteMeeting', 'get', 'update'];
+		const fields = actionProps.filter((p) =>
+			p.displayOptions?.show?.resource?.includes('onlineMeeting'),
+		);
+		const selectors = fields.filter((p) => p.name === 'operation');
+		const optionValues = (selector?: INodeProperties) =>
+			(selector?.options ?? []).map((option) => ('value' in option ? option.value : undefined));
+		const fieldsFor = (operation: string) =>
+			fields.filter(
+				(p) =>
+					p.type !== 'notice' &&
+					p.name !== 'operation' &&
+					p.displayOptions?.show?.operation?.includes(operation),
+			);
+
+		it('keeps the full operation selector for OAuth2 and hides it under SP', () => {
+			const oauth = selectors.find((p) => isSpHidden(p));
+			expect(optionValues(oauth)).toEqual(allOperations);
+		});
+
+		it('offers only the un-gated operations under SP', () => {
+			const sp = selectors.find((p) => isSpShown(p));
+			expect(optionValues(sp)).toEqual(spOperations);
+			expect(sp?.displayOptions?.hide).toBeUndefined();
+		});
+
+		it.each(spOperations)('%s fields are shown under SP', (operation) => {
+			const operationFields = fieldsFor(operation);
+			expect(operationFields.length).toBeGreaterThan(0);
+			for (const field of operationFields) {
+				expect(isSpHidden(field)).toBe(false);
+			}
+		});
+
+		it.each(allOperations.filter((operation) => !spOperations.includes(operation)))(
+			'%s fields stay hidden under SP',
+			(operation) => {
+				const operationFields = fieldsFor(operation);
+				expect(operationFields.length).toBeGreaterThan(0);
+				for (const field of operationFields) {
+					expect(isSpHidden(field)).toBe(true);
+				}
+			},
+		);
+
+		it('an SP-shown required organizer picker exists with list and By-ID modes', () => {
+			const organizer = fields.find((p) => p.name === 'organizerId');
+			expect(organizer).toBeDefined();
+			expect(organizer?.displayOptions).toEqual({
+				show: { resource: ['onlineMeeting'], '/authentication': [SERVICE_PRINCIPAL_AUTH] },
+			});
+			expect(organizer?.required).toBe(true);
+			expect(organizer?.modes?.map((m) => m.name)).toEqual(['list', 'id']);
+			// no extractValue: an expression that resolves to a UPN must reach the node
+			expect(organizer?.modes?.every((m) => m.extractValue === undefined)).toBe(true);
+		});
+
+		it('shows an SP notice for the resource', () => {
+			const notice = fields.find(
+				(p) =>
+					p.type === 'notice' &&
+					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+			);
+			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+		});
+	});
 
 	describe('channelMessage — only the sending operations are hidden under SP', () => {
 		const fieldsFor = (operation: string) =>

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/create.operation.ts
@@ -3,13 +3,7 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { applyMeetingSettings, withMeetingSettings } from './meetingSettings';
-import {
-	meetingRequest,
-	requiredText,
-	throwIfOnlineMeetingUnsupported,
-	toGraphUtc,
-} from './shared';
-import { SP_HIDE } from '../../transport';
+import { meetingRequest, meetingsPath, requiredText, toGraphUtc } from './shared';
 
 const properties: INodeProperties[] = [
 	{
@@ -61,17 +55,12 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['create'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/application-post-onlinemeetings?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const options = this.getNodeParameter('options', i);
 	const body: IDataObject = {
 		subject: requiredText.call(this, 'subject', i, 'Subject'),
@@ -83,5 +72,5 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		body.joinMeetingIdSettings = { isPasscodeRequired: options.passcodeRequired };
 	}
 
-	return await meetingRequest.call(this, 'POST', '/v1.0/me/onlineMeetings', body);
+	return await meetingRequest.call(this, 'POST', await meetingsPath.call(this, i), body);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -1,28 +1,67 @@
-import type { INodeProperties } from 'n8n-workflow';
+import type { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
 
 import * as create from './create.operation';
 import * as createOrGet from './createOrGet.operation';
 import * as deleteMeeting from './deleteMeeting.operation';
 import * as get from './get.operation';
-import { SERVICE_PRINCIPAL_UNSUPPORTED } from './shared';
 import * as update from './update.operation';
+import { userRLC } from '../../descriptions';
 import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
 
 export { create, createOrGet, deleteMeeting, get, update };
 
-export const description: INodeProperties[] = [
-	{
-		displayName: `Online meetings are not available with the Service Principal credential. ${SERVICE_PRINCIPAL_UNSUPPORTED}`,
-		name: 'onlineMeetingServicePrincipalNotice',
-		type: 'notice',
-		default: '',
-		displayOptions: {
-			show: {
-				resource: ['onlineMeeting'],
-				authentication: [SERVICE_PRINCIPAL_AUTH],
-			},
+const organizerRLC: INodeProperties = {
+	...userRLC,
+	displayName: 'Organizer',
+	name: 'organizerId',
+	description:
+		'The user whose meetings the app creates and manages. From List and user principal names need the User.Read.All application permission; an object ID needs none.',
+	displayOptions: {
+		show: {
+			resource: ['onlineMeeting'],
+			'/authentication': [SERVICE_PRINCIPAL_AUTH],
 		},
 	},
+};
+
+const operations: INodePropertyOptions[] = [
+	{
+		name: 'Create',
+		value: 'create',
+		description: 'Create an online meeting',
+		action: 'Create online meeting',
+	},
+	{
+		name: 'Create or Get',
+		value: 'createOrGet',
+		description:
+			'Create an online meeting with your own external ID, or get the existing meeting with that ID',
+		action: 'Create or get online meeting',
+	},
+	{
+		name: 'Delete',
+		value: 'deleteMeeting',
+		description: 'Delete an online meeting',
+		action: 'Delete online meeting',
+	},
+	{
+		name: 'Get',
+		value: 'get',
+		description: 'Get an online meeting by ID or join URL',
+		action: 'Get online meeting',
+	},
+	{
+		name: 'Update',
+		value: 'update',
+		description: 'Update an online meeting',
+		action: 'Update online meeting',
+	},
+];
+
+// Un-gated for the Service Principal credential so far; the rest stay delegated-only.
+const servicePrincipalOperations = ['create'];
+
+export const description: INodeProperties[] = [
 	{
 		displayName: 'Operation',
 		name: 'operation',
@@ -36,41 +75,40 @@ export const description: INodeProperties[] = [
 				...SP_HIDE,
 			},
 		},
-		options: [
-			{
-				name: 'Create',
-				value: 'create',
-				description: 'Create an online meeting',
-				action: 'Create online meeting',
-			},
-			{
-				name: 'Create or Get',
-				value: 'createOrGet',
-				description:
-					'Create an online meeting with your own external ID, or get the existing meeting with that ID',
-				action: 'Create or get online meeting',
-			},
-			{
-				name: 'Delete',
-				value: 'deleteMeeting',
-				description: 'Delete an online meeting',
-				action: 'Delete online meeting',
-			},
-			{
-				name: 'Get',
-				value: 'get',
-				description: 'Get an online meeting by ID or join URL',
-				action: 'Get online meeting',
-			},
-			{
-				name: 'Update',
-				value: 'update',
-				description: 'Update an online meeting',
-				action: 'Update online meeting',
-			},
-		],
+		options: operations,
 		default: 'create',
 	},
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['onlineMeeting'],
+				'/authentication': [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+		options: operations.filter(
+			(option) =>
+				typeof option.value === 'string' && servicePrincipalOperations.includes(option.value),
+		),
+		default: 'create',
+	},
+	{
+		displayName:
+			'With the Service Principal credential, online meetings need the OnlineMeetings.ReadWrite.All application permission (Read.All is enough for Get) and a Teams application access policy that grants this app access to the organizer\'s meetings. <a href="https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal/#allow-app-only-online-meetings" target="_blank">Learn more</a>.',
+		name: 'onlineMeetingServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['onlineMeeting'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+	},
+	organizerRLC,
 
 	...create.description,
 	...createOrGet.description,

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/shared.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/shared.ts
@@ -1,26 +1,101 @@
 import { DateTime } from 'luxon';
 import type { IDataObject, IExecuteFunctions, IHttpRequestMethods } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import {
+	buildTeamsPath,
 	getTeamsCredentialType,
 	microsoftApiRequest,
+	type MicrosoftGraphPathSegment,
+	rewriteForbiddenUnderSp,
 	SERVICE_PRINCIPAL_AUTH,
 } from '../../transport';
 
+const ACCESS_POLICY_MESSAGE =
+	'Microsoft Graph refused the app-only meeting request. Grant the OnlineMeetings.ReadWrite.All application permission and a Teams application access policy for the organizer (New-CsApplicationAccessPolicy, then Grant-CsApplicationAccessPolicy).';
+
+const ACCESS_POLICY_DETAIL =
+	'OnlineMeetings.Read.All is enough for Get. The permission needs admin consent, and policy changes can take up to 30 minutes to apply.';
+
+const ORGANIZER_HINT = "Check that the 'Organizer' parameter is a user in the tenant";
+
+const GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+
+function isServicePrincipal(this: IExecuteFunctions): boolean {
+	return getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
+}
+
 export const MEETING_HINT = "Check that the 'Meeting' parameter is correctly set";
 
-export const SERVICE_PRINCIPAL_UNSUPPORTED =
-	'Online meeting operations run on the signed-in user. Use an OAuth2 credential instead.';
-
 export function throwIfOnlineMeetingUnsupported(this: IExecuteFunctions): void {
-	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+	if (isServicePrincipal.call(this)) {
 		throw new NodeOperationError(
 			this.getNode(),
-			'Online meetings are not available with the Service Principal credential',
-			{ description: SERVICE_PRINCIPAL_UNSUPPORTED },
+			'This online meeting operation is not available with the Service Principal credential yet',
+			{ description: 'Use an OAuth2 credential for this operation.' },
 		);
 	}
+}
+
+// Graph addresses app-only meetings by the organizer's object ID, not the principal name.
+async function resolveOrganizer(this: IExecuteFunctions, i: number): Promise<string> {
+	const raw = this.getNodeParameter('organizerId', i, '', { extractValue: true });
+	const organizer = typeof raw === 'string' ? raw.trim() : '';
+	if (!organizer) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'The Organizer is required with the Service Principal credential',
+			{
+				description:
+					'App-only Microsoft Graph has no signed-in user. Select the user whose meetings the node should act on.',
+				itemIndex: i,
+			},
+		);
+	}
+	if (GUID.test(organizer)) return organizer;
+
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/users/', { id: organizer }]);
+	let user: IDataObject;
+	try {
+		user = (await microsoftApiRequest.call(
+			this,
+			'GET',
+			endpoint,
+			{},
+			{ $select: 'id' },
+		)) as IDataObject;
+	} catch (error) {
+		if (error instanceof NodeApiError && error.httpCode === '404') {
+			throw new NodeOperationError(this.getNode(), 'Organizer not found', {
+				description: ORGANIZER_HINT,
+				itemIndex: i,
+			});
+		}
+		throw rewriteForbiddenUnderSp.call(
+			this,
+			error,
+			"Resolving the organizer needs the User.Read.All application permission. Enter the organizer's object ID instead.",
+			'Grant User.Read.All to the app registration with admin consent to look up a user principal name.',
+		);
+	}
+	if (typeof user.id !== 'string' || user.id === '') {
+		throw new NodeOperationError(this.getNode(), 'Organizer not found', {
+			description: ORGANIZER_HINT,
+			itemIndex: i,
+		});
+	}
+	return user.id;
+}
+
+export async function meetingsPath(
+	this: IExecuteFunctions,
+	i: number,
+	segments: MicrosoftGraphPathSegment[] = [],
+): Promise<string> {
+	const root: MicrosoftGraphPathSegment[] = isServicePrincipal.call(this)
+		? ['/v1.0/users/', { id: await resolveOrganizer.call(this, i) }, '/onlineMeetings']
+		: ['/v1.0/me/onlineMeetings'];
+	return buildTeamsPath.call(this, [...root, ...segments]);
 }
 
 export function optionalText(this: IExecuteFunctions, value: unknown, label: string) {
@@ -56,6 +131,22 @@ export function toGraphUtc(this: IExecuteFunctions, value: unknown, label: strin
 	return parsed.toUTC().toISO({ suppressMilliseconds: true });
 }
 
+// A 404 on the meetings collection (POST, or the join-URL search) can only be the organizer.
+function rewriteAppOnlyError(
+	this: IExecuteFunctions,
+	error: unknown,
+	method: IHttpRequestMethods,
+	endpoint: string,
+): unknown {
+	if (!isServicePrincipal.call(this) || !(error instanceof NodeApiError)) return error;
+	if (error.httpCode === '404' && (method === 'POST' || endpoint.endsWith('/onlineMeetings'))) {
+		return new NodeOperationError(this.getNode(), 'Organizer not found', {
+			description: ORGANIZER_HINT,
+		});
+	}
+	return rewriteForbiddenUnderSp.call(this, error, ACCESS_POLICY_MESSAGE, ACCESS_POLICY_DETAIL);
+}
+
 export async function meetingRequest(
 	this: IExecuteFunctions,
 	method: IHttpRequestMethods,
@@ -63,7 +154,11 @@ export async function meetingRequest(
 	body: IDataObject = {},
 	qs: IDataObject = {},
 ) {
-	return await microsoftApiRequest.call(this, method, endpoint, body, qs, undefined, {
-		Prefer: 'include-unknown-enum-members',
-	});
+	try {
+		return await microsoftApiRequest.call(this, method, endpoint, body, qs, undefined, {
+			Prefer: 'include-unknown-enum-members',
+		});
+	} catch (error) {
+		throw rewriteAppOnlyError.call(this, error, method, endpoint);
+	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
@@ -15,6 +15,7 @@ import type { MicrosoftTeamsType } from './node.type';
 import * as onlineMeeting from './onlineMeeting';
 import * as task from './task';
 import { configureWaitTillDate } from '../../../../../utils/sendAndWait/configureWaitTillDate.util';
+import { stampItemIndexOnError } from '../../../GenericFunctions';
 
 export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 	const items = this.getInputData();
@@ -106,7 +107,7 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 				returnData.push(...executionErrorData);
 				continue;
 			}
-			throw error;
+			throw stampItemIndexOnError(error, i);
 		}
 	}
 	return [returnData];

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
@@ -14,6 +14,7 @@ import {
 	joinedTeamsEndpoint,
 	microsoftApiRequest,
 	microsoftApiRequestAllItems,
+	rewriteForbiddenUnderSp,
 	SERVICE_PRINCIPAL_AUTH,
 } from '../transport';
 
@@ -133,34 +134,31 @@ export async function getUsers(
 	// ConsistencyLevel is sent on every call: directory paging drops custom headers on
 	// nextLink requests, so the token branch needs it too or Graph rejects the $search.
 	const headers: IDataObject = { ConsistencyLevel: 'eventual' };
+	const qs: IDataObject = paginationToken ? {} : { $select: 'id,displayName,userPrincipalName' };
+	if (!paginationToken && filter) {
+		// `$search` escaping is NOT `$filter`'s quote-doubling: backslash-escape `\`
+		// first, then `"`, and the OR operator is uppercase and outside the quotes.
+		const escaped = filter.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+		qs.$search = `"displayName:${escaped}" OR "userPrincipalName:${escaped}"`;
+	}
 	let response: IDataObject;
-	if (paginationToken) {
+	try {
 		response = (await microsoftApiRequest.call(
 			this,
 			'GET',
-			'',
+			paginationToken ? '' : '/v1.0/users',
 			{},
-			{},
+			qs,
 			paginationToken,
 			headers,
 		)) as IDataObject;
-	} else {
-		const qs: IDataObject = { $select: 'id,displayName,userPrincipalName' };
-		if (filter) {
-			// `$search` escaping is NOT `$filter`'s quote-doubling: backslash-escape `\`
-			// first, then `"`, and the OR operator is uppercase and outside the quotes.
-			const escaped = filter.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
-			qs.$search = `"displayName:${escaped}" OR "userPrincipalName:${escaped}"`;
-		}
-		response = (await microsoftApiRequest.call(
+	} catch (error) {
+		throw rewriteForbiddenUnderSp.call(
 			this,
-			'GET',
-			'/v1.0/users',
-			{},
-			qs,
-			undefined,
-			headers,
-		)) as IDataObject;
+			error,
+			"The user list needs the User.Read.All application permission. Grant it with admin consent, or switch the field to By ID and enter the user's object ID.",
+			'A user principal name also needs User.Read.All, because the node looks it up.',
+		);
 	}
 
 	const returnData: INodeListSearchItems[] = (response.value as IDataObject[]).map((user) => ({

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/methods/listSearch.test.ts
@@ -1,10 +1,11 @@
-import { UserError, type ILoadOptionsFunctions, type INode } from 'n8n-workflow';
+import { NodeApiError, UserError, type ILoadOptionsFunctions, type INode } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
 import type { Mock } from 'vitest';
 import type { DeepMockProxy } from 'vitest-mock-extended';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
 import { getChats, getUsers } from '../../methods/listSearch';
+import { SERVICE_PRINCIPAL_AUTH } from '../../transport';
 import * as transport from '../../transport';
 import type * as _importType0 from '../../transport';
 
@@ -329,5 +330,39 @@ describe('Microsoft Teams v2 - getUsers', () => {
 			{ name: 'Ann Smith (ann@contoso.com)', value: 'u1' },
 			{ name: 'Zoe Brown (zoe@contoso.com)', value: 'u2' },
 		]);
+	});
+
+	describe('403 handling', () => {
+		const forbidden = () =>
+			new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' });
+
+		it('names the User.Read.All application permission under the Service Principal credential', async () => {
+			ctx.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+			apiRequest.mockRejectedValue(forbidden());
+
+			const thrown: unknown = await getUsers.call(ctx).catch((error: unknown) => error);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect((thrown as NodeApiError).message).toContain('User.Read.All');
+			expect((thrown as NodeApiError).message).toContain('By ID');
+			expect((thrown as NodeApiError).message).toContain('object ID');
+			expect((thrown as NodeApiError).httpCode).toBe('403');
+		});
+
+		it('also maps a 403 on a pagination request under the Service Principal credential', async () => {
+			ctx.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+			apiRequest.mockRejectedValue(forbidden());
+
+			await expect(
+				getUsers.call(ctx, undefined, 'https://graph.microsoft.com/v1.0/users?$skiptoken=abc'),
+			).rejects.toThrow('User.Read.All');
+		});
+
+		it('leaves a delegated 403 unchanged', async () => {
+			ctx.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
+			apiRequest.mockRejectedValue(forbidden());
+
+			await expect(getUsers.call(ctx)).rejects.toThrow('Forbidden');
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -1,9 +1,11 @@
 import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 
 import {
 	buildMicrosoftGraphPath,
 	createMicrosoftGraphTransport,
 	type MicrosoftGraphCredentialType,
+	type MicrosoftGraphPathSegment,
 	rewriteNotFound,
 	SERVICE_PRINCIPAL_AUTH,
 	SP_HIDE,
@@ -16,6 +18,7 @@ import {
 export {
 	SERVICE_PRINCIPAL_AUTH,
 	SP_HIDE,
+	type MicrosoftGraphPathSegment,
 	buildMicrosoftGraphPath as buildTeamsPath,
 	rewriteNotFound,
 	validateMicrosoftGraphId as validateTeamsId,
@@ -65,4 +68,20 @@ export function validateTaskBodyIdsUnderSp(
 	const node = this.getNode();
 	if (ids.planId !== undefined) validateMicrosoftGraphId(ids.planId, node);
 	if (ids.bucketId !== undefined) validateMicrosoftGraphId(ids.bucketId, node);
+}
+
+// The kernel's app-only 403 is generic; call sites name the missing permission or policy.
+export function rewriteForbiddenUnderSp(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+	error: unknown,
+	message: string,
+	description: string,
+): unknown {
+	if (getTeamsCredentialType.call(this) !== SERVICE_PRINCIPAL_AUTH) return error;
+	if (!(error instanceof NodeApiError) || error.httpCode !== '403') return error;
+	return new NodeApiError(
+		this.getNode(),
+		{ message, description },
+		{ message, description, httpCode: '403' },
+	);
 }

--- a/packages/nodes-base/utils/microsoft/test/transport.test.ts
+++ b/packages/nodes-base/utils/microsoft/test/transport.test.ts
@@ -314,6 +314,7 @@ describe('Microsoft Graph transport kernel', () => {
 						// proves the SPECIFIC 401/402/403 messages fire in production (the status
 						// is read from NodeApiError.httpCode, not the absent statusCode/error.error)
 						expect(error.message).toBe(expectedMessage);
+						expect((error as NodeApiError).httpCode).toBe(String(statusCode));
 						// The raw body must not leak through the surfaced message…
 						expect(error.message).not.toContain('request-id');
 						expect(error.message).not.toContain('token=');


### PR DESCRIPTION
## Summary

First of five stacked PRs for ENT-352. Lets the Microsoft Teams node create online meetings with the Service Principal (app-only) credential.

- Adds an **Organizer** field, shown only for the Service Principal credential. Pick a user from the list or enter an ID. Meetings are created on that user's behalf.
- Under this credential the Operation dropdown only lists operations that work app-only. This PR enables **Create**. The next four PRs enable Get, Create or Get, Delete, and Update.
- Without a Teams application access policy, Graph returns a bare 403. The node now says what to grant and which PowerShell commands to run.
- The user picker's 403 now says it needs `User.Read.All`.

No node version bump: this path was hidden before, so no existing workflow used it. Docs follow in n8n-docs after release.

## How to test

1. Use a Service Principal credential whose app has `OnlineMeetings.ReadWrite.All` (plus `User.Read.All` for the picker), and grant it an application access policy for a test user with `New-CsApplicationAccessPolicy` and `Grant-CsApplicationAccessPolicy`.
2. Teams node, Service Principal credential, Online Meeting, Create, with that user as Organizer. You get a join URL back.
3. Try a user without the policy. The error names the permission and the commands.
4. Switch to an OAuth2 credential. Nothing changes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-352

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
