### PR TITLE
feat: Keep ESLint rule policy in the shared layers (no-changelog)

### DIFF
--- a/.agents/review-rules/qa-dx/ratchets-and-allowlists.md
+++ b/.agents/review-rules/qa-dx/ratchets-and-allowlists.md
@@ -15,6 +15,7 @@ Flag a diff that **adds** entries to any of these, and ask for the fix instead:
 | `.boundaries-baseline.json` | `turbo boundaries` issue count |
 | `packages/testing/playwright/.janitor-baseline.json` | Playwright janitor findings |
 | `packages/cli/eslint.config.mjs` | the `misplaced-n8n-typeorm-import` and public-API allowlists, each captioned "NEVER add to this list" |
+| `.code-health-baseline.json` (`lint-config-layering`) | package-wide rule downgrades left in package ESLint configs |
 
 Removals are the healthy direction and need no comment.
 
@@ -33,3 +34,11 @@ Flag a lint rule moved from `'error'` to `'warn'` or `'off'`, and a new
 `eslint-disable` for one of the guarded rules. Most packages run
 `eslint . --quiet`, so a warning never fails CI — downgrading to `'warn'` is
 functionally deleting the rule while appearing to keep it.
+
+In a package `eslint.config.mjs` the `lint-config-layering` code-health rule
+catches this for you: a package-wide downgrade fails Static Analysis unless it
+is already in the baseline. What it cannot judge is a downgrade dressed as a
+scoped block. Check that a new `files` glob names the paths that actually need
+the exception, and that a rule retired in `@n8n/eslint-config/src/configs/base.ts`
+comes with the count of packages that had already stopped enforcing it
+(`node scripts/lint-parity/majority.mjs`).

--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -1310,6 +1310,904 @@
 				"message": "A bare `eslint-disable` directive silences every lint rule in its range, including the encryption guardrails.",
 				"hash": "7d9779f96d99"
 			}
