### PR TITLE
fix(core): Settle answered confirmation cards in the AI Assistant run-sync frame

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -55,7 +55,7 @@ import type {
 } from '@n8n/api-types';
 import type { ModuleRegistry } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
-import { seedAgentBuilderTargetMetadata } from '@n8n/instance-ai';
+import { buildAgentTreeFromEvents, seedAgentBuilderTargetMetadata } from '@n8n/instance-ai';
 import {
 	InstanceAiPersistPendingAgentRequest,
 	MAX_ATTACHMENT_BASE64_BYTES,
@@ -488,6 +488,77 @@ describe('InstanceAiController', () => {
 				.map(([frame]) => String(frame))
 				.filter((frame) => frame.includes('run-finish'));
 			expect(eventFrames).toEqual([`id: 7\ndata: ${JSON.stringify(midAwaitEvent.event)}\n\n`]);
+		});
+
+		it('should settle confirmation cards the server no longer holds before writing the run-sync frame', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+			instanceAiService.getThreadStatus.mockReturnValue({
+				hasActiveRun: true,
+				isSuspended: false,
+				backgroundTasks: [],
+			} as never);
+			instanceAiService.getMessageGroupId.mockReturnValue('mg-1');
+			instanceAiService.getRunIdsForMessageGroup.mockReturnValue(['run-1']);
+			eventLog.getEventsAfter.mockResolvedValue([]);
+			eventBus.subscribe.mockReturnValue(vi.fn());
+			eventLog.getEventsForRuns.mockResolvedValue([
+				{ type: 'run-start', runId: 'run-1', agentId: 'a1', payload: { messageGroupId: 'mg-1' } },
+			] as never);
+			// The fold only knows the card was requested. The run has since resumed
+			// (the pending row is gone), which is what the flagging reports.
+			vi.mocked(buildAgentTreeFromEvents).mockReturnValueOnce({
+				agentId: 'a1',
+				role: 'orchestrator',
+				status: 'active',
+				textContent: '',
+				reasoning: '',
+				toolCalls: [
+					{
+						toolCallId: 'tc-1',
+						toolName: 'build-workflow',
+						args: {},
+						isLoading: true,
+						confirmation: { requestId: 'req-1', severity: 'info', message: 'Create workflow?' },
+					},
+				],
+				children: [],
+				timeline: [],
+			} as never);
+			memoryService.flagExpiredConfirmations.mockImplementationOnce(async (messages) => {
+				for (const message of messages) {
+					for (const tc of message.agentTree?.toolCalls ?? []) {
+						if (tc.confirmation) tc.confirmation.expired = true;
+					}
+				}
+			});
+
+			const sseRes = mock<Response & { flush?: () => void }>({
+				setHeader: vi.fn(),
+				flushHeaders: vi.fn(),
+				write: vi.fn(),
+				end: vi.fn(),
+				flush: vi.fn(),
+			});
+			const sseReq = mock<AuthenticatedRequest>({
+				user: { id: USER_ID },
+				headers: {},
+				once: vi.fn(),
+			});
+
+			await controller.events(sseReq, sseRes, THREAD_ID, { lastEventId: undefined } as never);
+
+			const runSyncFrame = (sseRes.write as Mock).mock.calls
+				.map(([frame]) => String(frame))
+				.find((frame) => frame.startsWith('event: run-sync\n'));
+			expect(runSyncFrame).toBeDefined();
+			const { agentTree } = JSON.parse(runSyncFrame!.slice('event: run-sync\ndata: '.length)) as {
+				agentTree: {
+					toolCalls: Array<{ confirmation?: { requestId: string; expired?: boolean } }>;
+				};
+			};
+			expect(agentTree.toolCalls[0].confirmation).toEqual(
+				expect.objectContaining({ requestId: 'req-1', expired: true }),
+			);
 		});
 
 		it('should clean up the subscription when the client disconnects during bootstrap', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -427,6 +427,42 @@ describe('InstanceAiController', () => {
 	});
 
 	describe('events', () => {
+		// Bootstrap fixtures: one live run on group mg-1, and a request/response
+		// pair the handler can write to.
+		const RUN_START = {
+			type: 'run-start',
+			runId: 'run-1',
+			agentId: 'a1',
+			payload: { messageGroupId: 'mg-1' },
+		};
+		function stubLiveRun(runEvents: unknown[] = []): void {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+			instanceAiService.getThreadStatus.mockReturnValue({
+				hasActiveRun: true,
+				isSuspended: false,
+				backgroundTasks: [],
+			} as never);
+			instanceAiService.getMessageGroupId.mockReturnValue('mg-1');
+			instanceAiService.getRunIdsForMessageGroup.mockReturnValue(['run-1']);
+			eventLog.getEventsForRuns.mockResolvedValue(runEvents as never);
+		}
+		function sseIo(once: Mock = vi.fn()) {
+			const sseRes = mock<Response & { flush?: () => void }>({
+				setHeader: vi.fn(),
+				flushHeaders: vi.fn(),
+				write: vi.fn(),
+				end: vi.fn(),
+				flush: vi.fn(),
+			});
+			const sseReq = mock<AuthenticatedRequest>({
+				user: { id: USER_ID },
+				headers: {},
+				once: once as never,
+			});
+			const frames = () => (sseRes.write as Mock).mock.calls.map(([frame]) => String(frame));
+			return { sseReq, sseRes, frames };
+		}
+
 		it('should require instanceAi:message scope', () => {
 			expect(scopeOf('events')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
 		});
@@ -490,20 +526,40 @@ describe('InstanceAiController', () => {
 			expect(eventFrames).toEqual([`id: 7\ndata: ${JSON.stringify(midAwaitEvent.event)}\n\n`]);
 		});
 
+		it('should replay events that arrive while the run-sync confirmation check is in flight', async () => {
+			stubLiveRun([RUN_START]);
+			let liveHandler: ((stored: { id: number; event: unknown }) => void) | undefined;
+			eventBus.subscribe.mockImplementation((_threadId, handler) => {
+				// The bootstrap also registers a buffering subscription; the live
+				// delivery handler is the first one.
+				liveHandler ??= handler as (stored: { id: number; event: unknown }) => void;
+				return vi.fn();
+			});
+			// While the pending-row check is in flight, a relayed event arrives:
+			// the bootstrap must hold it and deliver it exactly once, after the frame.
+			const midAwaitEvent = {
+				id: 7,
+				event: { type: 'run-finish', runId: 'run-1', agentId: 'a1', payload: {} },
+			};
+			memoryService.flagExpiredConfirmations.mockImplementationOnce(async () => {
+				liveHandler!(midAwaitEvent);
+				eventLog.getEventsAfter.mockResolvedValue([midAwaitEvent] as never);
+			});
+			const { sseReq, sseRes, frames } = sseIo();
+
+			await controller.events(sseReq, sseRes, THREAD_ID, { lastEventId: undefined } as never);
+
+			const written = frames();
+			const runSyncIndex = written.findIndex((frame) => frame.startsWith('event: run-sync\n'));
+			const runFinishFrames = written.filter((frame) => frame.includes('run-finish'));
+			expect(runSyncIndex).toBeGreaterThanOrEqual(0);
+			expect(runFinishFrames).toEqual([`id: 7\ndata: ${JSON.stringify(midAwaitEvent.event)}\n\n`]);
+			expect(written.indexOf(runFinishFrames[0])).toBeGreaterThan(runSyncIndex);
+		});
+
 		it('should settle confirmation cards the server no longer holds before writing the run-sync frame', async () => {
-			memoryService.checkThreadOwnership.mockResolvedValue('owned');
-			instanceAiService.getThreadStatus.mockReturnValue({
-				hasActiveRun: true,
-				isSuspended: false,
-				backgroundTasks: [],
-			} as never);
-			instanceAiService.getMessageGroupId.mockReturnValue('mg-1');
-			instanceAiService.getRunIdsForMessageGroup.mockReturnValue(['run-1']);
-			eventLog.getEventsAfter.mockResolvedValue([]);
+			stubLiveRun([RUN_START]);
 			eventBus.subscribe.mockReturnValue(vi.fn());
-			eventLog.getEventsForRuns.mockResolvedValue([
-				{ type: 'run-start', runId: 'run-1', agentId: 'a1', payload: { messageGroupId: 'mg-1' } },
-			] as never);
 			// The fold only knows the card was requested. The run has since resumed
 			// (the pending row is gone), which is what the flagging reports.
 			vi.mocked(buildAgentTreeFromEvents).mockReturnValueOnce({
@@ -531,25 +587,11 @@ describe('InstanceAiController', () => {
 					}
 				}
 			});
-
-			const sseRes = mock<Response & { flush?: () => void }>({
-				setHeader: vi.fn(),
-				flushHeaders: vi.fn(),
-				write: vi.fn(),
-				end: vi.fn(),
-				flush: vi.fn(),
-			});
-			const sseReq = mock<AuthenticatedRequest>({
-				user: { id: USER_ID },
-				headers: {},
-				once: vi.fn(),
-			});
+			const { sseReq, sseRes, frames } = sseIo();
 
 			await controller.events(sseReq, sseRes, THREAD_ID, { lastEventId: undefined } as never);
 
-			const runSyncFrame = (sseRes.write as Mock).mock.calls
-				.map(([frame]) => String(frame))
-				.find((frame) => frame.startsWith('event: run-sync\n'));
+			const runSyncFrame = frames().find((frame) => frame.startsWith('event: run-sync\n'));
 			expect(runSyncFrame).toBeDefined();
 			const { agentTree } = JSON.parse(runSyncFrame!.slice('event: run-sync\ndata: '.length)) as {
 				agentTree: {
@@ -601,6 +643,35 @@ describe('InstanceAiController', () => {
 				return [
 					{ id: 1, event: { type: 'text-delta', runId: 'run-1', agentId: 'a1', payload: {} } },
 				] as never;
+			});
+
+			await controller.events(sseReq, sseRes, THREAD_ID, { lastEventId: undefined } as never);
+
+			// Both the live subscription (via the close handler) and the temporary
+			// buffering subscription (via the bootstrap finally) are removed.
+			expect(unsubscribers).toHaveLength(2);
+			expect(unsubscribers[0]).toHaveBeenCalledTimes(1);
+			expect(unsubscribers[1]).toHaveBeenCalledTimes(1);
+			expect(sseRes.write).not.toHaveBeenCalled();
+		});
+
+		it('should write no run-sync frame when the client disconnects during the confirmation check', async () => {
+			stubLiveRun([RUN_START]);
+			const unsubscribers: Mock[] = [];
+			eventBus.subscribe.mockImplementation(() => {
+				const unsubscribe = vi.fn();
+				unsubscribers.push(unsubscribe);
+				return unsubscribe;
+			});
+			let closeHandler: (() => void) | undefined;
+			const { sseReq, sseRes } = sseIo(
+				vi.fn((event: string, handler: () => void) => {
+					if (event === 'close') closeHandler = handler;
+				}),
+			);
+			// The client disconnects while the pending-row check is in flight.
+			memoryService.flagExpiredConfirmations.mockImplementationOnce(async () => {
+				closeHandler!();
 			});
 
 			await controller.events(sseReq, sseRes, THREAD_ID, { lastEventId: undefined } as never);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3425,6 +3425,70 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		expect(service.eventBus.publish).toHaveBeenCalledWith('thread-a', confirmationEvent);
 	});
 
+	it('does not publish the confirmation card when the run is cancelled during the row write', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		const abortController = new AbortController();
+		const tracing = {
+			actorRun: { id: 'segment-a-actor' },
+			withActiveSpan: vi.fn(
+				async (_run: unknown, callback: () => Promise<unknown>) => await callback(),
+			),
+		} as unknown as InstanceAiTraceContext;
+		// cancelRun aborts the suspended run while the row write is in flight.
+		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(async () => {
+			abortController.abort();
+		});
+		const confirmationEvent = {
+			type: 'confirmation-request',
+			runId: 'run-1',
+			agentId: 'orchestrator:run-1',
+			payload: {
+				requestId: 'req-1',
+				toolCallId: 'tool-call-1',
+				toolName: 'ask-user',
+				args: {},
+				severity: 'info',
+				message: 'Set up the slack channel',
+			},
+		} as unknown as Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
+		mockClaimedResumeResult({
+			status: 'suspended',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve(''),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+			suspension: {
+				toolCallId: 'tool-call-1',
+				requestId: 'req-1',
+				toolName: 'ask-user',
+				suspendPayload: { requestId: 'req-1', message: 'Set up the slack channel' },
+			},
+			confirmationEvent,
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				tracing,
+			},
+		);
+
+		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', confirmationEvent);
+		expect(service.tracing.finalizeRunTracing).not.toHaveBeenCalledWith(
+			'run-1',
+			tracing,
+			expect.objectContaining({ status: 'suspended' }),
+		);
+	});
+
 	it('keeps a suspending segment from finalizing or scheduling over a fast next segment', async () => {
 		const service = createTerminalGuardOrderService();
 		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -525,6 +525,8 @@ type TerminalGuardOrderServiceInternals = {
 	maybeStartWorkflowSetupFollowUp: Mock;
 	finalizeRun: Mock;
 	preserveHitlOnShutdown: Set<string>;
+	inFlightExecutions: Set<Promise<unknown>>;
+	shutdown: () => Promise<void>;
 	executeRun: (
 		user: User,
 		threadId: string,
@@ -3449,6 +3451,29 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		vi.mocked(createInstanceAiTraceContext).mockResolvedValueOnce(undefined);
 	}
 
+	/** The shutdown() surface: one suspended run, nothing else in flight. */
+	function stubShutdownSurface(
+		service: TerminalGuardOrderServiceInternals,
+		run: { runId: string; tracing: InstanceAiTraceContext; abortController: AbortController },
+	): void {
+		Object.assign(service.liveness, { shutdown: vi.fn() });
+		Object.assign(service.runState, {
+			shutdown: vi.fn(() => ({ activeRuns: [], suspendedRuns: [run], pendingThreadIds: [] })),
+		});
+		Object.assign(service.backgroundTasks, { cancelAll: vi.fn(() => []) });
+		Object.assign(service.tracing, { getTrackedThreadIds: vi.fn(() => []), clear: vi.fn() });
+		Object.assign(service.eventBus, { clear: vi.fn() });
+		Object.assign(service.logger, { debug: vi.fn() });
+		Object.assign(service, {
+			inFlightExecutions: new Set<Promise<unknown>>(),
+			gatewayService: { disconnectAll: vi.fn() },
+			browserSessionService: { shutdown: vi.fn(async () => {}) },
+			sandboxService: { stopSandboxExpiryTimers: vi.fn() },
+			domainAccessTrackersByThread: new Map(),
+			eventLog: { flushAll: vi.fn(async () => {}) },
+		});
+	}
+
 	it('writes the pending row before it publishes the confirmation card', async () => {
 		const service = createTerminalGuardOrderService();
 		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
@@ -3513,6 +3538,36 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			tracing,
 			expect.objectContaining({ status: 'suspended' }),
 		);
+	});
+
+	it('records the suspended run on shutdown() and keeps the confirmation card publish', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		const tracing = cardTracing();
+		const abortController = new AbortController();
+		stubShutdownSurface(service, { runId: 'run-1', tracing, abortController });
+		let flaggedAtAbort = false;
+		abortController.signal.addEventListener('abort', () => {
+			flaggedAtAbort = service.preserveHitlOnShutdown.has('run-1');
+		});
+		let shutdown: Promise<void> | undefined;
+		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(async () => {
+			shutdown = service.shutdown();
+			await new Promise<void>((resolve) => {
+				abortController.signal.addEventListener('abort', () => resolve(), { once: true });
+			});
+		});
+		mockClaimedResumeResult(suspendedWithCard());
+
+		const run = service.processResumedStream({}, {}, resumeOpts(abortController, tracing));
+		service.inFlightExecutions.add(run);
+		await run;
+		await shutdown;
+
+		// The flag lands before the abort fires, so the guard lets the card through.
+		expect(flaggedAtAbort).toBe(true);
+		expect(service.eventBus.publish).toHaveBeenCalledWith('thread-a', CARD_EVENT);
+		expect(service.eventBus.events.some((event) => event.type === 'run-finish')).toBe(false);
 	});
 
 	it('does not publish the confirmation card when the initial run is cancelled during the row write', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -525,6 +525,13 @@ type TerminalGuardOrderServiceInternals = {
 	maybeStartWorkflowSetupFollowUp: Mock;
 	finalizeRun: Mock;
 	preserveHitlOnShutdown: Set<string>;
+	executeRun: (
+		user: User,
+		threadId: string,
+		runId: string,
+		message: string,
+		abortController: AbortController,
+	) => Promise<void>;
 	processResumedStream: (
 		agent: unknown,
 		resumeData: unknown,
@@ -3485,6 +3492,76 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		expect(service.tracing.finalizeRunTracing).not.toHaveBeenCalledWith(
 			'run-1',
 			tracing,
+			expect.objectContaining({ status: 'suspended' }),
+		);
+	});
+
+	it('does not publish the confirmation card when the initial run is cancelled during the row write', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		// The smallest executeRun surface: no tracing, no attachments, no handoff.
+		Object.assign(service, {
+			resolveContextAttachments: vi.fn(async () => []),
+			createProxyRunConfig: vi.fn(async () => ({})),
+			browserSessionService: { getExtensionTraceContext: vi.fn() },
+			readThreadProvenance: vi.fn(async () => ({})),
+			isRunDebugEnabled: vi.fn(() => false),
+			createExecutionEnvironment: vi.fn(async () => ({
+				context: {},
+				memory: { getThread: vi.fn(async () => ({ title: 'Existing conversation' })) },
+				taskStorage: { get: vi.fn(async () => undefined) },
+				orchestrationContext: {},
+			})),
+			snapshotAttachedAgents: vi.fn(),
+			buildMessageWithRunningTasks: vi.fn(async (_threadId: string, text: string) => text),
+			buildWorkflowSetupStateBlock: vi.fn(async () => ''),
+			instanceContext: { buildBlock: vi.fn(async () => undefined) },
+			resolveProjectContextSection: vi.fn(async () => ''),
+			createAgentFromEnvironment: vi.fn(async () => ({})),
+			buildOrchestratorAgentStreamOptions: vi.fn(() => ({})),
+			domainAccessTrackersByThread: new Map(),
+		});
+		vi.mocked(createInstanceAiTraceContext).mockResolvedValueOnce(undefined);
+		const abortController = new AbortController();
+		// cancelRun aborts the suspended run while the row write is in flight.
+		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(async () => {
+			abortController.abort();
+		});
+		const confirmationEvent = {
+			type: 'confirmation-request',
+			runId: 'run-1',
+			agentId: 'orchestrator:run-1',
+			payload: {
+				requestId: 'req-1',
+				toolCallId: 'tool-call-1',
+				toolName: 'ask-user',
+				args: {},
+				severity: 'info',
+				message: 'Set up the slack channel',
+			},
+		} as unknown as Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
+		vi.mocked(streamAgentRun).mockResolvedValueOnce({
+			status: 'suspended',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve(''),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+			suspension: {
+				toolCallId: 'tool-call-1',
+				requestId: 'req-1',
+				toolName: 'ask-user',
+				suspendPayload: { requestId: 'req-1', message: 'Set up the slack channel' },
+			},
+			confirmationEvent,
+		});
+
+		await service.executeRun(fakeUser, 'thread-a', 'run-1', 'Set up slack', abortController);
+
+		// The run did suspend; the abort landed after that, not before the stream.
+		expect(service.runState.suspendRun).toHaveBeenCalled();
+		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', confirmationEvent);
+		expect(service.tracing.finalizeRunTracing).not.toHaveBeenCalledWith(
+			'run-1',
+			undefined,
 			expect.objectContaining({ status: 'suspended' }),
 		);
 	});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3355,6 +3355,76 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		);
 	});
 
+	it('writes the pending row before it publishes the confirmation card', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		const abortController = new AbortController();
+		const tracing = {
+			actorRun: { id: 'segment-a-actor' },
+			withActiveSpan: vi.fn(
+				async (_run: unknown, callback: () => Promise<unknown>) => await callback(),
+			),
+		} as unknown as InstanceAiTraceContext;
+		let releaseRow: () => void = () => {};
+		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(
+			async () =>
+				await new Promise<void>((resolve) => {
+					releaseRow = resolve;
+				}),
+		);
+		const confirmationEvent = {
+			type: 'confirmation-request',
+			runId: 'run-1',
+			agentId: 'orchestrator:run-1',
+			payload: {
+				requestId: 'req-1',
+				toolCallId: 'tool-call-1',
+				toolName: 'ask-user',
+				args: {},
+				severity: 'info',
+				message: 'Set up the slack channel',
+			},
+		} as unknown as Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
+		mockClaimedResumeResult({
+			status: 'suspended',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve(''),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+			suspension: {
+				toolCallId: 'tool-call-1',
+				requestId: 'req-1',
+				toolName: 'ask-user',
+				suspendPayload: { requestId: 'req-1', message: 'Set up the slack channel' },
+			},
+			confirmationEvent,
+		});
+
+		const resumed = service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				tracing,
+			},
+		);
+		await vi.waitFor(() =>
+			expect(service.suspendedThreads.persistPendingConfirmation).toHaveBeenCalled(),
+		);
+		// The row write is still in flight: a client that reconnects now must not
+		// be able to read the card from the log, or it settles the card as expired.
+		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', confirmationEvent);
+
+		releaseRow();
+		await resumed;
+		expect(service.eventBus.publish).toHaveBeenCalledWith('thread-a', confirmationEvent);
+	});
+
 	it('keeps a suspending segment from finalizing or scheduling over a fast next segment', async () => {
 		const service = createTerminalGuardOrderService();
 		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3362,37 +3362,24 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		);
 	});
 
