### PR TITLE
feat(Microsoft Teams Node): Add the Service Principal path for Online Meeting Delete

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
@@ -62,6 +62,7 @@ describe('Microsoft Teams V2 — onlineMeeting under the Service Principal crede
 		['create', createParams, 'POST', MEETINGS],
 		['get', byId, 'GET', `${MEETINGS}/${MEETING}`],
 		['createOrGet', { externalId: 'order-4711', options: {} }, 'POST', `${MEETINGS}/createOrGet`],
+		['deleteMeeting', byId, 'DELETE', `${MEETINGS}/${MEETING}`],
 	])(
 		"%s addresses the organizer's meetings instead of /me",
 		async (operation, params, method, path) => {
@@ -126,6 +127,26 @@ describe('Microsoft Teams V2 — onlineMeeting under the Service Principal crede
 		const calledPath = (transport.microsoftApiRequest as Mock).mock.calls[0][1] as string;
 		expect(calledPath).toBe(`/v1.0/me/onlineMeetings/${MEETING}`);
 	});
+
+	it.each([['deleteMeeting', {}, 'DELETE']])(
+		'%s resolves a join URL against the organizer first',
+		async (operation, params, method) => {
+			(transport.microsoftApiRequest as Mock)
+				.mockResolvedValueOnce({ value: [{ id: MEETING }] })
+				.mockResolvedValueOnce({});
+
+			await run(operation, { ...byUrl, ...params });
+
+			const calls = (transport.microsoftApiRequest as Mock).mock.calls.map((call) => [
+				call[0],
+				call[1],
+			]);
+			expect(calls).toEqual([
+				['GET', MEETINGS],
+				[method, `${MEETINGS}/${MEETING}`],
+			]);
+		},
+	);
 
 	describe('a user principal name as the organizer', () => {
 		it('is resolved to the object ID before the meeting request', async () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/onlineMeeting/servicePrincipal.test.ts
@@ -61,6 +61,7 @@ describe('Microsoft Teams V2 — onlineMeeting under the Service Principal crede
 	it.each([
 		['create', createParams, 'POST', MEETINGS],
 		['get', byId, 'GET', `${MEETINGS}/${MEETING}`],
+		['createOrGet', { externalId: 'order-4711', options: {} }, 'POST', `${MEETINGS}/createOrGet`],
 	])(
 		"%s addresses the organizer's meetings instead of /me",
 		async (operation, params, method, path) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -95,7 +95,6 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 	);
 
 	it.each([
-		['createOrGet', { externalId: 'order-4711', options: {} }],
 		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 		[
 			'update',

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -95,7 +95,6 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 	);
 
 	it.each([
-		['deleteMeeting', { meetingId: { __rl: true, mode: 'id', value: 'meeting-id' } }],
 		[
 			'update',
 			{

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -68,7 +68,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 	);
 
 	describe('onlineMeeting — un-gated under SP one operation at a time', () => {
-		const spOperations = ['create', 'get', 'createOrGet'];
+		const spOperations = ['create', 'get', 'createOrGet', 'deleteMeeting'];
 		const allOperations = ['create', 'createOrGet', 'deleteMeeting', 'get', 'update'];
 		const fields = actionProps.filter((p) =>
 			p.displayOptions?.show?.resource?.includes('onlineMeeting'),

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -68,7 +68,7 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 	);
 
 	describe('onlineMeeting — un-gated under SP one operation at a time', () => {
-		const spOperations = ['create', 'get'];
+		const spOperations = ['create', 'get', 'createOrGet'];
 		const allOperations = ['create', 'createOrGet', 'deleteMeeting', 'get', 'update'];
 		const fields = actionProps.filter((p) =>
 			p.displayOptions?.show?.resource?.includes('onlineMeeting'),
@@ -91,7 +91,9 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 
 		it('offers only the un-gated operations under SP', () => {
 			const sp = selectors.find((p) => isSpShown(p));
-			expect(optionValues(sp)).toEqual(spOperations);
+			expect(optionValues(sp)).toEqual(
+				allOperations.filter((operation) => spOperations.includes(operation)),
+			);
 			expect(sp?.displayOptions?.hide).toBeUndefined();
 		});
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/createOrGet.operation.ts
@@ -7,14 +7,7 @@ import {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
-import {
-	meetingRequest,
-	optionalText,
-	requiredText,
-	throwIfOnlineMeetingUnsupported,
-	toGraphUtc,
-} from './shared';
-import { SP_HIDE } from '../../transport';
+import { meetingRequest, meetingsPath, optionalText, requiredText, toGraphUtc } from './shared';
 
 const properties: INodeProperties[] = [
 	{
@@ -25,7 +18,7 @@ const properties: INodeProperties[] = [
 		default: '',
 		placeholder: 'e.g. order-4711-kickoff',
 		description:
-			'Your own ID for the meeting. Running the node again with the same ID returns the existing meeting instead of creating another one.',
+			'Your own ID for the meeting. Running the node again with the same ID for the same organizer returns the existing meeting instead of creating another one.',
 	},
 	{
 		displayName: 'Options',
@@ -66,17 +59,12 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['createOrGet'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-createorget?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const externalId = requiredText.call(this, 'externalId', i, 'External ID');
 	const options = this.getNodeParameter('options', i);
 	if (options.endDateTime && !options.startDateTime) {
@@ -98,5 +86,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		body.endDateTime = toGraphUtc.call(this, options.endDateTime, 'End Time');
 	}
 
-	return await meetingRequest.call(this, 'POST', '/v1.0/me/onlineMeetings/createOrGet', body);
+	return await meetingRequest.call(
+		this,
+		'POST',
+		await meetingsPath.call(this, i, ['/createOrGet']),
+		body,
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/deleteMeeting.operation.ts
@@ -3,9 +3,9 @@ import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { resolveMeetingId } from './meetingLocator';
-import { MEETING_HINT, meetingRequest, throwIfOnlineMeetingUnsupported } from './shared';
+import { meetingHint, meetingRequest, meetingsPath } from './shared';
 import { meetingRLC } from '../../descriptions';
-import { buildTeamsPath, rewriteNotFound, SP_HIDE } from '../../transport';
+import { rewriteNotFound } from '../../transport';
 
 const properties: INodeProperties[] = [meetingRLC];
 
@@ -14,19 +14,14 @@ const displayOptions = {
 		resource: ['onlineMeeting'],
 		operation: ['deleteMeeting'],
 	},
-	hide: {
-		...SP_HIDE,
-	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://learn.microsoft.com/en-us/graph/api/onlinemeeting-delete?view=graph-rest-1.0&tabs=http
-	throwIfOnlineMeetingUnsupported.call(this);
-
 	const meetingId = await resolveMeetingId.call(this, i);
-	const endpoint = buildTeamsPath.call(this, ['/v1.0/me/onlineMeetings/', { id: meetingId }]);
+	const endpoint = await meetingsPath.call(this, i, ['/', { id: meetingId }]);
 
 	try {
 		await meetingRequest.call(this, 'DELETE', endpoint);
@@ -36,7 +31,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			error,
 			"The meeting you are trying to delete doesn't exist",
-			MEETING_HINT,
+			meetingHint.call(this),
 		);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -59,7 +59,7 @@ const operations: INodePropertyOptions[] = [
 ];
 
 // Un-gated for the Service Principal credential so far; the rest stay delegated-only.
-const servicePrincipalOperations = ['create', 'get', 'createOrGet'];
+const servicePrincipalOperations = ['create', 'get', 'createOrGet', 'deleteMeeting'];
 
 export const description: INodeProperties[] = [
 	{

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/onlineMeeting/index.ts
@@ -59,7 +59,7 @@ const operations: INodePropertyOptions[] = [
 ];
 
 // Un-gated for the Service Principal credential so far; the rest stay delegated-only.
-const servicePrincipalOperations = ['create', 'get'];
+const servicePrincipalOperations = ['create', 'get', 'createOrGet'];
 
 export const description: INodeProperties[] = [
 	{


### PR DESCRIPTION
## Summary

Fourth of five stacked PRs for ENT-352. Enables **Delete** for the Service Principal credential, by meeting ID or by join URL.

## How to test

With the setup from #38320, delete a meeting by join URL, then Get it by ID. It fails with "doesn't exist".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-352

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
