### PR TITLE
fix(core): Run tool nodes of an AI Agent upstream of the destination node

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -58,6 +58,7 @@ import { DirectedGraph } from '../partial-execution-utils';
 import * as partialExecutionUtils from '../partial-execution-utils';
 import { createNodeData, toITaskData } from '../partial-execution-utils/__tests__/helpers';
 import { WorkflowExecute } from '../workflow-execute';
+import { modifyNode, nodeTypeArguments, passThroughNode, types } from './mock-node-types';
 
 vi.mock('node:fs', async (importActual) => ({
 	...(await importActual()),
@@ -617,6 +618,77 @@ describe('WorkflowExecute', () => {
 			expect(runNodeFilter).toContain(trigger.name);
 			expect(runNodeFilter).toContain(agent.name);
 			expect(runNodeFilter).toContain(tool.name);
+		});
+
+		test('runs the tool nodes of an agent upstream of the destination node', async () => {
+			const agentNodeType = modifyNode(passThroughNode)
+				.return({
+					actions: [
+						{
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'tool',
+							input: { query: 'test input' },
+							type: 'ai_tool',
+							id: 'action_1',
+							metadata: {},
+						},
+					],
+					metadata: {},
+				})
+				.return((response) => [
+					[
+						{
+							json: {
+								toolResult:
+									response?.actionResponses[0]?.data.data?.ai_tool?.[0]?.[0]?.json ?? null,
+							},
+						},
+					],
+				])
+				.done();
+
+			const trigger = createNodeData({ name: 'trigger', type: types.passThrough });
+			const agent = createNodeData({ name: 'agent', type: 'agent' });
+			const merge = createNodeData({ name: 'merge', type: types.passThrough });
+			const tool = createNodeData({ name: 'tool', type: types.passThrough });
+			const customNodeTypes = Helpers.NodeTypes({
+				...nodeTypeArguments,
+				agent: { type: agentNodeType, sourcePath: '' },
+			});
+
+			const workflow = new DirectedGraph()
+				.addNodes(trigger, agent, merge, tool)
+				.addConnections(
+					{ from: trigger, to: agent, type: NodeConnectionTypes.Main },
+					{ from: agent, to: merge, type: NodeConnectionTypes.Main },
+					{ from: tool, to: agent, type: NodeConnectionTypes.AiTool },
+				)
+				.toWorkflow({
+					name: '',
+					active: false,
+					nodeTypes: customNodeTypes,
+					settings: { executionOrder },
+				});
+
+			const workflowExecute = new WorkflowExecute(
+				Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>()),
+				executionMode,
+			);
+
+			const result = await workflowExecute.run({
+				workflow,
+				startNode: trigger,
+				destinationNode: { nodeName: merge.name, mode: 'inclusive' },
+			});
+
+			const runData = result.data.resultData.runData;
+			expect(runData[tool.name][0].executionStatus).toBe('success');
+
+			const agentRuns = runData[agent.name];
+			expect(agentRuns[agentRuns.length - 1].data?.main?.[0]?.[0]?.json.toolResult).toMatchObject({
+				query: 'test input',
+				toolCallId: 'action_1',
+			});
 		});
 	});
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -156,12 +156,16 @@ export class WorkflowExecute {
 			throw new UserError('No node to start the workflow from could be found');
 		}
 
-		// If a destination node is given we only run the direct parent nodes and no others
+		// Include non-main parents for the destination and each main ancestor.
+		// Agents use the engine to run tools through non-main connections.
 		let runNodeFilter: string[] | undefined;
 		if (destinationNode) {
+			const parentNodes = workflow.getParentNodes(destinationNode.nodeName);
 			runNodeFilter = [
-				...workflow.getParentNodes(destinationNode.nodeName),
-				...workflow.getParentNodes(destinationNode.nodeName, 'ALL_NON_MAIN'),
+				...parentNodes,
+				...[destinationNode.nodeName, ...parentNodes].flatMap((nodeName) =>
+					workflow.getParentNodes(nodeName, 'ALL_NON_MAIN'),
+				),
 			];
 			if (destinationNode.mode === 'inclusive') {
 				runNodeFilter.push(destinationNode.nodeName);


### PR DESCRIPTION
## Summary

Tool nodes of an AI Agent did not run when a user executed a node downstream of the agent with "Execute step" on a workflow that had no run data yet. The tool node stayed at "Unknown in 0s" in the logs, and the agent got an empty tool result. The reporter saw this with OpenRouter models, but the model provider is not the cause.

**Root cause.** `WorkflowExecute.run()` builds `runNodeFilter` when a destination node is set. The filter contained the main ancestors of the destination and the non-main parents of the destination only. The AI Agent V3 node runs its tools through the engine: it returns an `EngineRequest`, and the engine schedules the tool node. `processRunExecutionData` skips every node that is not in `runNodeFilter`. The tool node of an agent upstream of the destination was not in the filter, so the engine skipped it and resumed the agent with an empty observation. `runPartialWorkflow2` does not have this bug because `findSubgraph()` adds the non-main parents of every node in the subgraph.

**Fix.** `run()` now adds the non-main parents of the destination and of each main ancestor to `runNodeFilter`. This mirrors `findSubgraph()`. `getParentNodes(..., 'ALL_NON_MAIN')` is recursive, so nested sub-nodes (for example a model under a tool) are included too. Full runs (no destination) and partial runs with existing run data are unchanged.

## How to test

1. Create a new workflow: Manual Trigger → AI Agent (V3) → Edit Fields.
2. Attach a chat model (any provider) and one tool (for example the Calculator tool) to the AI Agent.
3. Set the agent prompt to something that requires the tool, for example `What is 17 * 23? Use the calculator.`
4. Do **not** run the workflow first. Open the Edit Fields node and click **Execute step**.
5. Before the fix: the Calculator node shows "Unknown in 0s" in the logs panel with an empty input, and the agent answers without a tool result.
6. After the fix: the Calculator node executes with status success, and the agent output contains the tool result.

Regression test: `packages/core/src/execution-engine/__tests__/workflow-execute.test.ts` → `run() destination filtering` → `runs the tool nodes of an agent upstream of the destination node`. The test fails on master (`expected undefined to be 'success'`) and passes with this change.

Run it from `packages/core`:

```bash
pnpm test src/execution-engine/__tests__/workflow-execute.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-872

fixes #29758

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

