### PR TITLE
fix(core): Clarify agent delegation and status checks (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/background/agent-wake.service.ts
+++ b/packages/cli/src/modules/agents/background/agent-wake.service.ts
@@ -120,7 +120,7 @@ export class AgentWakeService {
 				return `${JSON.stringify(title)} (${job.status})`;
 			})
 			.join(', ');
-		return `${AGENT_BACKGROUND_UPDATES_OPEN_TAG}${jobs.length} background job(s) settled: ${summaries}. Call check_background_jobs before you finish this turn.${AGENT_BACKGROUND_UPDATES_CLOSE_TAG}`;
+		return `${AGENT_BACKGROUND_UPDATES_OPEN_TAG}${jobs.length} background job(s) settled: ${summaries}. Call check_background_jobs once before you finish this turn, only if you have not already checked in this turn. Collect all relevant jobs in that call.${AGENT_BACKGROUND_UPDATES_CLOSE_TAG}`;
 	}
 
 	private scheduleLocal(threadId: string): void {

--- a/packages/cli/src/modules/agents/background/background-job-tools.ts
+++ b/packages/cli/src/modules/agents/background/background-job-tools.ts
@@ -51,16 +51,29 @@ export function createSpawnBackgroundSubAgentTool(options: BackgroundJobToolsOpt
 	return new Tool('spawn_background_subagent')
 		.description(
 			'Dispatch a sub-agent as a detached background job. Returns a receipt immediately; the ' +
-				'sub-agent keeps working after your turn ends. Pass "inline" as subAgentId to spawn a ' +
+				'sub-agent keeps working after your turn ends. Use delegate_subagent in the foreground by ' +
+				'default. Use background mode for clear parallel work, a clearly long task, or an ' +
+				'explicit user request for background mode. Pass "inline" as subAgentId to spawn a ' +
 				'copy of yourself for a self-contained subtask.' +
 				(roster ? ` Available configured sub-agents:\n${roster}` : ''),
 		)
 		.systemInstruction(
-			'Prefer spawn_background_subagent for independent pieces of work that can run in parallel ' +
-				'while you continue. After spawning, either continue with non-overlapping work or end ' +
-				'your turn telling the user that work continues in the background — never poll ' +
-				'check_background_jobs in a loop waiting for jobs to finish; check once in a later turn ' +
-				'instead. The final answer is the contract; never expect the full trace. Instruct ' +
+			'When delegation is appropriate, use delegate_subagent in the foreground by default. ' +
+				'Use spawn_background_subagent when independent work benefits from parallel execution, ' +
+				'when the task will clearly take substantial time, or when the user explicitly requests ' +
+				'background mode. If any of these conditions applies, choose spawn_background_subagent ' +
+				'instead of delegate_subagent. For example, run independent research workstreams as ' +
+				'separate background jobs, even when you need all their results for the final synthesis. ' +
+				'Broad research across many sources or several slow steps can indicate ' +
+				'a long task. A clearly long task can run in the background even if you have no other ' +
+				'work. If the duration is uncertain and no other background condition applies, use ' +
+				'foreground mode. Keep work that needs user input with the parent; background agents ' +
+				'cannot pause for user interaction. Pass all context the child needs. After a successful ' +
+				'launch, continue independent work that does not overlap with the child, or end your turn ' +
+				'with a short message that work continues in the background. Completion triggers a ' +
+				'follow-up. A launch receipt does not mean the task is complete. Do not check jobs just ' +
+				'to wait for them, and do not sleep or poll for completion. The final answer is the ' +
+				'contract; never expect the full trace. Instruct ' +
 				'sub-agents producing large outputs to write them to the shared workspace and return a ' +
 				'summary.',
 		)
@@ -158,7 +171,7 @@ export function createSpawnBackgroundSubAgentTool(options: BackgroundJobToolsOpt
 				return {
 					status: 'started',
 					jobId: receipt.jobId,
-					note: 'Job dispatched. Check on it later with check_background_jobs.',
+					note: 'Job dispatched. Continue independent work or end this turn with a short progress message. Completion triggers a follow-up. Do not wait, sleep, or poll for completion.',
 				};
 			}
 			return {
@@ -174,8 +187,17 @@ export function createCheckBackgroundJobsTool(jobService: AgentBackgroundJobServ
 		.description(
 			'List the background jobs of this conversation with their status and, once settled, ' +
 				'their result or error. Pass an empty object {} to list all jobs (required — do not pass null). ' +
-				'Call this at most once per turn: when jobs are still running, tell the user and end your ' +
-				'turn — repeated checks within one turn only burn time and tokens.',
+				'Call this at most once per turn. Collect all relevant jobs in that call, rather than ' +
+				'checking each job separately.',
+		)
+		.systemInstruction(
+			'Call check_background_jobs at most once per turn, including calls made together. ' +
+				'Omit jobIds to check all jobs, or include all relevant job IDs in one call. Use the ' +
+				'results already available and continue independent work. If further progress depends ' +
+				'on running jobs, end your turn with a short progress message. Completion triggers a ' +
+				'follow-up. Do not wait, sleep, or call this tool again in the same turn to see whether ' +
+				'a job has finished. A user status request or a completion hint can justify one check ' +
+				'in a later turn. Do not claim that running jobs are complete.',
 		)
 		.input(
 			z.object({
@@ -206,6 +228,7 @@ export function createCheckBackgroundJobsTool(jobService: AgentBackgroundJobServ
 					...(job.childExecutionId !== null ? { executionId: job.childExecutionId } : {}),
 				})),
 				runningCount: jobs.filter((job) => job.status === 'running').length,
+				note: 'You have checked background jobs for this turn. Use the available results and continue independent work. If further progress depends on running jobs, end this turn with a short progress message. Completion triggers a follow-up. Do not wait, sleep, or check again in this turn.',
 			};
 		})
 		.build();


### PR DESCRIPTION
## Summary

Use foreground delegation by default, with background mode for parallel work, long tasks, or explicit requests.
Guide the agent to check all relevant background jobs once per turn, then continue independent work or end the turn.

## How to test

- Setup: `N8N_ENABLED_MODULES=agents`, `N8N_AGENTS_BACKGROUND_TASKS_ENABLED=true`, and a configured agent model
- Compare a short delegated task with four independent research jobs, then request their status.
- Expected: foreground for short work; background for parallel research; at most one status check per turn
- Passed: 59 existing background-tool, runner, and wake-service tests; CLI lint and typecheck; workspace build; formatting
- Local model trials with stub jobs: 39/39 revised cases passed; four-job launch turns made zero status checks, compared with one in the baseline

The baseline did not reproduce repeated polling, so these trials do not prove that the loop cannot recur.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-845

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