+		],
+		"packages/core/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 14,
+				"message": "packages/core turns 'no-prototype-builtins' down to 'warn' for the whole package.",
+				"hash": "f6d9c62ac3fa"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 15,
+				"message": "packages/core turns 'no-ex-assign' down to 'warn' for the whole package.",
+				"hash": "1bb332c34de8"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 16,
+				"message": "packages/core turns 'no-useless-escape' down to 'warn' for the whole package.",
+				"hash": "8c7b005323e5"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 17,
+				"message": "packages/core turns '@typescript-eslint/no-require-imports' down to 'warn' for the whole package.",
+				"hash": "efdd5147a463"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 18,
+				"message": "packages/core turns '@typescript-eslint/no-base-to-string' down to 'warn' for the whole package.",
+				"hash": "5328912625c6"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 19,
+				"message": "packages/core turns '@typescript-eslint/prefer-optional-chain' down to 'warn' for the whole package.",
+				"hash": "eddccedaafb7"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 20,
+				"message": "packages/core turns '@typescript-eslint/no-array-delete' down to 'warn' for the whole package.",
+				"hash": "c05a6f2ae2f1"
+			}
+		],
+		"packages/cli/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 90,
+				"message": "packages/cli turns '@typescript-eslint/ban-ts-comment' down to 'off' for the whole package.",
+				"hash": "7e7e5e67871c"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 91,
+				"message": "packages/cli turns 'import-x/no-cycle' down to 'warn' for the whole package.",
+				"hash": "e53210bcd5e5"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 92,
+				"message": "packages/cli turns 'import-x/extensions' down to 'off' for the whole package.",
+				"hash": "e9ac61307734"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 93,
+				"message": "packages/cli turns 'no-ex-assign' down to 'warn' for the whole package.",
+				"hash": "9555ecb54f1c"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 94,
+				"message": "packages/cli turns 'no-case-declarations' down to 'warn' for the whole package.",
+				"hash": "ac66463536bc"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 95,
+				"message": "packages/cli turns 'no-fallthrough' down to 'warn' for the whole package.",
+				"hash": "d27fa33c682d"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 96,
+				"message": "packages/cli turns 'no-unsafe-optional-chaining' down to 'warn' for the whole package.",
+				"hash": "ea7a4933c714"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 97,
+				"message": "packages/cli turns 'no-async-promise-executor' down to 'warn' for the whole package.",
+				"hash": "af41798867ce"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 98,
+				"message": "packages/cli turns 'complexity' down to 'off' for the whole package.",
+				"hash": "55ccec6cbe85"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 99,
+				"message": "packages/cli turns '@typescript-eslint/prefer-promise-reject-errors' down to 'warn' for the whole package.",
+				"hash": "27aa46ca0c89"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 100,
+				"message": "packages/cli turns '@typescript-eslint/no-explicit-any' down to 'warn' for the whole package.",
+				"hash": "ec58ba458ff5"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 101,
+				"message": "packages/cli turns '@typescript-eslint/no-base-to-string' down to 'warn' for the whole package.",
+				"hash": "ada384a6c58c"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 102,
+				"message": "packages/cli turns '@typescript-eslint/no-redundant-type-constituents' down to 'warn' for the whole package.",
+				"hash": "fb40bae42683"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 103,
+				"message": "packages/cli turns '@typescript-eslint/no-restricted-types' down to 'warn' for the whole package.",
+				"hash": "ee8be51f48f3"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 104,
+				"message": "packages/cli turns '@typescript-eslint/no-unsafe-enum-comparison' down to 'warn' for the whole package.",
+				"hash": "e1d09e3cb444"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 105,
+				"message": "packages/cli turns '@typescript-eslint/no-unsafe-declaration-merging' down to 'warn' for the whole package.",
+				"hash": "abf613bdcbec"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 106,
+				"message": "packages/cli turns '@typescript-eslint/only-throw-error' down to 'warn' for the whole package.",
+				"hash": "f6b9cb56f2da"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 107,
+				"message": "packages/cli turns '@typescript-eslint/no-require-imports' down to 'warn' for the whole package.",
+				"hash": "ce5c4ddb8b21"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 108,
+				"message": "packages/cli turns '@typescript-eslint/array-type' down to 'warn' for the whole package.",
+				"hash": "06eb8c68c0e3"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 109,
+				"message": "packages/cli turns 'no-useless-escape' down to 'warn' for the whole package.",
+				"hash": "581e9d0a38b0"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 110,
+				"message": "packages/cli turns '@typescript-eslint/prefer-optional-chain' down to 'warn' for the whole package.",
+				"hash": "60a340796f69"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 111,
+				"message": "packages/cli turns '@typescript-eslint/no-duplicate-type-constituents' down to 'warn' for the whole package.",
+				"hash": "499e9bcc262e"
+			}
+		],
+		"packages/node-dev/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 7,
+				"message": "packages/node-dev turns 'unicorn/filename-case' down to 'warn' for the whole package.",
+				"hash": "55a9d5b897d9"
+			}
+		],
+		"packages/nodes-base/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 27,
+				"message": "packages/nodes-base turns 'no-ex-assign' down to 'warn' for the whole package.",
+				"hash": "405b1823ac6e"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 28,
+				"message": "packages/nodes-base turns 'no-control-regex' down to 'warn' for the whole package.",
+				"hash": "be29a0fb44a3"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 29,
+				"message": "packages/nodes-base turns 'no-constant-condition' down to 'warn' for the whole package.",
+				"hash": "f7df4e39eb2e"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 30,
+				"message": "packages/nodes-base turns 'no-dupe-else-if' down to 'warn' for the whole package.",
+				"hash": "f5be7d5a7f26"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 31,
+				"message": "packages/nodes-base turns 'no-fallthrough' down to 'warn' for the whole package.",
+				"hash": "c899a707272e"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 33,
+				"message": "packages/nodes-base turns 'import-x/export' down to 'warn' for the whole package.",
+				"hash": "9ed273bfcc65"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 34,
+				"message": "packages/nodes-base turns 'import-x/no-extraneous-dependencies' down to 'warn' for the whole package.",
+				"hash": "5eb27aed13a1"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 38,
+				"message": "packages/nodes-base turns '@typescript-eslint/ban-ts-comment' down to 'off' for the whole package.",
+				"hash": "496821aa3902"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 40,
+				"message": "packages/nodes-base turns '@typescript-eslint/prefer-promise-reject-errors' down to 'warn' for the whole package.",
+				"hash": "2d61f9d00a79"
+			}
+		],
+		"packages/workflow/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 12,
+				"message": "packages/workflow turns 'id-denylist' down to 'warn' for the whole package.",
+				"hash": "03927870bdf1"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 13,
+				"message": "packages/workflow turns 'no-fallthrough' down to 'warn' for the whole package.",
+				"hash": "cd442ee0d22b"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 14,
+				"message": "packages/workflow turns 'no-useless-escape' down to 'warn' for the whole package.",
+				"hash": "b0c2a209531b"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 15,
+				"message": "packages/workflow turns 'no-extra-boolean-cast' down to 'warn' for the whole package.",
+				"hash": "f1b59e9a9170"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 16,
+				"message": "packages/workflow turns 'no-case-declarations' down to 'warn' for the whole package.",
+				"hash": "e0313976c4b5"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 17,
+				"message": "packages/workflow turns 'no-prototype-builtins' down to 'warn' for the whole package.",
+				"hash": "974eaf5efe54"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 18,
+				"message": "packages/workflow turns '@typescript-eslint/no-base-to-string' down to 'warn' for the whole package.",
+				"hash": "d3d0cc6967be"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 19,
+				"message": "packages/workflow turns '@typescript-eslint/no-redundant-type-constituents' down to 'warn' for the whole package.",
+				"hash": "39ee215cccec"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 20,
+				"message": "packages/workflow turns '@typescript-eslint/prefer-optional-chain' down to 'warn' for the whole package.",
+				"hash": "155e0b154873"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 22,
+				"message": "packages/workflow turns '@typescript-eslint/no-duplicate-type-constituents' down to 'warn' for the whole package.",
+				"hash": "b3f813b386ed"
+			}
+		],
+		"packages/@n8n/ai-node-sdk/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 6,
+				"message": "packages/@n8n/ai-node-sdk turns '@typescript-eslint/no-explicit-any' down to 'warn' for the whole package.",
+				"hash": "8e1ddde4bb6d"
+			}
+		],
+		"packages/@n8n/ai-utilities/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 9,
+				"message": "packages/@n8n/ai-utilities turns '@typescript-eslint/no-explicit-any' down to 'warn' for the whole package.",
+				"hash": "d5a8d7cd9636"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 10,
+				"message": "packages/@n8n/ai-utilities turns 'no-case-declarations' down to 'warn' for the whole package.",
+				"hash": "b95bfb2a3056"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 17,
+				"message": "packages/@n8n/ai-utilities turns 'unicorn/filename-case' down to 'off' for the whole package.",
+				"hash": "de46ec6eb650"
+			}
+		],
+		"packages/@n8n/backend-common/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 8,
+				"message": "packages/@n8n/backend-common turns '@typescript-eslint/no-wrapper-object-types' down to 'warn' for the whole package.",
+				"hash": "c1e3aa8a2e1c"
+			}
+		],
+		"packages/@n8n/codemirror-lang/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 6,
+				"message": "packages/@n8n/codemirror-lang turns 'no-useless-escape' down to 'warn' for the whole package.",
+				"hash": "98b3e5d89db4"
+			}
+		],
+		"packages/@n8n/codemirror-lang-sql/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 6,
+				"message": "packages/@n8n/codemirror-lang-sql turns 'no-useless-escape' down to 'warn' for the whole package.",
+				"hash": "b03974f4c1da"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 7,
+				"message": "packages/@n8n/codemirror-lang-sql turns '@typescript-eslint/no-unsafe-enum-comparison' down to 'off' for the whole package.",
+				"hash": "3ee104dc1cd2"
+			}
+		],
+		"packages/@n8n/db/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 25,
+				"message": "packages/@n8n/db turns '@typescript-eslint/no-base-to-string' down to 'warn' for the whole package.",
+				"hash": "21a54ac84b21"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 26,
+				"message": "packages/@n8n/db turns '@typescript-eslint/no-restricted-types' down to 'warn' for the whole package.",
+				"hash": "1b7a8eee4264"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 27,
+				"message": "packages/@n8n/db turns 'no-useless-escape' down to 'warn' for the whole package.",
+				"hash": "aa31a2b9878a"
+			}
+		],
+		"packages/@n8n/decorators/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 8,
+				"message": "packages/@n8n/decorators turns '@typescript-eslint/no-base-to-string' down to 'warn' for the whole package.",
+				"hash": "b4aab632b998"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 9,
+				"message": "packages/@n8n/decorators turns 'import-x/export' down to 'warn' for the whole package.",
+				"hash": "efaf9102fe79"
+			}
+		],
+		"packages/@n8n/engine/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 11,
+				"message": "packages/@n8n/engine turns 'unicorn/filename-case' down to 'off' for the whole package.",
+				"hash": "2455a576216c"
+			}
+		],
+		"packages/@n8n/eslint-plugin-community-nodes/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 18,
+				"message": "packages/@n8n/eslint-plugin-community-nodes turns 'eslint-plugin/require-meta-docs-url' down to 'off' for the whole package.",
+				"hash": "160308f43107"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 20,
+				"message": "packages/@n8n/eslint-plugin-community-nodes turns 'eslint-plugin/require-meta-default-options' down to 'off' for the whole package.",
+				"hash": "fb3cdbc0b797"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 22,
+				"message": "packages/@n8n/eslint-plugin-community-nodes turns '@typescript-eslint/naming-convention' down to 'off' for the whole package.",
+				"hash": "b9b7b80295d3"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 24,
+				"message": "packages/@n8n/eslint-plugin-community-nodes turns 'import-x/no-default-export' down to 'off' for the whole package.",
+				"hash": "3f7dfc88d2cc"
+			}
+		],
+		"packages/@n8n/extension-sdk/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 7,
+				"message": "packages/@n8n/extension-sdk turns '@typescript-eslint/no-unnecessary-boolean-literal-compare' down to 'warn' for the whole package.",
+				"hash": "1358f2270558"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 8,
+				"message": "packages/@n8n/extension-sdk turns '@typescript-eslint/no-floating-promises' down to 'warn' for the whole package.",
+				"hash": "a01fcd4e7fd1"
+			}
+		],
+		"packages/@n8n/imap/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 9,
+				"message": "packages/@n8n/imap turns '@typescript-eslint/no-unnecessary-boolean-literal-compare' down to 'warn' for the whole package.",
+				"hash": "c01451c28a03"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 10,
+				"message": "packages/@n8n/imap turns '@typescript-eslint/no-floating-promises' down to 'warn' for the whole package.",
+				"hash": "9466b50c2cbc"
+			}
+		],
+		"packages/@n8n/instance-ai/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 100,
+				"message": "packages/@n8n/instance-ai turns 'unicorn/filename-case' down to 'off' for the whole package.",
+				"hash": "b76f6179d75b"
+			}
+		],
+		"packages/@n8n/json-schema-to-zod/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 8,
+				"message": "packages/@n8n/json-schema-to-zod turns 'import-x/no-cycle' down to 'off' for the whole package.",
+				"hash": "bd1fd9f55f2e"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 12,
+				"message": "packages/@n8n/json-schema-to-zod turns 'no-constant-condition' down to 'warn' for the whole package.",
+				"hash": "e7995ba65bba"
+			}
+		],
+		"packages/@n8n/node-cli/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 21,
+				"message": "packages/@n8n/node-cli turns 'unicorn/filename-case' down to 'off' for the whole package.",
+				"hash": "450dc7735f37"
+			}
+		],
+		"packages/@n8n/task-runner/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 10,
+				"message": "packages/@n8n/task-runner turns '@typescript-eslint/no-require-imports' down to 'warn' for the whole package.",
+				"hash": "9eab9fc92af8"
+			}
+		],
+		"packages/@n8n/tournament/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 8,
+				"message": "packages/@n8n/tournament turns '@typescript-eslint/no-restricted-types' down to 'off' for the whole package.",
+				"hash": "a7bd4d72aeaa"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 9,
+				"message": "packages/@n8n/tournament turns '@typescript-eslint/no-implied-eval' down to 'off' for the whole package.",
+				"hash": "38c062765f50"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 10,
+				"message": "packages/@n8n/tournament turns '@typescript-eslint/no-explicit-any' down to 'off' for the whole package.",
+				"hash": "228a8d26e7bf"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 17,
+				"message": "packages/@n8n/tournament turns 'unicorn/filename-case' down to 'off' for the whole package.",
+				"hash": "a8dd0ff69014"
+			}
+		],
+		"packages/@n8n/utils/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 7,
+				"message": "packages/@n8n/utils turns 'no-prototype-builtins' down to 'warn' for the whole package.",
+				"hash": "cc7739fda55b"
+			}
+		],
+		"packages/frontend/editor-ui/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 55,
+				"message": "packages/frontend/editor-ui turns 'no-restricted-syntax' down to 'off' for the whole package.",
+				"hash": "991d49a8245c"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 234,
+				"message": "packages/frontend/editor-ui turns 'n8n-local-rules/no-internal-package-import' down to 'warn' for the whole package.",
+				"hash": "4b3a85b06980"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 235,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/ban-ts-comment' down to 'off' for the whole package.",
+				"hash": "e8c5a011088f"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 236,
+				"message": "packages/frontend/editor-ui turns 'id-denylist' down to 'warn' for the whole package.",
+				"hash": "bd2977006e41"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 237,
+				"message": "packages/frontend/editor-ui turns 'no-case-declarations' down to 'warn' for the whole package.",
+				"hash": "e305144fdb0f"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 238,
+				"message": "packages/frontend/editor-ui turns 'no-useless-escape' down to 'warn' for the whole package.",
+				"hash": "9280bef13c13"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 239,
+				"message": "packages/frontend/editor-ui turns 'no-prototype-builtins' down to 'warn' for the whole package.",
+				"hash": "352fae23e0d1"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 240,
+				"message": "packages/frontend/editor-ui turns 'no-fallthrough' down to 'warn' for the whole package.",
+				"hash": "db7c8593f721"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 241,
+				"message": "packages/frontend/editor-ui turns 'no-extra-boolean-cast' down to 'warn' for the whole package.",
+				"hash": "0cbbb7983686"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 242,
+				"message": "packages/frontend/editor-ui turns 'no-sparse-arrays' down to 'warn' for the whole package.",
+				"hash": "750f119df597"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 243,
+				"message": "packages/frontend/editor-ui turns 'no-control-regex' down to 'warn' for the whole package.",
+				"hash": "5f096c4e5a30"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 244,
+				"message": "packages/frontend/editor-ui turns 'import-x/extensions' down to 'warn' for the whole package.",
+				"hash": "301322f12ba8"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 245,
+				"message": "packages/frontend/editor-ui turns 'import-x/no-cycle' down to 'warn' for the whole package.",
+				"hash": "3f9ee03a211f"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 246,
+				"message": "packages/frontend/editor-ui turns 'import-x/no-duplicates' down to 'warn' for the whole package.",
+				"hash": "7ff9cd71e584"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 247,
+				"message": "packages/frontend/editor-ui turns 'no-unsafe-optional-chaining' down to 'warn' for the whole package.",
+				"hash": "29c386f9afa1"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 248,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-restricted-types' down to 'warn' for the whole package.",
+				"hash": "674bc7c925bb"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 249,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/dot-notation' down to 'warn' for the whole package.",
+				"hash": "b01af73ed4af"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 250,
+				"message": "packages/frontend/editor-ui turns '@stylistic/lines-between-class-members' down to 'warn' for the whole package.",
+				"hash": "abd5d6c83376"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 251,
+				"message": "packages/frontend/editor-ui turns '@stylistic/member-delimiter-style' down to 'warn' for the whole package.",
+				"hash": "c48bcd875f1a"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 252,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-empty-interface' down to 'warn' for the whole package.",
+				"hash": "271c5309b542"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 253,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-for-in-array' down to 'warn' for the whole package.",
+				"hash": "249d350f8066"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 254,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-loop-func' down to 'warn' for the whole package.",
+				"hash": "fa39d584681d"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 255,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-non-null-assertion' down to 'warn' for the whole package.",
+				"hash": "875c5c8d162e"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 256,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-shadow' down to 'warn' for the whole package.",
+				"hash": "b4bfbb79e513"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 257,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-this-alias' down to 'warn' for the whole package.",
+				"hash": "cd21cdd292fa"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 258,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-unnecessary-boolean-literal-compare' down to 'warn' for the whole package.",
+				"hash": "59d1ce2379ac"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 259,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-unnecessary-type-assertion' down to 'warn' for the whole package.",
+				"hash": "2eb8b8a9ba23"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 260,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-unused-expressions' down to 'warn' for the whole package.",
+				"hash": "27661db19f4f"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 261,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-var-requires' down to 'warn' for the whole package.",
+				"hash": "32b4b7a30c8e"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 262,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/prefer-optional-chain' down to 'warn' for the whole package.",
+				"hash": "8379fe8350b5"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 263,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/restrict-plus-operands' down to 'warn' for the whole package.",
+				"hash": "f41881f25dad"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 264,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-redundant-type-constituents' down to 'warn' for the whole package.",
+				"hash": "edfe82c98ea3"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 265,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-unsafe-enum-comparison' down to 'warn' for the whole package.",
+				"hash": "577beb091f06"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 266,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/prefer-promise-reject-errors' down to 'warn' for the whole package.",
+				"hash": "cb1d57707d43"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 267,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/no-base-to-string' down to 'warn' for the whole package.",
+				"hash": "96f813e59fa6"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 268,
+				"message": "packages/frontend/editor-ui turns 'vue/attribute-hyphenation' down to 'warn' for the whole package.",
+				"hash": "33e956db8dec"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 269,
+				"message": "packages/frontend/editor-ui turns '@typescript-eslint/restrict-template-expressions' down to 'warn' for the whole package.",
+				"hash": "affee27335fc"
+			}
+		],
+		"packages/@n8n/workflow-sdk/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 71,
+				"message": "packages/@n8n/workflow-sdk turns 'n8n-local-rules/no-interpolation-in-regular-string' down to 'off' for the whole package.",
+				"hash": "e5999d7c77a9"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 73,
+				"message": "packages/@n8n/workflow-sdk turns 'id-denylist' down to 'off' for the whole package.",
+				"hash": "0f94a71d5ae8"
+			}
+		],
+		"packages/testing/playwright/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 21,
+				"message": "packages/testing/playwright turns '@typescript-eslint/no-unused-expressions' down to 'off' for the whole package.",
+				"hash": "e2f93b5b591a"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 22,
+				"message": "packages/testing/playwright turns '@typescript-eslint/no-use-before-define' down to 'off' for the whole package.",
+				"hash": "75d3ec1677ba"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 23,
+				"message": "packages/testing/playwright turns '@typescript-eslint/promise-function-async' down to 'off' for the whole package.",
+				"hash": "35dbe9e44ada"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 24,
+				"message": "packages/testing/playwright turns 'playwright/expect-expect' down to 'warn' for the whole package.",
+				"hash": "e8b5f4b0f0dd"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 25,
+				"message": "packages/testing/playwright turns 'playwright/max-nested-describe' down to 'warn' for the whole package.",
+				"hash": "77d82ee8a802"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 27,
+				"message": "packages/testing/playwright turns 'playwright/no-skipped-test' down to 'warn' for the whole package.",
+				"hash": "14eb9eecd1b4"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 78,
+				"message": "packages/testing/playwright turns 'unicorn/filename-case' down to 'off' for the whole package.",
+				"hash": "de86b9645930"
+			}
+		],
+		"packages/frontend/@n8n/design-system/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 12,
+				"message": "packages/frontend/@n8n/design-system turns 'no-prototype-builtins' down to 'warn' for the whole package.",
+				"hash": "f7e604999631"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 13,
+				"message": "packages/frontend/@n8n/design-system turns '@typescript-eslint/prefer-optional-chain' down to 'warn' for the whole package.",
+				"hash": "e6d8e187bb0b"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 14,
+				"message": "packages/frontend/@n8n/design-system turns '@typescript-eslint/restrict-template-expressions' down to 'warn' for the whole package.",
+				"hash": "86a0b84b8415"
+			}
+		],
+		"packages/frontend/@n8n/i18n/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 6,
+				"message": "packages/frontend/@n8n/i18n turns '@typescript-eslint/no-unnecessary-type-assertion' down to 'warn' for the whole package.",
+				"hash": "5836fd4581b2"
+			}
+		],
+		"packages/frontend/@n8n/stores/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 6,
+				"message": "packages/frontend/@n8n/stores turns '@typescript-eslint/no-unnecessary-type-assertion' down to 'warn' for the whole package.",
+				"hash": "63e2dd35dc47"
+			}
+		],
+		"packages/modules/insights/frontend/eslint.config.mjs": [
+			{
+				"rule": "lint-config-layering",
+				"line": 24,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/naming-convention' down to 'warn' for the whole package.",
+				"hash": "3da608aa064b"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 25,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/no-unsafe-argument' down to 'warn' for the whole package.",
+				"hash": "e9ae1f320e01"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 26,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/no-unsafe-assignment' down to 'warn' for the whole package.",
+				"hash": "a488f2f44a8e"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 27,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/no-unsafe-call' down to 'warn' for the whole package.",
+				"hash": "58fd1d708522"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 28,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/no-unsafe-member-access' down to 'warn' for the whole package.",
+				"hash": "7de9b4bde334"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 29,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/no-unsafe-return' down to 'warn' for the whole package.",
+				"hash": "14aa32c2f578"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 30,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/await-thenable' down to 'warn' for the whole package.",
+				"hash": "f6b34bf81039"
+			},
+			{
+				"rule": "lint-config-layering",
+				"line": 31,
+				"message": "packages/modules/insights/frontend turns '@typescript-eslint/require-await' down to 'warn' for the whole package.",
+				"hash": "b857963c49d1"
+			}
 		]
 	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,9 @@ config picks exactly one:
 A package config may add `ignores`, an additive plugin config, a block that
 raises rules to `error`, and blocks scoped to `files`. It must not turn a rule
 down for the whole package: every lint script runs with `--quiet`, so a `warn`
