### PR TITLE
feat(AI Agent Node): Add option to force a tool call on the first iteration

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/description.ts
@@ -13,6 +13,15 @@ const enableStreaminOption: INodeProperties = {
 	description: 'Whether this agent will stream the response in real-time as it generates text',
 };
 
+const forceToolCallOnFirstIterationOption: INodeProperties = {
+	displayName: 'Force Tool Call on First Iteration',
+	name: 'forceToolCallOnFirstIteration',
+	type: 'boolean',
+	default: false,
+	description:
+		'Whether the model must call at least one tool on its first response of each run. Later responses are unrestricted so the agent can answer. Useful for smaller models that otherwise skip tool calls; the model must support forced tool choice.',
+};
+
 const maxTokensFromMemoryOption: INodeProperties = {
 	displayName: 'Max Tokens To Read From Memory',
 	name: 'maxTokensFromMemory',
@@ -34,5 +43,6 @@ export const toolsAgentProperties: INodeProperties = {
 		enableStreaminOption,
 		getBatchingOptionFields(undefined, 1),
 		maxTokensFromMemoryOption,
+		forceToolCallOnFirstIterationOption,
 	],
 };

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/createAgentSequence.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/createAgentSequence.ts
@@ -30,19 +30,26 @@ export function createAgentSequence(
 	outputParser?: N8nOutputParser,
 	memory?: BaseChatMemory,
 	fallbackModel?: BaseChatModel | null,
+	forceToolCall = false,
 ) {
+	const allTools = getAllTools(model, tools);
 	const agent = createToolCallingAgent({
-		llm: model,
-		tools: getAllTools(model, tools),
+		llm:
+			forceToolCall && model.bindTools ? model.bindTools(allTools, { tool_choice: 'any' }) : model,
+		tools: allTools,
 		prompt,
 		streamRunnable: false,
 	});
 
 	let fallbackAgent: AgentRunnableSequence | undefined;
 	if (fallbackModel) {
+		const fallbackTools = getAllTools(fallbackModel, tools);
 		fallbackAgent = createToolCallingAgent({
-			llm: fallbackModel,
-			tools: getAllTools(fallbackModel, tools),
+			llm:
+				forceToolCall && fallbackModel.bindTools
+					? fallbackModel.bindTools(fallbackTools, { tool_choice: 'any' })
+					: fallbackModel,
+			tools: fallbackTools,
 			prompt,
 			streamRunnable: false,
 		});

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
@@ -82,7 +82,7 @@ export async function executeBatch(
 
 		const itemContext = await prepareItemContext(ctx, itemIndex, processedResponse, model);
 
-		const { tools, prompt, options, outputParser } = itemContext;
+		const { tools, prompt, options, outputParser, steps } = itemContext;
 
 		// Create executors for primary and fallback models
 		const executor: AgentRunnableSequence = createAgentSequence(
@@ -93,6 +93,7 @@ export async function executeBatch(
 			outputParser,
 			memory,
 			fallbackModel,
+			options.forceToolCallOnFirstIteration === true && steps.length === 0,
 		);
 
 		// Run the agent with processed response

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/createAgentSequence.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/createAgentSequence.test.ts
@@ -112,6 +112,44 @@ describe('createAgentSequence', () => {
 		]);
 	});
 
+	it('should force tool calls for primary and fallback models', () => {
+		const boundModel = mock<BaseChatModel>();
+		const boundFallbackModel = mock<BaseChatModel>();
+		const model = mock<BaseChatModel>({
+			bindTools: vi.fn().mockReturnValue(boundModel),
+		});
+		const fallbackModel = mock<BaseChatModel>({
+			bindTools: vi.fn().mockReturnValue(boundFallbackModel),
+		});
+		const mockAgent = mock<any>();
+
+		mockAgent.withFallbacks = vi.fn().mockReturnValue(mockAgent);
+		(createToolCallingAgent as Mock).mockReturnValue(mockAgent);
+		(RunnableSequence.from as Mock).mockReturnValue(mock<any>());
+
+		createAgentSequence(
+			model,
+			[mockTool],
+			mockPrompt,
+			{},
+			undefined,
+			undefined,
+			fallbackModel,
+			true,
+		);
+
+		expect(model.bindTools).toHaveBeenCalledWith([mockTool], { tool_choice: 'any' });
+		expect(fallbackModel.bindTools).toHaveBeenCalledWith([mockTool], { tool_choice: 'any' });
+		expect(createToolCallingAgent).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ llm: boundModel, tools: [mockTool] }),
+		);
+		expect(createToolCallingAgent).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ llm: boundFallbackModel, tools: [mockTool] }),
+		);
+	});
+
 	it('should pass output parser to getAgentStepsParser', () => {
 		const mockAgent = mock<any>();
 		const mockRunnableSequence = mock<any>();

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/executeBatch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/executeBatch.test.ts
@@ -7,9 +7,10 @@ import { vi } from 'vitest';
 import type { ItemContext } from '../prepareItemContext';
 import { executeBatch } from '../executeBatch';
 
-const { runAgentMock, prepareItemContextMock } = vi.hoisted(() => ({
+const { runAgentMock, prepareItemContextMock, createAgentSequenceMock } = vi.hoisted(() => ({
 	runAgentMock: vi.fn(),
 	prepareItemContextMock: vi.fn(),
+	createAgentSequenceMock: vi.fn(),
 }));
 
 vi.mock('@utils/output_parsers/N8nOutputParser', () => ({
@@ -23,7 +24,7 @@ vi.mock('../prepareItemContext', () => ({ prepareItemContext: prepareItemContext
 vi.mock('../checkMaxIterations', () => ({ checkMaxIterations: vi.fn() }));
 
 vi.mock('../createAgentSequence', () => ({
-	createAgentSequence: vi.fn().mockReturnValue(mock()),
+	createAgentSequence: createAgentSequenceMock,
 }));
 
 vi.mock('../finalizeResult', () => ({ finalizeResult: vi.fn() }));
@@ -37,11 +38,11 @@ beforeEach(() => {
 	mockContext.getNodeParameter.mockReturnValue(10);
 });
 
-function buildItemContext(itemIndex: number): ItemContext {
+function buildItemContext(itemIndex: number, hasSteps = false): ItemContext {
 	return {
 		itemIndex,
 		input: 'test',
-		steps: [],
+		steps: hasSteps ? [mock<ItemContext['steps'][number]>()] : [],
 		tools: [],
 		prompt: mock(),
 		options: {
@@ -51,6 +52,23 @@ function buildItemContext(itemIndex: number): ItemContext {
 		outputParser: undefined,
 	};
 }
+
+describe('executeBatch — forced tool calls', () => {
+	it.each([
+		{ iteration: 'first', hasSteps: false, forceToolCall: true },
+		{ iteration: 'later', hasSteps: true, forceToolCall: false },
+	])('passes the force flag for the $iteration iteration', async ({ hasSteps, forceToolCall }) => {
+		const model = mock<BaseChatModel>();
+		const itemContext = buildItemContext(0, hasSteps);
+		itemContext.options.forceToolCallOnFirstIteration = true;
+		prepareItemContextMock.mockResolvedValue(itemContext);
+		runAgentMock.mockResolvedValue(undefined);
+
+		await executeBatch(mockContext, [{ json: {} }], 0, model, null, undefined);
+
+		expect(createAgentSequenceMock.mock.lastCall?.at(-1)).toBe(forceToolCall);
+	});
+});
 
 describe('executeBatch — error enrichment', () => {
 	it('surfaces a useful message in the output item when a tool throws a plain Error("Error") and continueOnFail is on', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/types.ts
@@ -35,6 +35,7 @@ export type AgentOptions = {
 	passthroughBinaryPdfs?: boolean;
 	enableStreaming?: boolean;
 	maxTokensFromMemory?: number;
+	forceToolCallOnFirstIteration?: boolean;
 	tracingMetadata?: {
 		values?: TracingMetadataEntry[];
 	};


### PR DESCRIPTION
## Summary

The AI Agent node (v3) never sends `tool_choice` to the chat model. `createAgentSequence` passes the raw model to LangChain's `createToolCallingAgent`, which calls `bindTools(tools)` without a tool choice. OpenAI-compatible providers treat the missing field as `auto`. Smaller models (for example Mistral-Small-24B on IONOS, vLLM, or Ollama) then answer in prose and never call the wired tool, so RAG fails silently.

This PR adds the opt-in option **Force Tool Call on First Iteration** to the AI Agent (v3) and Agent Tool (v3) options. Default: off.

When the option is on and the item has no prior tool steps in the current run, the agent binds the primary and the fallback model with LangChain's portable `tool_choice: 'any'` before it hands them to `createToolCallingAgent`. `@langchain/openai` sends this as `tool_choice: "required"`; the Anthropic, Gemini, Mistral and Bedrock integrations accept `any` natively. Later iterations stay unrestricted, so the agent can still produce its final answer.

When the option is off, the request the agent sends is unchanged.

## How to test

1. Create a workflow: Chat Trigger → AI Agent (v3) with one trivial tool (for example a Code Tool that returns a constant) and an OpenAI Chat Model that points at an OpenAI-compatible endpoint. Put a request-logging proxy (or a mock server) in front of the endpoint.
2. Set the agent system message to "You MUST call the `get_value` tool to answer any question."
3. Send "What is the value?" with the option **off**. The first request body has `tools` but no `tool_choice`.
4. Open the agent **Options**, add **Force Tool Call on First Iteration**, turn it on, and send the message again. The first request body now has `tool_choice: "required"`. The request after the tool result has no `tool_choice`, and the agent answers.
5. Repeat step 4 with a fallback model connected: both models get the same binding.

Unit tests:

```bash
cd packages/@n8n/nodes-langchain
pnpm test nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/createAgentSequence.test.ts nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/executeBatch.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-870

fixes #31135

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

