### PR TITLE
feat(Microsoft Teams Node): Add the Service Principal path for Online Meeting Get

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.test.ts
@@ -1,0 +1,30 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+const joinWebUrl =
+	'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d';
+
+describe('Test MicrosoftTeamsV2, onlineMeeting => get by join URL (Service Principal)', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Prefer', 'include-unknown-enum-members')
+		.get('/v1.0/users/11111111-2222-3333-4444-555555555555/onlineMeetings')
+		.query({ $filter: `JoinWebUrl eq '${joinWebUrl}'` })
+		.reply(200, {
+			value: [
+				{
+					id: 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi',
+					startDateTime: '2026-09-10T10:00:00Z',
+					endDateTime: '2026-09-10T10:30:00Z',
+					joinWebUrl,
+					subject: 'Quarterly Sync',
+				},
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['get.servicePrincipal.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/get.servicePrincipal.workflow.json
@@ -1,0 +1,96 @@
+{
+	"name": "onlineMeeting get by join URL (Service Principal)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "6666-9999-77777",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [880, 380]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "onlineMeeting",
+				"operation": "get",
+				"meetingId": {
+					"__rl": true,
+					"mode": "url",
+					"value": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d"
+				},
+				"organizerId": {
+					"__rl": true,
+					"mode": "id",
+					"value": "11111111-2222-3333-4444-555555555555"
+				}
+			},
+			"id": "6666-5555-77777",
+			"name": "Microsoft Teams",
+			"type": "n8n-nodes-base.microsoftTeams",
+			"typeVersion": 2,
+			"position": [1100, 380],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "spCredId",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1400, 380]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi",
+					"startDateTime": "2026-09-10T10:00:00Z",
+					"endDateTime": "2026-09-10T10:30:00Z",
+					"joinWebUrl": "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0?context=%7b%22Tid%22%3a%22abc%22%7d",
+					"subject": "Quarterly Sync"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Teams",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Microsoft Teams": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0a5f7c1e-6c5f-4a1b-9c1e-1f2e3d4c5b6a",
+	"id": "onlineMeetingGetSp01",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
@@ -20,7 +20,11 @@ vi.mock('../../../../v2/transport', async () => {
 
 const ORGANIZER = '11111111-2222-3333-4444-555555555555';
 const MEETING = 'MSpkYzE3Njc0Yy04MWQ5LTRhZGItYmZi';
+const JOIN_URL = 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDE2Nzg0%40thread.v2/0';
 const MEETINGS = `/v1.0/users/${ORGANIZER}/onlineMeetings`;
+
+const byId = { meetingId: { __rl: true, mode: 'id', value: MEETING } };
+const byUrl = { meetingId: { __rl: true, mode: 'url', value: JOIN_URL } };
 
 const createParams = {
 	subject: 'Sync',
@@ -54,7 +58,10 @@ describe('Microsoft Teams V2 — onlineMeeting under the Service Principal crede
 		return await node.execute.call(ctx);
 	};
 
-	it.each([['create', createParams, 'POST', MEETINGS]])(
+	it.each([
+		['create', createParams, 'POST', MEETINGS],
+		['get', byId, 'GET', `${MEETINGS}/${MEETING}`],
+	])(
 		"%s addresses the organizer's meetings instead of /me",
 		async (operation, params, method, path) => {
 			await run(operation, params);
@@ -70,6 +77,54 @@ describe('Microsoft Teams V2 — onlineMeeting under the Service Principal crede
 			);
 		},
 	);
+
+	it("get by join URL filters the organizer's meetings", async () => {
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ value: [{ id: MEETING }] });
+
+		await run('get', byUrl);
+
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+			'GET',
+			MEETINGS,
+			{},
+			{ $filter: `JoinWebUrl eq '${JOIN_URL}'` },
+			undefined,
+			meetingHeaders,
+		);
+	});
+
+	it('keeps the not-found rewrite for a 404 on a meeting, naming both parameters', async () => {
+		(transport.microsoftApiRequest as Mock).mockRejectedValue(
+			new NodeApiError(ctx.getNode(), { message: 'Not Found' }, { httpCode: '404' }),
+		);
+
+		const thrown: unknown = await run('get', byId).catch((error: unknown) => error);
+
+		expect(thrown).toBeInstanceOf(NodeOperationError);
+		expect((thrown as NodeOperationError).message).toBe(
+			"The meeting you are trying to get doesn't exist",
+		);
+		expect((thrown as NodeOperationError).description).toBe(
+			"Check that the 'Meeting' and 'Organizer' parameters are correctly set",
+		);
+	});
+
+	it('leaves a delegated 403 unchanged', async () => {
+		(transport.microsoftApiRequest as Mock).mockRejectedValue(
+			new NodeApiError(
+				ctx.getNode(),
+				{ message: 'Insufficient privileges to complete the operation' },
+				{ httpCode: '403', message: 'Insufficient privileges to complete the operation' },
+			),
+		);
+		setParams(ctx, { resource: 'onlineMeeting', operation: 'get', ...byId });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Insufficient privileges to complete the operation',
+		);
+		const calledPath = (transport.microsoftApiRequest as Mock).mock.calls[0][1] as string;
+		expect(calledPath).toBe(`/v1.0/me/onlineMeetings/${MEETING}`);
+	});
 
 	describe('a user principal name as the organizer', () => {
 		it('is resolved to the object ID before the meeting request', async () => {
@@ -202,36 +257,41 @@ describe('Microsoft Teams V2 — onlineMeeting under the Service Principal crede
 		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 	});
 
-	it.each([['create', createParams]])(
-		'%s names the access policy setup when Graph answers 403',
-		async (operation, params) => {
-			(transport.microsoftApiRequest as Mock).mockRejectedValue(
-				new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' }),
-			);
+	it.each([
+		['create', createParams],
+		['get', byId],
+	])('%s names the access policy setup when Graph answers 403', async (operation, params) => {
+		(transport.microsoftApiRequest as Mock).mockRejectedValue(
+			new NodeApiError(ctx.getNode(), { message: 'Forbidden' }, { httpCode: '403' }),
+		);
 
-			const thrown: unknown = await run(operation, params).catch((error: unknown) => error);
+		const thrown: unknown = await run(operation, params).catch((error: unknown) => error);
 
-			expect(thrown).toBeInstanceOf(NodeApiError);
-			expect((thrown as NodeApiError).httpCode).toBe('403');
-			expect((thrown as NodeApiError).context.itemIndex).toBe(0);
-			// the message alone must be actionable: continueOnFail emits only the message
-			const message = (thrown as NodeApiError).message;
-			expect(message).toContain('Microsoft Graph refused the app-only meeting request');
-			expect(message).toContain('OnlineMeetings.ReadWrite.All');
-			expect(message).toContain('New-CsApplicationAccessPolicy');
-			expect(message).toContain('Grant-CsApplicationAccessPolicy');
-			expect((thrown as NodeApiError).description).toContain('30 minutes');
-		},
-	);
+		expect(thrown).toBeInstanceOf(NodeApiError);
+		expect((thrown as NodeApiError).httpCode).toBe('403');
+		expect((thrown as NodeApiError).context.itemIndex).toBe(0);
+		// the message alone must be actionable: continueOnFail emits only the message
+		const message = (thrown as NodeApiError).message;
+		expect(message).toContain('Microsoft Graph refused the app-only meeting request');
+		expect(message).toContain('OnlineMeetings.ReadWrite.All');
+		expect(message).toContain('New-CsApplicationAccessPolicy');
+		expect(message).toContain('Grant-CsApplicationAccessPolicy');
+		expect((thrown as NodeApiError).description).toContain('30 minutes');
+	});
 
-	it.each([['create', createParams]])(
+	it.each([
+		['create', createParams],
+		['get by join URL', byUrl],
+	])(
 		'%s reports a 404 on the meetings collection as an unknown organizer',
 		async (operation, params) => {
 			(transport.microsoftApiRequest as Mock).mockRejectedValue(
 				new NodeApiError(ctx.getNode(), { message: 'Not Found' }, { httpCode: '404' }),
 			);
 
-			await expect(run(operation, params)).rejects.toThrow('Organizer not found');
+			await expect(run(operation === 'create' ? 'create' : 'get', params)).rejects.toThrow(
+				'Organizer not found',
+			);
 		},
 	);
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -95,7 +95,6 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 	);
 
 	it.each([
-		['get', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 		['createOrGet', { externalId: 'order-4711', options: {} }],
 		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 		[

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -68,7 +68,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 	);
 
 	describe('onlineMeeting — un-gated under SP one operation at a time', () => {
-		const spOperations = ['create'];
+		const spOperations = ['create', 'get'];
 		const allOperations = ['create', 'createOrGet', 'deleteMeeting', 'get', 'update'];
 		const fields = actionProps.filter((p) =>
 			p.displayOptions?.show?.resource?.includes('onlineMeeting'),

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/get.operation.ts
@@ -3,9 +3,9 @@ import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { fetchMeetingByJoinUrl, readMeetingLocator } from './meetingLocator';
-import { MEETING_HINT, meetingRequest, throwIfOnlineMeetingUnsupported } from './shared';
+import { meetingHint, meetingRequest, meetingsPath } from './shared';
 import { meetingRLC } from '../../descriptions';
-import { buildTeamsPath, rewriteNotFound, SP_HIDE } from '../../transport';
+import { rewriteNotFound } from '../../transport';
 
 const properties: INodeProperties[] = [meetingRLC];
 
@@ -14,23 +14,18 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['get'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const { mode, value } = readMeetingLocator.call(this, i);
 	if (mode === 'url') {
-		return await fetchMeetingByJoinUrl.call(this, value);
+		return await fetchMeetingByJoinUrl.call(this, i, value);
 	}
 
-	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: value }]);
+	const endpoint = await meetingsPath.call(this, i, ['/', { id: value }]);
 	try {
 		return await meetingRequest.call(this, 'GET', endpoint);
 	} catch (error) {
@@ -38,7 +33,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			error,
 			"The meeting you are trying to get doesn't exist",
-			MEETING_HINT,
+			meetingHint.call(this),
 		);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -59,7 +59,7 @@ const operations: INodePropertyOptions[] = [
 ];
 
 // Un-gated for the Service Principal credential so far; the rest stay delegated-only.
-const servicePrincipalOperations = ['create'];
+const servicePrincipalOperations = ['create', 'get'];
 
 export const description: INodeProperties[] = [
 	{

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/meetingLocator.ts
@@ -2,7 +2,7 @@ import { type IDataObject, type IExecuteFunctions, NodeOperationError } from 'n8
 
 import { odataStringLiteral } from '@utils/microsoft/odata';
 
-import { meetingRequest } from './shared';
+import { meetingRequest, meetingsPath } from './shared';
 
 const isLocator = (value: unknown): value is { mode: unknown; value: unknown } =>
 	typeof value === 'object' && value !== null && 'mode' in value && 'value' in value;
@@ -21,6 +21,7 @@ export function readMeetingLocator(
 
 export async function fetchMeetingByJoinUrl(
 	this: IExecuteFunctions,
+	i: number,
 	joinWebUrl: string,
 ): Promise<IDataObject> {
 	if (!joinWebUrl) {
@@ -31,7 +32,7 @@ export async function fetchMeetingByJoinUrl(
 	const response = await meetingRequest.call(
 		this,
 		'GET',
-		'/v1.0/me/onlineMeetings',
+		await meetingsPath.call(this, i),
 		{},
 		{
 			$filter: `JoinWebUrl eq ${odataStringLiteral(joinWebUrl)}`,
@@ -49,6 +50,6 @@ export async function fetchMeetingByJoinUrl(
 export async function resolveMeetingId(this: IExecuteFunctions, i: number): Promise<string> {
 	const { mode, value } = readMeetingLocator.call(this, i);
 	if (mode !== 'url') return value;
-	const meeting = await fetchMeetingByJoinUrl.call(this, value);
+	const meeting = await fetchMeetingByJoinUrl.call(this, i, value);
 	return asText(meeting.id);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/shared.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/shared.ts
@@ -27,6 +27,12 @@ function isServicePrincipal(this: IExecuteFunctions): boolean {
 
 export const MEETING_HINT = "Check that the 'Meeting' parameter is correctly set";
 
+export function meetingHint(this: IExecuteFunctions): string {
+	return isServicePrincipal.call(this)
+		? "Check that the 'Meeting' and 'Organizer' parameters are correctly set"
+		: "Check that the 'Meeting' parameter is correctly set";
+}
+
 export function throwIfOnlineMeetingUnsupported(this: IExecuteFunctions): void {
 	if (isServicePrincipal.call(this)) {
 		throw new NodeOperationError(


### PR DESCRIPTION
## Summary

Second of five stacked PRs for ENT-352. Enables **Get** for the Service Principal credential, by meeting ID or by join URL, against the organizer's meetings. When a meeting isn't found, the hint now points at both the Meeting and Organizer fields.

## How to test

With the setup from #38320, run Get with a meeting ID, then with its join URL. Both return the meeting.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-352

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