-enforces nothing and reads as if it did.
+enforces nothing and reads as if it did. The code-health rule
+`lint-config-layering` enforces this, with existing debt in
+`.code-health-baseline.json`, which only shrinks.
 
 To stop enforcing a rule everywhere, retire it in `base.ts` with the count
 behind the decision. To enforce one again in a package that is ready, set it to

--- a/packages/testing/code-health/src/index.ts
+++ b/packages/testing/code-health/src/index.ts
@@ -5,6 +5,7 @@ import type { CodeHealthContext } from './context.js';
 import { CatalogViolationsRule } from './rules/catalog-violations.rule.js';
 import { EncryptionBoundaryRule } from './rules/encryption-boundary.rule.js';
 import { EndpointScopeCoverageRule } from './rules/endpoint-scope-coverage.rule.js';
+import { LintConfigLayeringRule } from './rules/lint-config-layering.rule.js';
 import { MigrationTimestampRule } from './rules/migration-timestamp.rule.js';
 import { SingleInstanceLibsRule } from './rules/single-instance-libs.rule.js';
 import { SingleInstanceLockfileRule } from './rules/single-instance-lockfile.rule.js';
@@ -16,6 +17,7 @@ export type { CodeHealthContext } from './context.js';
 export { CatalogViolationsRule } from './rules/catalog-violations.rule.js';
 export { EncryptionBoundaryRule } from './rules/encryption-boundary.rule.js';
 export { EndpointScopeCoverageRule } from './rules/endpoint-scope-coverage.rule.js';