-	it('writes the pending row before it publishes the confirmation card', async () => {
-		const service = createTerminalGuardOrderService();
-		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
-		const abortController = new AbortController();
-		const tracing = {
-			actorRun: { id: 'segment-a-actor' },
-			withActiveSpan: vi.fn(
-				async (_run: unknown, callback: () => Promise<unknown>) => await callback(),
-			),
-		} as unknown as InstanceAiTraceContext;
-		let releaseRow: () => void = () => {};
-		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(
-			async () =>
-				await new Promise<void>((resolve) => {
-					releaseRow = resolve;
-				}),
-		);
-		const confirmationEvent = {
-			type: 'confirmation-request',
-			runId: 'run-1',
-			agentId: 'orchestrator:run-1',
-			payload: {
-				requestId: 'req-1',
-				toolCallId: 'tool-call-1',
-				toolName: 'ask-user',
-				args: {},
-				severity: 'info',
-				message: 'Set up the slack channel',
-			},
-		} as unknown as Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
-		mockClaimedResumeResult({
+	// Fixtures for the confirmation-card tests below. The tests differ only in
+	// when the abort fires and whether the card must still reach the client.
+	const CARD_EVENT = {
+		type: 'confirmation-request',
+		runId: 'run-1',
+		agentId: 'orchestrator:run-1',
+		payload: {
+			requestId: 'req-1',
+			toolCallId: 'tool-call-1',
+			toolName: 'ask-user',
+			args: {},
+			severity: 'info',
+			message: 'Set up the slack channel',
+		},
+	} as unknown as Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
+
+	function suspendedWithCard(): Awaited<ReturnType<typeof resumeAgentRun>> {
+		return {
 			status: 'suspended',
 			agentRunId: 'agent-run-1',
 			text: Promise.resolve(''),
@@ -3403,103 +3390,41 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 				toolName: 'ask-user',
 				suspendPayload: { requestId: 'req-1', message: 'Set up the slack channel' },
 			},
-			confirmationEvent,
-		});
+			confirmationEvent: CARD_EVENT,
+		};
+	}
 
-		const resumed = service.processResumedStream(
-			{},
-			{},
-			{
-				runId: 'run-1',
-				agentRunId: 'agent-run-1',
-				threadId: 'thread-a',
-				user: fakeUser,
-				toolCallId: 'tool-call-1',
-				signal: abortController.signal,
-				abortController,
-				tracing,
-			},
-		);
-		await vi.waitFor(() =>
-			expect(service.suspendedThreads.persistPendingConfirmation).toHaveBeenCalled(),
-		);
-		// The row write is still in flight: a client that reconnects now must not
-		// be able to read the card from the log, or it settles the card as expired.
-		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', confirmationEvent);
-
-		releaseRow();
-		await resumed;
-		expect(service.eventBus.publish).toHaveBeenCalledWith('thread-a', confirmationEvent);
-	});
-
-	it('does not publish the confirmation card when the run is cancelled during the row write', async () => {
-		const service = createTerminalGuardOrderService();
-		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
-		const abortController = new AbortController();
-		const tracing = {
+	function cardTracing(): InstanceAiTraceContext {
+		return {
 			actorRun: { id: 'segment-a-actor' },
-			withActiveSpan: vi.fn(
-				async (_run: unknown, callback: () => Promise<unknown>) => await callback(),
-			),
+			withActiveSpan: vi.fn(async (_run: unknown, body: () => Promise<unknown>) => await body()),
 		} as unknown as InstanceAiTraceContext;
-		// cancelRun aborts the suspended run while the row write is in flight.
+	}
+
+	function resumeOpts(abortController: AbortController, tracing: InstanceAiTraceContext) {
+		return {
+			runId: 'run-1',
+			agentRunId: 'agent-run-1',
+			threadId: 'thread-a',
+			user: fakeUser,
+			toolCallId: 'tool-call-1',
+			signal: abortController.signal,
+			abortController,
+			tracing,
+		};
+	}
+
+	/** Aborts the run while the pending-row write is in flight. */
+	function abortDuringRowWrite(service: TerminalGuardOrderServiceInternals): AbortController {
+		const abortController = new AbortController();
 		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(async () => {
 			abortController.abort();
 		});
-		const confirmationEvent = {
-			type: 'confirmation-request',
-			runId: 'run-1',
-			agentId: 'orchestrator:run-1',
-			payload: {
-				requestId: 'req-1',
-				toolCallId: 'tool-call-1',
-				toolName: 'ask-user',
-				args: {},
-				severity: 'info',
-				message: 'Set up the slack channel',
-			},
-		} as unknown as Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
-		mockClaimedResumeResult({
-			status: 'suspended',
-			agentRunId: 'agent-run-1',
-			text: Promise.resolve(''),
-			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
-			suspension: {
-				toolCallId: 'tool-call-1',
-				requestId: 'req-1',
-				toolName: 'ask-user',
-				suspendPayload: { requestId: 'req-1', message: 'Set up the slack channel' },
-			},
-			confirmationEvent,
-		});
+		return abortController;
+	}
 
-		await service.processResumedStream(
-			{},
-			{},
-			{
-				runId: 'run-1',
-				agentRunId: 'agent-run-1',
-				threadId: 'thread-a',
-				user: fakeUser,
-				toolCallId: 'tool-call-1',
-				signal: abortController.signal,
-				abortController,
-				tracing,
-			},
-		);
-
-		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', confirmationEvent);
-		expect(service.tracing.finalizeRunTracing).not.toHaveBeenCalledWith(
-			'run-1',
-			tracing,
-			expect.objectContaining({ status: 'suspended' }),
-		);
-	});
-
-	it('does not publish the confirmation card when the initial run is cancelled during the row write', async () => {
-		const service = createTerminalGuardOrderService();
-		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
-		// The smallest executeRun surface: no tracing, no attachments, no handoff.
+	/** The smallest executeRun surface: no tracing, no attachments, no handoff. */
+	function stubInitialRunSurface(service: TerminalGuardOrderServiceInternals): void {
 		Object.assign(service, {
 			resolveContextAttachments: vi.fn(async () => []),
 			createProxyRunConfig: vi.fn(async () => ({})),
@@ -3522,44 +3447,109 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			domainAccessTrackersByThread: new Map(),
 		});
 		vi.mocked(createInstanceAiTraceContext).mockResolvedValueOnce(undefined);
-		const abortController = new AbortController();
-		// cancelRun aborts the suspended run while the row write is in flight.
-		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(async () => {
-			abortController.abort();
-		});
-		const confirmationEvent = {
-			type: 'confirmation-request',
-			runId: 'run-1',
-			agentId: 'orchestrator:run-1',
-			payload: {
-				requestId: 'req-1',
-				toolCallId: 'tool-call-1',
-				toolName: 'ask-user',
-				args: {},
-				severity: 'info',
-				message: 'Set up the slack channel',
-			},
-		} as unknown as Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
-		vi.mocked(streamAgentRun).mockResolvedValueOnce({
-			status: 'suspended',
-			agentRunId: 'agent-run-1',
-			text: Promise.resolve(''),
-			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
-			suspension: {
-				toolCallId: 'tool-call-1',
-				requestId: 'req-1',
-				toolName: 'ask-user',
-				suspendPayload: { requestId: 'req-1', message: 'Set up the slack channel' },
-			},
-			confirmationEvent,
-		});
+	}
+
+	it('writes the pending row before it publishes the confirmation card', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		let releaseRow: () => void = () => {};
+		service.suspendedThreads.persistPendingConfirmation.mockImplementationOnce(
+			async () =>
+				await new Promise<void>((resolve) => {
+					releaseRow = resolve;
+				}),
+		);
+		mockClaimedResumeResult(suspendedWithCard());
+
+		const resumed = service.processResumedStream(
+			{},
+			{},
+			resumeOpts(new AbortController(), cardTracing()),
+		);
+		await vi.waitFor(() =>
+			expect(service.suspendedThreads.persistPendingConfirmation).toHaveBeenCalled(),
+		);
+		// The row write is still in flight: a client that reconnects now must not
+		// be able to read the card from the log, or it settles the card as expired.
+		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', CARD_EVENT);
+
+		releaseRow();
+		await resumed;
+		expect(service.eventBus.publish).toHaveBeenCalledWith('thread-a', CARD_EVENT);
+	});
+
+	it('does not publish the confirmation card when the run is cancelled during the row write', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		const tracing = cardTracing();
+		// cancelRun already published run-finish and dropped the row.
+		const abortController = abortDuringRowWrite(service);
+		mockClaimedResumeResult(suspendedWithCard());
+
+		await service.processResumedStream({}, {}, resumeOpts(abortController, tracing));
+
+		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', CARD_EVENT);
+		expect(service.tracing.finalizeRunTracing).not.toHaveBeenCalledWith(
+			'run-1',
+			tracing,
+			expect.objectContaining({ status: 'suspended' }),
+		);
+	});
+
+	it('publishes the confirmation card when shutdown aborts the run during the row write', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		const tracing = cardTracing();
+		// shutdown keeps the row and the checkpoint, so the card must still go out.
+		service.preserveHitlOnShutdown.add('run-1');
+		const abortController = abortDuringRowWrite(service);
+		mockClaimedResumeResult(suspendedWithCard());
+
+		await service.processResumedStream({}, {}, resumeOpts(abortController, tracing));
+
+		expect(service.eventBus.publish).toHaveBeenCalledWith('thread-a', CARD_EVENT);
+		expect(service.tracing.finalizeRunTracing).toHaveBeenCalledWith(
+			'run-1',
+			tracing,
+			expect.objectContaining({ status: 'suspended' }),
+		);
+	});
+
+	it('does not publish the confirmation card when the initial run is cancelled during the row write', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		stubInitialRunSurface(service);
+		// cancelRun already published run-finish and dropped the row.
+		const abortController = abortDuringRowWrite(service);
+		vi.mocked(streamAgentRun).mockResolvedValueOnce(suspendedWithCard());
 
 		await service.executeRun(fakeUser, 'thread-a', 'run-1', 'Set up slack', abortController);
 
 		// The run did suspend; the abort landed after that, not before the stream.
 		expect(service.runState.suspendRun).toHaveBeenCalled();
-		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', confirmationEvent);
+		expect(service.eventBus.publish).not.toHaveBeenCalledWith('thread-a', CARD_EVENT);
 		expect(service.tracing.finalizeRunTracing).not.toHaveBeenCalledWith(
+			'run-1',
+			undefined,
+			expect.objectContaining({ status: 'suspended' }),
+		);
+	});
+
+	it('publishes the confirmation card when shutdown aborts the initial run during the row write', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		stubInitialRunSurface(service);
+		// shutdown keeps the row and the checkpoint, so the card must still go out.
+		service.preserveHitlOnShutdown.add('run-1');
+		const abortController = abortDuringRowWrite(service);
+		vi.mocked(streamAgentRun).mockResolvedValueOnce(suspendedWithCard());
+
+		await service.executeRun(fakeUser, 'thread-a', 'run-1', 'Set up slack', abortController);
+
+		// The run did suspend; the abort landed after that, not before the stream.
+		expect(service.runState.suspendRun).toHaveBeenCalled();
+		expect(service.eventBus.publish).toHaveBeenCalledWith('thread-a', CARD_EVENT);
+		expect(service.tracing.finalizeRunTracing).toHaveBeenCalledWith(
 			'run-1',
 			undefined,
 			expect.objectContaining({ status: 'suspended' }),

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -492,9 +492,11 @@ export class InstanceAiMemoryService {
 	}
 
 	/** Cross-check every confirmation card against `instance_ai_pending_confirmations`
-	 *  and flip `confirmation.expired = true` on the ones with no live row. */
-	private async flagExpiredConfirmations(
-		messages: Awaited<ReturnType<typeof parseStoredMessages>>,
+	 *  and flip `confirmation.expired = true` on the ones with no live row. Shared
+	 *  by the history read and the SSE run-sync frame so both render a settled
+	 *  card the same way. */
+	async flagExpiredConfirmations(
+		messages: Parameters<typeof markExpiredConfirmations>[0],
 	): Promise<void> {
 		const requestIds = collectConfirmationRequestIds(messages);
 		if (requestIds.length === 0) return;

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -377,7 +377,7 @@ export class InstanceAiController {
 		//     message group. Each frame uses a named SSE event type
 		//     (event: run-sync) with NO id: field so the browser's lastEventId is
 		//     unaffected and the replay cursor stays consistent.
-		const writeRunSyncFrame = (
+		const writeRunSyncFrame = async (
 			groupId: string,
 			group: { runIds: string[]; status: 'active' | 'suspended' | 'background' },
 			runEvents: InstanceAiEvent[],
@@ -385,6 +385,12 @@ export class InstanceAiController {
 			if (runEvents.length === 0) return;
 
 			const agentTree = buildAgentTreeFromEvents(runEvents);
+			// The fold records that a confirmation was requested, not that it was
+			// answered. Settle cards whose pending row is gone (same check as the
+			// history read); otherwise a client that reconnects mid-run re-arms a
+			// card the server already consumed, and every click on it fails.
+			await this.memoryService.flagExpiredConfirmations([{ agentTree }]);
+			if (closed) return;
 			res.write(
 				`event: run-sync\ndata: ${JSON.stringify({
 					runId: group.runIds.at(-1),
@@ -439,7 +445,7 @@ export class InstanceAiController {
 			for (const [groupId, group] of liveGroups) {
 				const runEvents = await this.eventLog.getEventsForRuns(threadId, group.runIds);
 				if (closed) return;
-				writeRunSyncFrame(groupId, group, runEvents);
+				await writeRunSyncFrame(groupId, group, runEvents);
 				for (const event of runEvents) {
 					if (event.type === 'text-block' || event.type === 'reasoning-block') {
 						foldedBlockKeys.add(blockKey(event));

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -4196,7 +4196,9 @@ export class InstanceAiService {
 						plannedBuild,
 						runHandoff: runControl.state,
 					});
-					void this.suspendedThreads.persistPendingConfirmation({
+					// Awaited: the card event is published below, and a client that reconnects
+					// settles any card whose row is missing (run-sync frame + history read).
+					await this.suspendedThreads.persistPendingConfirmation({
 						requestId: result.suspension.requestId,
 						threadId,
 						userId: user.id,
@@ -5438,7 +5440,9 @@ export class InstanceAiService {
 						plannedBuild: opts.plannedBuild,
 						runHandoff: runControl.state,
 					});
-					void this.suspendedThreads.persistPendingConfirmation({
+					// Awaited: the card event is published below, and a client that reconnects
+					// settles any card whose row is missing (run-sync frame + history read).
+					await this.suspendedThreads.persistPendingConfirmation({
 						requestId: result.suspension.requestId,
 						threadId: opts.threadId,
 						userId: opts.user.id,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -801,7 +801,8 @@ export class InstanceAiService {
 	/**
 	 * Run IDs whose post-stream terminal handling should be skipped when their
 	 * abort fires. Populated by `shutdown()` for runs that were sitting on an
-	 * inline HITL confirmation, and drained by `shouldPreserveHitlOnShutdown(runId)`.
+	 * inline HITL confirmation and for suspended runs, and drained by
+	 * `shouldPreserveHitlOnShutdown(runId)`.
 	 */
 	private readonly preserveHitlOnShutdown = new Set<string>();
 
@@ -1951,11 +1952,14 @@ export class InstanceAiService {
 			// Suspended runs are recoverable from the checkpoint store + pending
 			// confirmation index, so leave the run-finish unpublished and the
 			// snapshot untouched. We only need to abort the in-process stream;
-			// the DB rows are intentionally preserved across restart.
+			// the DB rows are intentionally preserved across restart. The flag
+			// keeps the card publish alive if the abort lands before the card
+			// reaches the log.
 			await this.tracing.finalizeRunTracing(run.runId, run.tracing, {
 				status: 'cancelled',
 				reason: 'service_shutdown',
 			});
+			this.preserveHitlOnShutdown.add(run.runId);
 			run.abortController.abort();
 		}
 		for (const task of this.backgroundTasks.cancelAll()) {
@@ -4255,9 +4259,11 @@ export class InstanceAiService {
 					return;
 				}
 
-				// The awaits above yield to cancelRun. It already published run-finish
-				// and dropped the pending row, so a card published now cannot be answered.
-				if (signal.aborted) return;
+				// The awaits above yield to cancelRun and shutdown. cancelRun already
+				// published run-finish and dropped the pending row, so a card published
+				// now cannot be answered. Shutdown keeps both, so the card must still
+				// reach the log.
+				if (signal.aborted && !this.shouldPreserveHitlOnShutdown(runId)) return;
 
 				if (result.confirmationEvent) {
 					this.trackConfirmationRequest(user.id, threadId, result.confirmationEvent);
@@ -5501,9 +5507,11 @@ export class InstanceAiService {
 					return;
 				}
 
-				// The awaits above yield to cancelRun. It already published run-finish
-				// and dropped the pending row, so a card published now cannot be answered.
-				if (opts.signal.aborted) return;
+				// The awaits above yield to cancelRun and shutdown. cancelRun already
+				// published run-finish and dropped the pending row, so a card published
+				// now cannot be answered. Shutdown keeps both, so the card must still
+				// reach the log.
+				if (opts.signal.aborted && !this.shouldPreserveHitlOnShutdown(opts.runId)) return;
 
 				if (result.confirmationEvent) {
 					this.trackConfirmationRequest(opts.user.id, opts.threadId, result.confirmationEvent);

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -4255,6 +4255,10 @@ export class InstanceAiService {
 					return;
 				}
 
+				// The awaits above yield to cancelRun. It already published run-finish
+				// and dropped the pending row, so a card published now cannot be answered.
+				if (signal.aborted) return;
+
 				if (result.confirmationEvent) {
 					this.trackConfirmationRequest(user.id, threadId, result.confirmationEvent);
 					this.eventBus.publish(threadId, result.confirmationEvent);
@@ -5496,6 +5500,10 @@ export class InstanceAiService {
 					});
 					return;
 				}
+
+				// The awaits above yield to cancelRun. It already published run-finish
+				// and dropped the pending row, so a card published now cannot be answered.
+				if (opts.signal.aborted) return;
 
 				if (result.confirmationEvent) {
 					this.trackConfirmationRequest(opts.user.id, opts.threadId, result.confirmationEvent);

--- a/packages/cli/src/modules/instance-ai/message-parser.ts
+++ b/packages/cli/src/modules/instance-ai/message-parser.ts
@@ -393,7 +393,9 @@ function isActionableConfirmation(tc: InstanceAiToolCallState): boolean {
 	);
 }
 
-export function collectConfirmationRequestIds(messages: InstanceAiMessage[]): string[] {
+export function collectConfirmationRequestIds(
+	messages: Array<Pick<InstanceAiMessage, 'agentTree'>>,
+): string[] {
 	const requestIds: string[] = [];
 	for (const message of messages) {
 		if (!message.agentTree) continue;
@@ -415,7 +417,7 @@ export function collectConfirmationRequestIds(messages: InstanceAiMessage[]): st
  * means "resolved", not "expired", so relabeling them would rewrite history.
  */
 export function markExpiredConfirmations(
-	messages: InstanceAiMessage[],
+	messages: Array<Pick<InstanceAiMessage, 'agentTree'>>,
 	liveRequestIds: Set<string>,
 ): void {
 	for (const message of messages) {

--- a/packages/cli/src/modules/instance-ai/suspended-thread-persistence.service.ts
+++ b/packages/cli/src/modules/instance-ai/suspended-thread-persistence.service.ts
@@ -73,8 +73,10 @@ export class SuspendedThreadPersistenceService {
 	/**
 	 * Persist the index for a HITL confirmation so a fresh process can find it
 	 * after the in-memory `pendingConfirmations` / `suspendedRuns` maps are gone.
-	 * Fire-and-forget: a DB write failure must not block the agent flow, which
-	 * still operates correctly via the in-memory state on this main.
+	 * Never throws: a DB write failure must not block the agent flow, which
+	 * still operates correctly via the in-memory state on this main. Callers
+	 * await it before they publish the card, so no client can read the card
+	 * from the log while its row is still missing.
 	 */
 	async persistPendingConfirmation(params: {
 		requestId: string;


### PR DESCRIPTION
## Summary

The AI Assistant showed an approved confirmation card a second time when the user switched conversations and came back while the run was still busy. Clicks on the card failed with "Failed to send confirmation", and the message box stayed blocked until the run finished on its own.

Why: the server records every card it asks, but not the answer. Only the open tab knew the answer, and a conversation switch drops that. On return, the server rebuilt the conversation from its records and sent the card as still open.

Fix: before the server sends a rebuilt conversation, it checks each card against its list of open questions and marks the closed ones as settled. Two smaller fixes cover the same moment:

- The server saves the open question before it shows the card. A client that reconnects in between never sees a card it cannot answer.
- If the user cancels the run during that save, the server skips the card. The run is already over. A server restart also stops the run at that moment, but keeps the question for later, so the card still goes out.

## How to test

1. Ask the AI Assistant for a workflow with a Manual Trigger and a 45-second Wait node, and ask it to run the workflow once.
2. When the "Allow n8n Assistant to execute workflow?" card appears, choose "Always allow during this session".
3. While the workflow runs, open another conversation, then come back through "Chat history".

Before: the card comes back and blocks the message box. A click shows "Failed to send confirmation".
After: the card stays settled and the run finishes normally.

Unit tests: `instance-ai.controller.test.ts` covers the settle check. `instance-ai.service.test.ts` covers the two smaller fixes for a first run and for a resumed run, including the restart case.

Not in this PR:

- A click on an already-answered card still shows the generic "Try again" message.
- With two tabs on one conversation, the second tab does not learn that the first one answered a card.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1391

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

