### PR TITLE
feat(editor): Move Agent AI action to top bar

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7988,6 +7988,7 @@
 	"agents.builder.header.switcher.ariaLabel": "Switch agent",
 	"agents.builder.header.saving": "Saving…",
 	"agents.builder.header.saved": "Saved",
+	"agents.builder.header.editWithAi": "Edit with n8n AI",
 	"agents.builder.preview.button": "Preview",
 	"agents.builder.preview.disabledTooltip": "This agent's configuration has errors. Resolve them before previewing.",
 	"agents.builder.preview.layout.fullpage": "Full screen",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
@@ -34,18 +34,12 @@ vi.mock('vue-router', () => ({
 }));
 
 vi.mock('@n8n/design-system', () => ({
+	N8nAssistantIcon: { template: '<i data-testid="stub-assistant-icon"></i>', props: ['size'] },
 	N8nIcon: { template: '<i v-bind="$attrs"></i>', props: ['icon', 'size'] },
 	N8nButton: {
 		template:
 			'<component :is="href ? \'a\' : \'button\'" v-bind="$attrs" :href="href" :data-variant="variant" :data-icon="icon" :disabled="!href && disabled" :aria-disabled="disabled || undefined" @click="$emit(\'click\', $event)"><slot /></component>',
 		props: ['variant', 'size', 'icon', 'iconOnly', 'disabled', 'href'],
-		emits: ['click'],
-	},
-	N8nToggle: {
-		name: 'N8nToggle',
-		template:
-			'<button v-bind="$attrs" :data-variant="variant" :data-icon="icon" :disabled="disabled" :aria-label="label" :aria-pressed="modelValue" @click="$emit(\'click\', $event)" />',
-		props: ['modelValue', 'variant', 'size', 'icon', 'label', 'disabled'],
 		emits: ['click'],
 	},
 	N8nDropdownMenuItem: {
@@ -135,6 +129,7 @@ function mountHeader(
 		mode: 'edit' | 'preview';
 		artifactMode: boolean;
 		isPreviewOpen: boolean;
+		instanceAiAvailable: boolean;
 		currentSessionTitle: string;
 		sessionOptions: Array<{ id: string; label: string }>;
 		configValidationStatus: 'valid' | 'invalid' | null;
@@ -151,6 +146,7 @@ function mountHeader(
 			mode: overrides.mode,
 			artifactMode: overrides.artifactMode,
 			isPreviewOpen: overrides.isPreviewOpen,
+			instanceAiAvailable: overrides.instanceAiAvailable,
 			currentSessionTitle: overrides.currentSessionTitle,
 			sessionOptions: overrides.sessionOptions,
 			configValidationStatus: overrides.configValidationStatus,
@@ -166,6 +162,38 @@ describe('AgentBuilderHeader', () => {
 		routerPush.mockReset();
 		routerResolve.mockClear();
 		agentsListRef.value = null;
+	});
+
+	it('shows the Instance AI action when it is available', async () => {
+		const wrapper = mountHeader({ instanceAiAvailable: true });
+		const button = wrapper.get('[data-testid="agent-builder-instance-ai-btn"]');
+
+		expect(button.attributes('aria-label')).toBe('agents.builder.header.editWithAi');
+		expect(wrapper.get('[data-testid="stub-tooltip"]').attributes('data-content')).toBe(
+			'agents.builder.header.editWithAi',
+		);
+
+		await button.trigger('click');
+
+		expect(wrapper.emitted('open-instance-ai')).toEqual([[]]);
+	});
+
+	it.each([
+		{ label: 'Instance AI is unavailable', instanceAiAvailable: false },
+		{ label: 'preview is open', instanceAiAvailable: true, isPreviewOpen: true },
+		{ label: 'artifact mode is active', instanceAiAvailable: true, artifactMode: true },
+	])('hides the Instance AI action when $label', (overrides) => {
+		const wrapper = mountHeader(overrides);
+
+		expect(wrapper.find('[data-testid="agent-builder-instance-ai-btn"]').exists()).toBe(false);
+	});
+
+	it('disables the Instance AI action when no agent is loaded', () => {
+		const wrapper = mountHeader({ agent: null, instanceAiAvailable: true });
+
+		expect(
+			wrapper.get('[data-testid="agent-builder-instance-ai-btn"]').attributes('disabled'),
+		).toBeDefined();
 	});
 
 	it('renders breadcrumbs, publish and action dropdown', () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
@@ -42,6 +42,12 @@ vi.mock('@n8n/design-system', () => ({
 		props: ['variant', 'size', 'icon', 'iconOnly', 'disabled', 'href'],
 		emits: ['click'],
 	},
+	N8nToggle: {
+		template:
+			'<button v-bind="$attrs" :data-icon="icon" :disabled="disabled" :aria-label="label" :aria-pressed="modelValue" @click="$emit(\'click\', $event)" />',
+		props: ['modelValue', 'variant', 'size', 'icon', 'label', 'disabled'],
+		emits: ['click'],
+	},
 	N8nDropdownMenuItem: {
 		name: 'N8nDropdownMenuItem',
 		template: '<button :data-testid="testId" @click="$emit(\'select\', id)">{{ label }}</button>',
@@ -138,7 +144,7 @@ function mountHeader(
 ) {
 	return mount(AgentBuilderHeader, {
 		props: {
-			agent: overrides.agent ?? baseAgent,
+			agent: 'agent' in overrides ? (overrides.agent ?? null) : baseAgent,
 			projectId: 'p1',
 			agentId: 'a1',
 			projectName: 'projectName' in overrides ? (overrides.projectName ?? null) : 'My project',

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -488,7 +488,7 @@ const commonStubs = {
 	AgentBuilderHeader: {
 		name: 'AgentBuilderHeader',
 		template:
-			'<div data-testid="stub-agent-builder-header" :data-project-name="projectName" :data-artifact-mode="String(artifactMode)" :data-config-validation-status="String(configValidationStatus)" :data-save-status="String(saveStatus)"></div>',
+			'<div data-testid="stub-agent-builder-header" :data-project-name="projectName" :data-artifact-mode="String(artifactMode)" :data-instance-ai-available="String(instanceAiAvailable)" :data-config-validation-status="String(configValidationStatus)" :data-save-status="String(saveStatus)"></div>',
 		props: [
 			'agent',
 			'projectId',
@@ -498,6 +498,7 @@ const commonStubs = {
 			'beforeRevertToPublished',
 			'artifactMode',
 			'isPreviewOpen',
+			'instanceAiAvailable',
 			'configValidationStatus',
 			'saveStatus',
 			'beforePublish',
@@ -511,6 +512,7 @@ const commonStubs = {
 			'reverted',
 			'switch-agent',
 			'toggle-version-history',
+			'open-instance-ai',
 		],
 	},
 	AgentPreviewDock: {
@@ -2153,32 +2155,21 @@ describe('AgentBuilderView — three-column shell', () => {
 		expect(wrapper.find('[data-testid="stub-agent-builder-header"]').exists()).toBe(true);
 	});
 
-	it('renders the floating Instance AI button in builder mode', async () => {
+	it('passes Instance AI availability to the header', async () => {
 		const wrapper = await renderView();
-		expect(wrapper.find('[data-testid="agent-builder-instance-ai-btn"]').exists()).toBe(true);
-	});
+		const header = wrapper.findComponent({ name: 'AgentBuilderHeader' });
 
-	it('hides the floating Instance AI button in artifact mode', async () => {
-		const wrapper = await renderView({
-			props: {
-				artifactMode: true,
-				artifactProjectId: 'p2',
-				artifactAgentId: 'a2',
-			},
-		});
+		expect(header.props('instanceAiAvailable')).toBe(true);
 
-		expect(wrapper.find('[data-testid="agent-builder-instance-ai-btn"]').exists()).toBe(false);
-	});
-
-	it('hides the floating Instance AI button when Instance AI is unavailable', async () => {
 		instanceAiAvailableRef.value = false;
-		const wrapper = await renderView();
-		expect(wrapper.find('[data-testid="agent-builder-instance-ai-btn"]').exists()).toBe(false);
+		await nextTick();
+
+		expect(header.props('instanceAiAvailable')).toBe(false);
 	});
 
-	it('opens the agent artifact without sending an opening message', async () => {
+	it('opens the agent artifact from the header without sending an opening message', async () => {
 		const wrapper = await renderView();
-		await wrapper.find('[data-testid="agent-builder-instance-ai-btn"]').trigger('click');
+		wrapper.findComponent({ name: 'AgentBuilderHeader' }).vm.$emit('open-instance-ai');
 		await flushPromises();
 
 		expect(openAgentArtifactThread).toHaveBeenCalledWith(

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
@@ -10,12 +10,13 @@ import { computed, onMounted, useCssModule } from 'vue';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
 import type { AgentConfigValidationIssue } from '@n8n/api-types';
 import {
+	N8nAssistantIcon,
 	N8nBreadcrumbs,
 	N8nButton,
 	N8nDropdownMenu,
 	N8nDropdownMenuItem,
 	N8nIcon,
-	N8nToggle,
+	N8nTooltip,
 } from '@n8n/design-system';
 import type { PathItem } from '@n8n/design-system';
 import type { DropdownMenuItemProps } from '@n8n/design-system';
@@ -39,6 +40,7 @@ const props = defineProps<{
 	beforeRevertToPublished?: () => Promise<void> | void;
 	artifactMode?: boolean;
 	isPreviewOpen?: boolean;
+	instanceAiAvailable?: boolean;
 	/** True while the AI is actively building/mutating this agent in artifact mode — disables publish/revert/unpublish without hiding them. */
 	editingLocked?: boolean;
 	configValidationStatus?: 'valid' | 'invalid' | null;
@@ -55,6 +57,7 @@ const emit = defineEmits<{
 	reverted: [agent: AgentResource];
 	'switch-agent': [agentId: string];
 	'toggle-version-history': [];
+	'open-instance-ai': [];
 }>();
 
 const i18n = useI18n();
@@ -164,6 +167,23 @@ function onMenuSelect(id: string) {
 <template>
 	<header :class="$style.header" data-testid="agent-builder-header">
 		<div :class="$style.left">
+			<N8nTooltip
+				v-if="!props.isPreviewOpen && !props.artifactMode && props.instanceAiAvailable"
+				:content="i18n.baseText('agents.builder.header.editWithAi')"
+			>
+				<N8nButton
+					variant="ghost"
+					size="medium"
+					icon-only
+					:disabled="!props.agent"
+					:aria-label="i18n.baseText('agents.builder.header.editWithAi')"
+					:class="$style.aiButton"
+					data-testid="agent-builder-instance-ai-btn"
+					@click="emit('open-instance-ai')"
+				>
+					<N8nAssistantIcon size="large" />
+				</N8nButton>
+			</N8nTooltip>
 			<N8nBreadcrumbs
 				v-if="!props.artifactMode"
 				:items="breadcrumbItems"
@@ -289,8 +309,8 @@ function onMenuSelect(id: string) {
 .left {
 	display: flex;
 	align-items: center;
-	flex: 0 0 auto;
-	min-width: max-content;
+	flex-shrink: 0;
+	min-width: 0;
 }
 
 .left :global(.n8n-breadcrumbs) {
@@ -319,6 +339,7 @@ function onMenuSelect(id: string) {
 	font-size: var(--font-size--sm);
 	gap: var(--spacing--4xs);
 	flex-shrink: 0;
+	min-width: 0;
 }
 
 .switcherLabel {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
@@ -17,6 +17,7 @@ import {
 	N8nDropdownMenuItem,
 	N8nIcon,
 	N8nTooltip,
+	N8nToggle,
 } from '@n8n/design-system';
 import type { PathItem } from '@n8n/design-system';
 import type { DropdownMenuItemProps } from '@n8n/design-system';

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, nextTick, onBeforeUnmount, useTemplateRef } from 'vue';
 import { useStorage } from '@vueuse/core';
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
-import { N8nAssistantIcon, N8nButton, N8nIcon, type ActionDropdownItem } from '@n8n/design-system';
+import { N8nIcon, type ActionDropdownItem } from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import {
 	MAX_AGENT_FILE_SIZE_BYTES,
@@ -2048,6 +2048,7 @@ function onSwitchAgent(nextAgentId: string) {
 			:config-validation-issues="configValidation?.issues ?? []"
 			:before-publish="refreshValidationBeforePublish"
 			:is-preview-open="isPreviewDockOpen"
+			:instance-ai-available="instanceAiAvailable"
 			@header-action="onHeaderAction"
 			@open-preview="onOpenPreview"
 			@close-preview="closePreviewDock"
@@ -2055,6 +2056,7 @@ function onSwitchAgent(nextAgentId: string) {
 			@unpublished="onUnpublished"
 			@reverted="onReverted"
 			@switch-agent="onSwitchAgent"
+			@open-instance-ai="onOpenInstanceAi"
 		/>
 		<div
 			ref="builderContainer"
@@ -2065,27 +2067,6 @@ function onSwitchAgent(nextAgentId: string) {
 				},
 			]"
 		>
-			<div
-				v-if="!isPreviewActive && !isArtifactMode && instanceAiAvailable"
-				:class="$style.aiButtonWrapper"
-			>
-				<N8nButton
-					variant="subtle"
-					icon-only
-					size="large"
-					:disabled="!agent"
-					:aria-label="locale.baseText('aiAssistant.tooltip')"
-					:class="$style.aiButtonIcon"
-					data-testid="agent-builder-instance-ai-btn"
-					@click="onOpenInstanceAi"
-				>
-					<template #default>
-						<div>
-							<N8nAssistantIcon size="large" />
-						</div>
-					</template>
-				</N8nButton>
-			</div>
 			<div v-if="showBuilderLoading" :class="$style.loading">
 				<N8nIcon icon="spinner" spin />
 			</div>
@@ -2241,26 +2222,5 @@ function onSwitchAgent(nextAgentId: string) {
 .editorColumn {
 	flex: 1 1 auto;
 	min-width: 0;
-}
-
-.aiButtonWrapper {
-	position: absolute;
-	top: 0;
-	right: 0;
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--2xs);
-	padding: var(--spacing--sm);
-	z-index: 1;
-}
-
-.aiButtonIcon {
-	display: inline-flex;
-	justify-content: center;
-	align-items: center;
-
-	svg {
-		display: block;
-	}
 }
 </style>


### PR DESCRIPTION
## Summary

- Move the n8n AI action from the Agent builder canvas to the top bar.
- Place the action to the left of the breadcrumbs.
- Hide the action during preview and artifact modes.
- Add a tooltip and accessible label for the action.

<img width="888" height="256" alt="CleanShot 2026-09-10 at 13 33 38@2x" src="https://github.com/user-attachments/assets/3050c35c-97a1-4518-820b-f542066adbc0" />

## How to test

1. Open an Agent in the Agent builder.
2. Confirm that the n8n AI action appears to the left of the breadcrumbs.
3. Select the action and confirm that the AI panel opens.
4. Open the Agent preview and confirm that the action is hidden.
5. Open artifact mode and confirm that the action is hidden.
6. Test an instance without Instance AI and confirm that the action is hidden.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-814

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