+export { LintConfigLayeringRule } from './rules/lint-config-layering.rule.js';
 export { MigrationTimestampRule } from './rules/migration-timestamp.rule.js';
 export { SingleInstanceLibsRule } from './rules/single-instance-libs.rule.js';
 export { SingleInstanceLockfileRule } from './rules/single-instance-lockfile.rule.js';
@@ -54,6 +56,13 @@ const defaultRuleSettings: RuleSettingsMap = {
 		enabled: true,
 		severity: 'error',
 		options: {},
+	},
+	'lint-config-layering': {
+		enabled: true,
+		severity: 'error',
+		// This package is a dependency of @n8n/eslint-config, so extending it
+		// would be a cycle.
+		options: { exempt: ['packages/frontend/@n8n/eslint-plugin-design-system'] },
 	},
 	'stale-overrides': {
 		enabled: true,
@@ -136,6 +145,7 @@ export function createDefaultRunner(settings?: RuleSettingsMap): RuleRunner<Code
 	runner.registerRule(new SingleInstanceLibsRule());
 	runner.registerRule(new SingleInstanceLockfileRule());
 	runner.registerRule(new EncryptionBoundaryRule());
+	runner.registerRule(new LintConfigLayeringRule());
 	runner.registerRule(new StaleOverridesRule());
 	runner.registerRule(new EndpointScopeCoverageRule());
 	runner.registerRule(new SubpathPurityRule());

--- a/packages/testing/code-health/src/rules/lint-config-layering.rule.test.ts
+++ b/packages/testing/code-health/src/rules/lint-config-layering.rule.test.ts
@@ -1,0 +1,230 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { CodeHealthContext } from '../context.js';
+import { LintConfigLayeringRule } from './lint-config-layering.rule.js';
+
+const HEAD = `import { defineConfig } from 'eslint/config';
+import { backendConfig } from '@n8n/eslint-config/backend';
+`;
+
+describe('LintConfigLayeringRule', () => {
+	let rootDir: string;
+	let rule: LintConfigLayeringRule;
+
+	beforeEach(() => {
+		rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-health-lint-layering-'));
+		rule = new LintConfigLayeringRule();
+	});
+
+	afterEach(() => {
+		fs.rmSync(rootDir, { recursive: true, force: true });
+	});
+
+	function writePackage(dir: string, config: string | null): void {
+		const full = path.join(rootDir, dir);
+		fs.mkdirSync(full, { recursive: true });
+		fs.writeFileSync(path.join(full, 'package.json'), JSON.stringify({ name: dir }));
+		if (config !== null) fs.writeFileSync(path.join(full, 'eslint.config.mjs'), config);
+	}
+
+	async function analyze(options: Record<string, unknown> = {}): Promise<string[]> {
+		rule.configure({ enabled: true, severity: 'error', options });
+		const context: CodeHealthContext = { rootDir };
+		const violations = await rule.analyze(context);
+		return violations.map((v) => `${path.relative(rootDir, v.file)}:${v.line} ${v.message}`);
+	}
+
+	describe('accepts', () => {
+		it('a config that only extends its layer', async () => {
+			writePackage('packages/a', `${HEAD}\nexport default defineConfig(backendConfig);\n`);
+
+			expect(await analyze()).toEqual([]);
+		});
+
+		it('ignores and an additive plugin config', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}import playwright from 'eslint-plugin-playwright';\n
+export default defineConfig(
+	{ ignores: ['dist/**'] },
+	backendConfig,
+	playwright.configs['flat/recommended'],
+);
+`,
+			);
+
+			expect(await analyze()).toEqual([]);
+		});
+
+		it('a package-wide block that only raises rules', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}
+export default defineConfig(backendConfig, {
+	rules: {
+		complexity: ['error', 27],
+		'@typescript-eslint/naming-convention': ['error', { selector: 'default', format: ['camelCase'] }],
+	},
+});
+`,
+			);
+
+			expect(await analyze()).toEqual([]);
+		});
+
+		it('a relaxation scoped to real paths', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}
+export default defineConfig(backendConfig, {
+	files: ['src/legacy/thing.ts'],
+	rules: { 'n8n-local-rules/no-uncentralized-http': 'off' },
+});
+`,
+			);
+
+			expect(await analyze()).toEqual([]);
+		});
+
+		it('a relaxation scoped to test files', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}
+export default defineConfig(backendConfig, {
+	files: ['**/*.test.ts'],
+	rules: { '@typescript-eslint/no-explicit-any': 'off' },
+});
+`,
+			);
+
+			expect(await analyze()).toEqual([]);
+		});
+
+		it('a package with no ESLint config', async () => {
+			writePackage('packages/a', null);
+
+			expect(await analyze()).toEqual([]);
+		});
+
+		it('an exempt package', async () => {
+			writePackage(
+				'packages/frontend/@n8n/eslint-plugin-design-system',
+				"import tseslint from 'typescript-eslint';\nexport default tseslint.config();\n",
+			);
+
+			expect(
+				await analyze({ exempt: ['packages/frontend/@n8n/eslint-plugin-design-system'] }),
+			).toEqual([]);
+		});
+	});
+
+	describe('reports', () => {
+		it('a package-wide downgrade', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}
+export default defineConfig(backendConfig, {
+	rules: { '@typescript-eslint/no-explicit-any': 'warn' },
+});
+`,
+			);
+
+			const violations = await analyze();
+
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain("turns '@typescript-eslint/no-explicit-any' down to 'warn'");
+		});
+
+		it('a package-wide off, and a numeric severity', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}
+export default defineConfig(backendConfig, {
+	rules: { 'no-empty': 'off', eqeqeq: 0 },
+});
+`,
+			);
+
+			expect(await analyze()).toHaveLength(2);
+		});
+
+		it('a downgrade in a block whose glob still covers the package', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}
+export default defineConfig(backendConfig, {
+	files: ['src/**/*.ts'],
+	rules: { 'no-empty': 'off' },
+});
+`,
+			);
+
+			const violations = await analyze();
+
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain("turns 'no-empty' down to 'off'");
+		});
+
+		it('a severity that is not a literal', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}
+export default defineConfig(backendConfig, {
+	rules: { 'no-debugger': process.env.CI ? 'error' : 'off' },
+});
+`,
+			);
+
+			const violations = await analyze();
+
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain('is not a literal');
+		});
+
+		it('two shared layers at once', async () => {
+			writePackage(
+				'packages/a',
+				`${HEAD}import { frontendConfig } from '@n8n/eslint-config/frontend';\n
+export default defineConfig(backendConfig, frontendConfig);
+`,
+			);
+
+			const violations = await analyze();
+
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain('extends more than one shared layer');
+		});
+
+		it('an import of a retired subpath', async () => {
+			writePackage(
+				'packages/a',
+				`import { defineConfig } from 'eslint/config';
+import { nodeConfig } from '@n8n/eslint-config/node';
+
+export default defineConfig(nodeConfig);
+`,
+			);
+
+			const violations = await analyze();
+
+			expect(violations).toHaveLength(2);
+			expect(violations[0]).toContain("'@n8n/eslint-config/node', which no longer exists");
+			expect(violations[1]).toContain('does not extend a shared ESLint layer');
+		});
+
+		it('a config that extends no layer', async () => {
+			writePackage(
+				'packages/a',
+				"import tseslint from 'typescript-eslint';\nexport default tseslint.config();\n",
+			);
+
+			const violations = await analyze();
+
+			expect(violations).toHaveLength(1);
+			expect(violations[0]).toContain('does not extend a shared ESLint layer');
+		});
+	});
+});

