### PR TITLE
feat(editor): Advertise browser-use recording on the empty AI Assistant screen

### DIFF
--- a/packages/@n8n/telemetry/src/events/instance-ai.ts
+++ b/packages/@n8n/telemetry/src/events/instance-ai.ts
@@ -159,7 +159,7 @@ export const INSTANCE_AI_TELEMETRY = defineTelemetryEvents({
 		description: 'The user opened the Browser Use connection interface.',
 		properties: z.object({
 			browser_supported: z.boolean(),
-			source: z.enum(['input_menu', 'credential_setup', 'tools_modal']),
+			source: z.enum(['input_menu', 'credential_setup', 'tools_modal', 'empty_state_promo']),
 		}),
 	},
 	BROWSER_USE_INSTALL_EXTENSION_CLICKED: {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -6961,6 +6961,8 @@
 	"instanceAi.browserUse.connectLinkError.message": "Could not create a connection link. Please try again.",
 	"instanceAi.browserUse.disconnectError.title": "Browser Use disconnect failed",
 	"instanceAi.browserUse.disconnectError.message": "Failed to disconnect Browser Use",
+	"instanceAi.recordPromo.label": "Not sure how to explain it? Record the steps instead",
+	"instanceAi.recordPromo.startPrompt": "I'm not sure how to describe what I need. Can you record me doing it in my browser instead?",
 	"instanceAi.error.sendFailed": "Failed to send message",
 	"instanceAi.view.reconnecting": "Reconnecting...",
 	"instanceAi.agentTree.subAgent": "Sub-agent",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -77,6 +77,11 @@ import {
 	TEMPLATE_PROMPT_SUFFIX,
 } from '@/experiments/instanceAiTemplateExamples';
 import { InstanceAiFreeNudge } from '@/experiments/instanceAiFreeNudge';
+import InstanceAiRecordPromoPill from './components/InstanceAiRecordPromoPill.vue';
+import { useInstanceAiRecordPromoPill } from './composables/useInstanceAiRecordPromoPill';
+import { useBrowserUseConnection } from './composables/useBrowserUseConnection';
+import { armAutoApproveRecording } from './composables/useAutoApproveRecording';
+import type { ThreadRuntime } from './instanceAi.store';
 
 // Experiment cleanup: remove with instanceAiPromptSuggestionsV2.
 const INSTANCE_AI_PROMPT_SUGGESTIONS_V2_TITLE_KEY: BaseTextKey =
@@ -131,6 +136,8 @@ const i18n = useI18n();
 useDocumentTitle().set(i18n.baseText('instanceAi.view.title'));
 const { goToUpgrade } = usePageRedirectionHelper();
 const creditBanner = useCreditWarningBanner(showCreditWarning);
+const recordPromo = useInstanceAiRecordPromoPill();
+const { ensureConnected: ensureBrowserConnected } = useBrowserUseConnection();
 const { isFeatureEnabled: isProactiveAgentExperimentEnabled } =
 	useInstanceAiProactiveAgentExperiment();
 const { isFeatureEnabled: isPromptSuggestionsV2ExperimentEnabled } =
@@ -465,6 +472,7 @@ async function handleSubmit(
 	message: string,
 	attachments?: InstanceAiAttachment[],
 	restoreDraft?: () => boolean,
+	options?: { onThreadReady?: (thread: ThreadRuntime) => void },
 ) {
 	if (!settingsStore.isWorkflowBuilderAvailable) {
 		return;
@@ -500,6 +508,7 @@ async function handleSubmit(
 	}
 
 	const thread = store.getOrCreateRuntime(threadId, selectedProject.value);
+	options?.onThreadReady?.(thread);
 	// Await admission before navigating. A refused send (e.g. a concurrency cap) must not
 	// drop the user into a blank thread, and handing the draft to the destination view is
 	// not an option: it reads its composer draft from localStorage once, synchronously, on
@@ -549,6 +558,15 @@ async function handleSubmit(
 	void router.replace({
 		name: INSTANCE_AI_THREAD_VIEW,
 		params: { threadId },
+	});
+}
+
+async function handleRecordPromoClick() {
+	const connected = await ensureBrowserConnected('empty_state_promo');
+	if (!connected) return;
+
+	await handleSubmit(i18n.baseText('instanceAi.recordPromo.startPrompt'), undefined, undefined, {
+		onThreadReady: armAutoApproveRecording,
 	});
 }
 
@@ -659,6 +677,11 @@ function handleShelfSuggestionInsert(payload: {
 							!creditBanner.visible.value &&
 							settingsStore.isWorkflowBuilderAvailable
 						"
+					/>
+					<InstanceAiRecordPromoPill
+						:eligible="recordPromo.isEligible.value"
+						@click="handleRecordPromoClick"
+						@dismiss="recordPromo.dismiss"
 					/>
 					<CreditWarningBanner
 						v-if="creditBanner.visible.value"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -33,6 +33,8 @@ const {
 	appSettingsStoreMock,
 	replaceMock,
 	showErrorMock,
+	browserUseFeatureEnabled,
+	ensureBrowserConnectedMock,
 	templateExamplesStoreMock,
 	templateExamplesEnabled,
 	telemetryTrack,
@@ -105,6 +107,8 @@ const {
 	replaceMock: vi.fn(),
 	showErrorMock: vi.fn(),
 	telemetryTrack: vi.fn(),
+	browserUseFeatureEnabled: { value: false },
+	ensureBrowserConnectedMock: vi.fn(),
 }));
 
 vi.mock('@/experiments/instanceAiProactiveAgent', () => ({
@@ -286,6 +290,14 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore: () => ({ pushRef: 'test-push-ref' }),
 }));
 
+vi.mock('@/experiments/instanceAiBrowserUse', () => ({
+	useInstanceAiBrowserUseExperiment: () => ({ isFeatureEnabled: browserUseFeatureEnabled }),
+}));
+
+vi.mock('../composables/useBrowserUseConnection', () => ({
+	useBrowserUseConnection: () => ({ ensureConnected: ensureBrowserConnectedMock }),
+}));
+
 vi.mock('uuid', () => ({
 	v4: () => 'thread-placeholder',
 }));
@@ -398,6 +410,26 @@ const InstanceAiFreeNudgeStub = defineComponent({
 	},
 });
 
+const InstanceAiRecordPromoPillStub = defineComponent({
+	name: 'InstanceAiRecordPromoPillStub',
+	props: {
+		eligible: { type: Boolean, required: true },
+	},
+	emits: ['click', 'dismiss'],
+	setup(props, { emit }) {
+		return () =>
+			h(
+				'button',
+				{
+					'data-test-id': 'instance-ai-record-promo-stub',
+					'data-eligible': String(props.eligible),
+					onClick: () => emit('click'),
+				},
+				'record',
+			);
+	},
+});
+
 const renderView = createComponentRenderer(InstanceAiEmptyView, {
 	global: {
 		provide: {
@@ -406,6 +438,7 @@ const renderView = createComponentRenderer(InstanceAiEmptyView, {
 		stubs: {
 			InstanceAiInput: InstanceAiInputStub,
 			InstanceAiFreeNudge: InstanceAiFreeNudgeStub,
+			InstanceAiRecordPromoPill: InstanceAiRecordPromoPillStub,
 		},
 	},
 });
@@ -454,6 +487,9 @@ describe('InstanceAiEmptyView', () => {
 			amendContext: null,
 			contextualSuggestion: null,
 			sendMessage: vi.fn().mockResolvedValue(true),
+			pendingConfirmations: ref([]),
+			resolveConfirmation: vi.fn(),
+			confirmAction: vi.fn().mockResolvedValue(true),
 		} as unknown as ThreadRuntime;
 		store.getOrCreateRuntime.mockReturnValue(thread);
 		store.deleteThread.mockResolvedValue(true);
@@ -474,6 +510,8 @@ describe('InstanceAiEmptyView', () => {
 		appSettingsStoreMock.isCloudDeployment = false;
 		templateExamplesStoreMock.hasLoadFailed = false;
 		templateExamplesEnabled.value = false;
+		browserUseFeatureEnabled.value = false;
+		ensureBrowserConnectedMock.mockReset();
 	});
 
 	afterEach(() => {
@@ -1070,5 +1108,62 @@ describe('InstanceAiEmptyView', () => {
 		expect(getByTestId('instance-ai-input-text')).toHaveTextContent(
 			'Build me an invoice automation',
 		);
+	});
+
+	describe('record promo pill', () => {
+		it('is eligible only when the browser-use experiment is enabled', () => {
+			browserUseFeatureEnabled.value = false;
+			expect(renderView().getByTestId('instance-ai-record-promo-stub')).toHaveAttribute(
+				'data-eligible',
+				'false',
+			);
+		});
+
+		it('creates no thread when the extension connect flow is declined', async () => {
+			browserUseFeatureEnabled.value = true;
+			ensureBrowserConnectedMock.mockResolvedValue(false);
+			const { getByTestId } = renderView();
+
+			expect(getByTestId('instance-ai-record-promo-stub')).toHaveAttribute('data-eligible', 'true');
+
+			await fireEvent.click(getByTestId('instance-ai-record-promo-stub'));
+			await flushPromises();
+
+			expect(ensureBrowserConnectedMock).toHaveBeenCalledWith('empty_state_promo');
+			expect(store.syncThread).not.toHaveBeenCalled();
+			expect(thread.sendMessage).not.toHaveBeenCalled();
+		});
+
+		it('starts a thread with the canned prompt once connected, and arms auto-approve', async () => {
+			browserUseFeatureEnabled.value = true;
+			ensureBrowserConnectedMock.mockResolvedValue(true);
+			store.syncThread.mockResolvedValue(undefined);
+			const { getByTestId } = renderView();
+
+			await fireEvent.click(getByTestId('instance-ai-record-promo-stub'));
+			await flushPromises();
+
+			expect(thread.sendMessage).toHaveBeenCalledWith(
+				"I'm not sure how to describe what I need. Can you record me doing it in my browser instead?",
+				undefined,
+				'test-push-ref',
+			);
+
+			(thread.pendingConfirmations as unknown as { value: unknown[] }).value = [
+				{
+					toolCall: {
+						toolName: 'start-browser-recording',
+						confirmation: { requestId: 'req-1', inputType: 'continue' },
+					},
+				},
+			];
+			await flushPromises();
+
+			expect(thread.resolveConfirmation).toHaveBeenCalledWith('req-1', 'approved');
+			expect(thread.confirmAction).toHaveBeenCalledWith('req-1', {
+				kind: 'approval',
+				approved: true,
+			});
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiRecordPromoPill.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiRecordPromoPill.vue
@@ -1,0 +1,81 @@
+<script lang="ts" setup>
+import { N8nIcon, N8nIconButton, N8nText } from '@n8n/design-system';
+import { useI18n } from '@n8n/i18n';
+
+const emit = defineEmits<{ click: []; dismiss: [] }>();
+
+defineProps<{
+	eligible: boolean;
+}>();
+
+const i18n = useI18n();
+</script>
+
+<template>
+	<div v-if="eligible" :class="$style.pill" data-test-id="instance-ai-record-promo">
+		<button type="button" :class="$style.body" @click="emit('click')">
+			<N8nIcon icon="video" :class="$style.icon" />
+			<N8nText size="small" :class="$style.copy">{{
+				i18n.baseText('instanceAi.recordPromo.label')
+			}}</N8nText>
+		</button>
+		<N8nIconButton
+			icon="x"
+			variant="ghost"
+			size="xsmall"
+			:aria-label="i18n.baseText('generic.dismiss')"
+			:class="$style.dismiss"
+			style="--button--radius: var(--radius--full)"
+			data-test-id="instance-ai-record-promo-dismiss"
+			@click="emit('dismiss')"
+		/>
+	</div>
+</template>
+
+<style lang="scss" module>
+.pill {
+	display: inline-flex;
+	align-self: center;
+	align-items: center;
+	gap: var(--spacing--2xs);
+	padding: var(--spacing--4xs);
+	padding-left: var(--spacing--2xs);
+	background: var(--background--info);
+	border: 1px solid var(--border-color--info);
+	border-radius: var(--radius--full);
+	white-space: nowrap;
+}
+
+.body {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	font: inherit;
+}
+
+.icon {
+	color: var(--icon-color--info);
+}
+
+.copy {
+	color: var(--text-color--info);
+}
+
+.dismiss {
+	--button--color: var(--icon-color--info);
+	--button--color--background-hover: color-mix(
+		in srgb,
+		var(--background--info),
+		var(--text-color--info) 10%
+	);
+	--button--color--background-active: color-mix(
+		in srgb,
+		var(--background--info),
+		var(--text-color--info) 15%
+	);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/__tests__/useAutoApproveRecording.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/__tests__/useAutoApproveRecording.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import type { PendingConfirmationItem, ThreadRuntime } from '../../instanceAi.store';
+import { armAutoApproveRecording } from '../useAutoApproveRecording';
+
+function buildItem(toolName: string, inputType: string | undefined, requestId: string) {
+	return {
+		toolCall: {
+			toolName,
+			confirmation: { requestId, inputType },
+		},
+	} as unknown as PendingConfirmationItem;
+}
+
+function buildThread(pendingConfirmations: ReturnType<typeof ref<PendingConfirmationItem[]>>) {
+	return {
+		pendingConfirmations,
+		resolveConfirmation: vi.fn(),
+		confirmAction: vi.fn().mockResolvedValue(true),
+	} as unknown as ThreadRuntime;
+}
+
+describe('armAutoApproveRecording', () => {
+	it('auto-approves the start-browser-recording continue confirmation once it appears', async () => {
+		const pendingConfirmations = ref<PendingConfirmationItem[]>([]);
+		const thread = buildThread(pendingConfirmations);
+
+		armAutoApproveRecording(thread);
+		pendingConfirmations.value = [buildItem('start-browser-recording', 'continue', 'req-1')];
+		await Promise.resolve();
+
+		expect(thread.resolveConfirmation).toHaveBeenCalledWith('req-1', 'approved');
+		expect(thread.confirmAction).toHaveBeenCalledWith('req-1', {
+			kind: 'approval',
+			approved: true,
+		});
+	});
+
+	it('ignores confirmations for other tools', async () => {
+		const pendingConfirmations = ref<PendingConfirmationItem[]>([]);
+		const thread = buildThread(pendingConfirmations);
+
+		armAutoApproveRecording(thread);
+		pendingConfirmations.value = [buildItem('submit-workflow', 'continue', 'req-2')];
+		await Promise.resolve();
+
+		expect(thread.resolveConfirmation).not.toHaveBeenCalled();
+		expect(thread.confirmAction).not.toHaveBeenCalled();
+	});
+
+	it('only fires once even if the confirmation list updates again', async () => {
+		const pendingConfirmations = ref<PendingConfirmationItem[]>([]);
+		const thread = buildThread(pendingConfirmations);
+
+		armAutoApproveRecording(thread);
+		pendingConfirmations.value = [buildItem('start-browser-recording', 'continue', 'req-3')];
+		await Promise.resolve();
+		pendingConfirmations.value = [
+			buildItem('start-browser-recording', 'continue', 'req-3'),
+			buildItem('start-browser-recording', 'continue', 'req-4'),
+		];
+		await Promise.resolve();
+
+		expect(thread.confirmAction).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useAutoApproveRecording.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useAutoApproveRecording.ts
@@ -1,0 +1,45 @@
+import { watch } from 'vue';
+
+import type { ThreadRuntime } from '../instanceAi.store';
+
+/** The backend's `DOMAIN_TOOL_IDS.START_BROWSER_RECORDING` (packages/@n8n/instance-ai). */
+const START_BROWSER_RECORDING_TOOL_ID = 'start-browser-recording';
+
+/** Give up quietly if the agent never proposes recording (e.g. it asks a question first). */
+const AUTO_APPROVE_TIMEOUT_MS = 20_000;
+
+/**
+ * Auto-clicks the agent's "Start recording" confirmation the moment it appears on this
+ * thread — the same two calls `InstanceAiConfirmationPanel.vue`'s `handleContinue` makes.
+ *
+ * Scoped to a single thread and a single fire: this must never become a generic auto-allow
+ * for `inputType: 'continue'` confirmations elsewhere, since that suspend exists specifically
+ * because starting a recording captures the user's screen.
+ */
+export function armAutoApproveRecording(thread: ThreadRuntime): void {
+	let settled = false;
+	const stop = watch(
+		thread.pendingConfirmations,
+		(items) => {
+			const item = items.find(
+				(candidate) =>
+					candidate.toolCall.toolName === START_BROWSER_RECORDING_TOOL_ID &&
+					candidate.toolCall.confirmation.inputType === 'continue',
+			);
+			if (!item || settled) return;
+
+			settled = true;
+			stop();
+			thread.resolveConfirmation(item.toolCall.confirmation.requestId, 'approved');
+			void thread.confirmAction(item.toolCall.confirmation.requestId, {
+				kind: 'approval',
+				approved: true,
+			});
+		},
+		{ immediate: true },
+	);
+
+	setTimeout(() => {
+		if (!settled) stop();
+	}, AUTO_APPROVE_TIMEOUT_MS);
+}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiRecordPromoPill.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiRecordPromoPill.ts
@@ -1,0 +1,34 @@
+import { computed } from 'vue';
+import { useStorage } from '@n8n/composables/useStorage';
+
+import { useInstanceAiBrowserUseExperiment } from '@/experiments/instanceAiBrowserUse';
+import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
+
+const DISMISSED_STORAGE_KEY = 'N8N_INSTANCE_AI_RECORD_PROMO_DISMISSED';
+
+/**
+ * Eligibility and dismissal for the "record instead of typing" promo pill.
+ * No PostHog variant here (unlike Free Nudge) — this ships to everyone who
+ * already qualifies for Browser Use, gated the same way the "+" input menu
+ * decides whether to offer its browser item.
+ */
+export function useInstanceAiRecordPromoPill() {
+	const settingsStore = useInstanceAiSettingsStore();
+	const { isFeatureEnabled } = useInstanceAiBrowserUseExperiment();
+	const dismissedStorage = useStorage(DISMISSED_STORAGE_KEY);
+
+	const isDismissed = computed(() => dismissedStorage.value === 'true');
+	const isEligible = computed(
+		() =>
+			isFeatureEnabled.value &&
+			settingsStore.isBrowserUseEnabledByAdmin &&
+			settingsStore.isWorkflowBuilderAvailable &&
+			!isDismissed.value,
+	);
+
+	function dismiss() {
+		dismissedStorage.value = 'true';
+	}
+
+	return { isEligible, isDismissed, dismiss };
+}


### PR DESCRIPTION
## Summary

Adds a dismissible pill above the AI Assistant input on the empty
conversation screen, next to the existing "Free nudge" pill. It
targets users who struggle to describe their automation in words and
invites them to record themselves doing it instead.

Clicking the pill:
- Checks whether the Browser Use extension is connected.
- If not connected, opens the existing "Connect Browser Use" flow.
- If connected, starts a new thread with a canned prompt and
  auto-approves the agent's resulting "Start recording" confirmation,
  so recording starts with no second click.

Dismissing the pill persists in `localStorage` and never shows again
in that browser.

## How to test

1. Run this branch's editor (`pnpm dev:be` + `pnpm dev:fe:editor`, or
   the built `n8n-editor-ui` served by `pnpm dev:be`).
2. This pill is gated behind the `090_instance_ai_browser_use` PostHog
   experiment and the `browserUseEnabled` admin setting (on by
   default). To force the experiment on locally, open the browser
   console on the running instance and run:
   `window.featureFlags.override('090_instance_ai_browser_use', 'variant')`,
   then reload.
3. Open the AI Assistant from an empty conversation.
4. Confirm the pill "Not sure how to explain it? Record the steps
   instead" appears above the input.
5. Click its × button. Reload the page. Confirm the pill stays
   hidden. Clear the `N8N_INSTANCE_AI_RECORD_PROMO_DISMISSED`
   `localStorage` key to bring it back.
6. With the Browser Use extension not connected, click the pill
   body. Confirm it opens the "Connect Browser Use" modal, and that
   backing out of it starts no thread.
7. With the extension connected, click the pill body. Confirm it
   starts a new thread and the agent's "Start recording" confirmation
   auto-approves without a second click.

Step 7 (the connected path) needs a real Browser Use extension
connection and a live agent turn to confirm end to end — I could not
verify that part myself in this session (no Anthropic API key, and no
way to side-load the extension's own install dialog through browser
automation). The auto-approve logic itself is covered by
`useAutoApproveRecording.test.ts` and the connected-click case in
`InstanceAiEmptyView.test.ts`. Flagging this explicitly for whoever
reviews/tests this PR.

## Related Linear tickets, Github issues, and Community forum posts

None — hackweek exploration, no Linear ticket.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