--- a/packages/testing/code-health/src/rules/lint-config-layering.rule.ts
+++ b/packages/testing/code-health/src/rules/lint-config-layering.rule.ts
@@ -1,0 +1,217 @@
+import { BaseRule } from '@n8n/rules-engine';
+import type { Violation } from '@n8n/rules-engine';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Project, ScriptKind, SyntaxKind } from 'ts-morph';
+import type { Node, ObjectLiteralExpression } from 'ts-morph';
+
+import type { CodeHealthContext } from '../context.js';
+import { findPackageJsonFiles, relativeDir } from '../utils/package-json-scanner.js';
+
+const CONFIG_FILENAMES = ['eslint.config.mjs', 'eslint.config.js', 'eslint.config.cjs'];
+
+const LAYERS = ['base', 'backend', 'frontend', 'nodes'];
+const LAYER_IMPORT = /^@n8n\/eslint-config\/([a-z-]+)$/;
+
+/** Retired export paths, replaced by the four layers. */
+const REMOVED_SUBPATHS = new Set(['node', 'encryption-boundary']);
+
+/**
+ * A `files` glob that covers effectively the whole package, so a block scoped to
+ * it is a package-wide decision wearing a scope.
+ */
+const PACKAGE_WIDE_GLOB =
+	/^\.?\/?(?:\*\*|\*\*\/\*|src\/\*\*|src\/\*\*\/\*)(?:\.[cm]?[jt]sx?|\.vue)?$/;
+
+/** A glob that names test material, where relaxations are expected. */
+const TEST_GLOB = /(^|\/)(?:test|tests|__test__|__tests__)(\/|$)|\.(?:test|spec|cy|stories)\./;
+
+const WEAK_SEVERITY = new Set(['off', 'warn', '0', '1']);
+
+/**
+ * Keeps the ESLint setup readable by keeping the decisions in one place.
+ *
+ * The repo used to carry a rule table in each of 72 package configs, which is
+ * how it ended up with the same override written 35 times and four rules
+ * silently shadowed by a duplicate key. The four shared layers hold the policy
+ * now, so a package config may pick a layer and scope exceptions to paths, but
+ * it may not quietly re-decide a rule for its whole tree.
+ *
+ * Allowed in a package config:
+ * - exactly one shared layer
+ * - `ignores`, and additive plugin configs
+ * - any severity inside a block with a real `files` scope (that is a ratchet,
+ *   and it says which paths it covers)
+ * - a package-wide block that only raises rules to `error`
+ *
+ * Reported: a package-wide `off`/`warn`, a severity that is not a literal (it
+ * cannot be read from the config or translated to another linter), and any
+ * import of a retired subpath. Existing debt lives in the baseline, which only
+ * shrinks.
+ */
+export class LintConfigLayeringRule extends BaseRule<CodeHealthContext> {
+	readonly id = 'lint-config-layering';
+	readonly name = 'Lint Config Layering';
+	readonly description =
+		'Package ESLint configs must extend one shared layer from @n8n/eslint-config and scope every relaxation to a path, so rule policy stays in the shared layers.';
+	readonly severity = 'error' as const;
+
+	async analyze(context: CodeHealthContext): Promise<Violation[]> {
+		const { rootDir } = context;
+		const options = this.getOptions();
+		const exempt = Array.isArray(options.exempt) ? (options.exempt as string[]) : [];
+
+		const violations: Violation[] = [];
+		const seen = new Set<string>();
+
+		for (const packageJsonPath of await findPackageJsonFiles(rootDir)) {
+			const packageDir = path.dirname(packageJsonPath);
+			const rel = relativeDir(rootDir, packageJsonPath);
+			if (exempt.some((entry) => rel === entry || rel.startsWith(`${entry}/`))) continue;
+
+			const configPath = CONFIG_FILENAMES.map((name) => path.join(packageDir, name)).find((p) =>
+				fs.existsSync(p),
+			);
+			if (!configPath || seen.has(configPath)) continue;
+			seen.add(configPath);
+
+			violations.push(...this.checkConfig(configPath, rel));
+		}
+
+		return violations;
+	}
+
+	private checkConfig(configPath: string, packageName: string): Violation[] {
+		const text = fs.readFileSync(configPath, 'utf-8');
+		const source = new Project({
+			useInMemoryFileSystem: true,
+			compilerOptions: { allowJs: true },
+		}).createSourceFile(configPath, text, { scriptKind: ScriptKind.JS });
+
+		const violations: Violation[] = [];
+		const at = (node: Node) => {
+			const { line, column } = source.getLineAndColumnAtPos(node.getStart());
+			return { line, column };
+		};
+
+		// 1. exactly one layer, and no retired subpath
+		const layerImports: string[] = [];
+		for (const declaration of source.getImportDeclarations()) {
+			const specifier = declaration.getModuleSpecifierValue();
+			const match = LAYER_IMPORT.exec(specifier);
+			if (!match) continue;
+			const subpath = match[1];
+			if (REMOVED_SUBPATHS.has(subpath)) {
+				const { line, column } = at(declaration);
+				violations.push(
+					this.createViolation(
+						configPath,
+						line,
+						column,
+						`${packageName} imports '@n8n/eslint-config/${subpath}', which no longer exists.`,
+						'Use one of the four layers: base, backend, frontend or nodes. The boundary configs are part of backendConfig.',
+					),
+				);
+				continue;
+			}
+			if (LAYERS.includes(subpath)) layerImports.push(subpath);
+		}
+
+		if (layerImports.length === 0) {
+			violations.push(
+				this.createViolation(
+					configPath,
+					1,
+					1,
+					`${packageName} does not extend a shared ESLint layer.`,
+					'Import baseConfig, backendConfig, frontendConfig or nodesConfig from @n8n/eslint-config and pass it to defineConfig.',
+				),
+			);
+		} else if (layerImports.length > 1) {
+			violations.push(
+				this.createViolation(
+					configPath,
+					1,
+					1,
+					`${packageName} extends more than one shared layer (${layerImports.join(', ')}).`,
+					'Pick the single layer that matches the package. The backend layer already contains the base layer, and the nodes layer contains the backend layer.',
+				),
+			);
+		}
+
+		// 2. every `rules` block: package-wide blocks may only raise to error
+		for (const rulesProperty of source.getDescendantsOfKind(SyntaxKind.PropertyAssignment)) {
+			if (rulesProperty.getName().replace(/['"]/g, '') !== 'rules') continue;
+			const rulesObject = rulesProperty.getInitializerIfKind(SyntaxKind.ObjectLiteralExpression);
+			if (!rulesObject) continue;
+
+			const owner = rulesProperty.getParentIfKind(SyntaxKind.ObjectLiteralExpression);
+			if (!owner) continue;
+
+			for (const entry of rulesObject.getProperties()) {
+				if (!entry.isKind(SyntaxKind.PropertyAssignment)) continue;
+				const ruleId = entry.getName().replace(/['"]/g, '');
+				const severity = readSeverity(entry.getInitializer());
+
+				if (severity === undefined) {
+					const { line, column } = at(entry);
+					violations.push(
+						this.createViolation(
+							configPath,
+							line,
+							column,
+							`${packageName} sets '${ruleId}' to a severity that is not a literal.`,
+							'Use a literal severity. A severity computed from the environment makes the config resolve differently per machine and cannot be translated to another linter.',
+						),
+					);
+					continue;
+				}
+
+				if (!WEAK_SEVERITY.has(severity)) continue;
+				if (isScopedToPaths(owner)) continue;
+
+				const { line, column } = at(entry);
+				violations.push(
+					this.createViolation(
+						configPath,
+						line,
+						column,
+						`${packageName} turns '${ruleId}' down to '${severity}' for the whole package.`,
+						'Scope it to the paths that need it with `files`, or retire the rule in the shared layer if the whole repo has stopped enforcing it. Under `--quiet` a warning enforces nothing.',
+					),
+				);
+			}
+		}
+
+		return violations;
+	}
+}
+
+/** The literal severity of a rule entry, or undefined when it is computed. */
+function readSeverity(initializer: Node | undefined): string | undefined {
+	if (!initializer) return undefined;
+	if (initializer.isKind(SyntaxKind.StringLiteral)) return initializer.getLiteralValue();
+	if (initializer.isKind(SyntaxKind.NumericLiteral)) return initializer.getText();
+	if (initializer.isKind(SyntaxKind.ArrayLiteralExpression)) {
+		return readSeverity(initializer.getElements()[0]);
+	}
+	return undefined;
+}
+
+/** True when the block names paths narrower than the package itself. */
+function isScopedToPaths(owner: ObjectLiteralExpression): boolean {
+	const filesProperty = owner.getProperty('files');
+	if (!filesProperty?.isKind(SyntaxKind.PropertyAssignment)) return false;
+	const array = filesProperty.getInitializerIfKind(SyntaxKind.ArrayLiteralExpression);
+	if (!array) return false;
+
+	const globs = array
+		.getElements()
+		.filter((element) => element.isKind(SyntaxKind.StringLiteral))
+		.map((element) => element.getLiteralValue());
+	if (globs.length === 0) return false;
+
+	// test globs always count as a scope; otherwise at least one glob must be
+	// narrower than the whole package
+	return globs.some((glob) => TEST_GLOB.test(glob) || !PACKAGE_WIDE_GLOB.test(glob));
+}


### PR DESCRIPTION
## Summary

Enforce the usage of shared configurations via code health to evade linting rules slipping to 50 different variations again.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

