### PR TITLE
ci: Run owners and PR quality scripts without a Node.js setup (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -572,6 +572,7 @@ Composite actions in `.github/actions/`:
 | Action                   | Purpose                                      | Used By            |
 |--------------------------|----------------------------------------------|--------------------|
 | `setup-nodejs`           | pnpm + Node.js + Turbo cache + Docker (opt)  | Most CI workflows  |
+| `run-workflow-script`    | Run a `.github/scripts` module with no setup or install | Owners and PR quality checks |
 | `docker-registry-login`  | GHCR + DockerHub + DHI authentication        | Docker workflows   |
 
 ### setup-nodejs
@@ -607,6 +608,30 @@ newly created sticky disk - it stays at 0 bytes however many runs commit to it,
 while the build reports a successful commit. Every job therefore shares the
 `n8n-io/n8n` key, which is the only disk that actually retains layers. Revisit
 once new-disk retention works.
+
+### run-workflow-script
+
+```yaml
+inputs:
+  script:        # path of the module, relative to the repository root
+  github-token:  # token for the Octokit client, also exported as GITHUB_TOKEN
+```
+
+Runs one `.github/scripts` module through `actions/github-script`. That action
+brings its own Node.js and an Octokit client, so the job needs no
+`setup-nodejs` step and no dependency install. The action loads
+`github-helpers.mjs`, hands the client to `setOctokit`, then imports the module
+and awaits its exported `main()`.
+
+Use it for a module that imports only node builtins and other `.github/scripts`
+modules. `github-helpers.mjs` loads `@actions/github` and `semver` only when
+they are present, so it works in both modes. A module that needs an npm
+package (`semver`, `yaml`, `minimatch`, ...) keeps the `setup-nodejs` path with
+the `.github/scripts` install command.
+
+Pair it with a sparse checkout of `.github` when the module reads nothing else
+from the tree. Cone mode always includes the root files, so `OWNERS` and
+`package.json` stay available.
 
 ### docker-registry-login
 
@@ -687,6 +712,7 @@ Scripts in `.github/scripts/`:
 | `nightly-sbom-context.mjs` | Resolve the source SHA and image tag for nightly SBOM validation | `test-sbom-nightly.yml` |
 | `db-test-matrix.mjs`    | DB test matrix from `postgres-versions.json` | `ci-pull-requests.yml` |
 | `quality/check-cubic-config.mjs` | Validate `cubic.yaml` against the vendored cubic schema; enforce its silent agent/character limits. `--refresh` re-pulls the schema | `test-workflow-scripts-reusable.yml`, `util-refresh-cubic-schema.yml` |
+| `glob.mjs`              | Builtin-only glob matcher for changed-file paths (`**`, `*`, dot segments) | `quality/check-pr-size.mjs` |
 | `probe-registry.mjs`    | Registry path throughput probe (temporary) | `util-probe-registry.yml` |
 
 ### Preview Scripts

--- a/.github/actions/run-workflow-script/action.yml
+++ b/.github/actions/run-workflow-script/action.yml
@@ -1,0 +1,42 @@
+# Runs one `.github/scripts` module without a Node.js setup or a dependency
+# install. actions/github-script brings its own Node.js and Octokit client;
+# the module receives that client through `setOctokit` in github-helpers.mjs.
+#
+# The module must export an async `main()` function and must import only
+# node builtins and other `.github/scripts` modules. A module that needs an
+# npm package (semver, yaml, ...) keeps using `setup-nodejs` with an
+# install command instead.
+name: 'Run workflow script'
+description: 'Runs a .github/scripts module through actions/github-script, without a Node.js setup or dependency install.'
+
+inputs:
+  script:
+    description: 'Path of the module, relative to the repository root. It must export an async main() function.'
+    required: true
+  github-token:
+    description: 'Token for the Octokit client. Also exported as GITHUB_TOKEN for the module.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run workflow script
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        SCRIPT: ${{ inputs.script }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const path = require('node:path');
+          const { pathToFileURL } = require('node:url');
+          const load = (file) => import(pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, file)).href);
+
+          const { setOctokit } = await load('.github/scripts/github-helpers.mjs');
+          setOctokit(github);
+
+          const { main } = await load(process.env.SCRIPT);
+          if (typeof main !== 'function') {
+            throw new Error(`${process.env.SCRIPT} does not export main()`);
+          }
+          await main();

--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -1,8 +1,17 @@
-import { getOctokit } from '@actions/github';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
-import semver from 'semver';
+
+// Scripts that run through `run-workflow-script` have no node_modules: they
+// get their client through `setOctokit` and never call the release helpers.
+const actionsGithub = await import('@actions/github').catch((error) => {
+	if (error.code !== 'ERR_MODULE_NOT_FOUND') throw error;
+	return null;
+});
+const require = createRequire(import.meta.url);
+/** @returns { typeof import('semver') } */
+const loadSemver = () => require('semver');
 
 export const CURRENT_MAJOR_VERSION = 2;
 export const RELEASE_CANDIDATE_BRANCH_PREFIX = 'release-candidate/';
@@ -48,8 +57,8 @@ export function pickHighestReleaseTag(tags) {
 	const versions = tags
 		.filter((t) => t.startsWith(RELEASE_PREFIX))
 		.map((t) => ({ tag: t, v: stripReleasePrefixes(t) }))
-		.filter(({ v }) => semver.valid(v))
-		.sort((a, b) => semver.rcompare(a.v, b.v));
+		.filter(({ v }) => loadSemver().valid(v))
+		.sort((a, b) => loadSemver().rcompare(a.v, b.v));
 
 	return /** @type { ReleaseVersion } */ (versions[0]?.tag) ?? null;
 }
@@ -128,7 +137,7 @@ export function resolveRcBranchForTrack(track) {
 	const releaseTag = pickHighestReleaseTag(tagsAtCommit);
 	if (!releaseTag) return null;
 
-	const parsed = semver.parse(stripReleasePrefixes(releaseTag));
+	const parsed = loadSemver().parse(stripReleasePrefixes(releaseTag));
 	if (!parsed) return null;
 
 	return `release-candidate/${parsed.major}.${parsed.minor}.x`;
@@ -145,12 +154,12 @@ export function resolveRcBranchForTrack(track) {
  * */
 export function tagVersionInfoToReleaseCandidateBranchName(tagVersionInfo) {
 	const version = tagVersionInfo.version;
-	const majorVersion = semver.major(version);
+	const majorVersion = loadSemver().major(version);
 	if (majorVersion < CURRENT_MAJOR_VERSION) {
 		return `${majorVersion}.x`;
 	}
 
-	return `${RELEASE_CANDIDATE_BRANCH_PREFIX}${majorVersion}.${semver.minor(version)}.x`;
+	return `${RELEASE_CANDIDATE_BRANCH_PREFIX}${majorVersion}.${loadSemver().minor(version)}.x`;
 }
 
 /**
@@ -351,18 +360,37 @@ export function localRefExists(ref) {
 	return res.ok;
 }
 
+/** @type { GitHubInstance | null } */
+let injectedOctokit = null;
+
 /**
- * Initializes octokit with GITHUB_TOKEN from env vars.
+ * Use a ready client instead of building one from GITHUB_TOKEN.
+ * `run-workflow-script` passes the client that actions/github-script provides.
  *
- * Also ensures the existence of useful environment variables.
+ * @param { GitHubInstance | null } octokit
+ */
+export function setOctokit(octokit) {
+	injectedOctokit = octokit;
+}
+
+/**
+ * Returns the octokit client and the current repository.
+ *
+ * Uses the injected client when set, otherwise builds one from GITHUB_TOKEN.
  * */
 export function initGithub() {
-	const token = ensureEnvVar('GITHUB_TOKEN');
 	const repoFullName = ensureEnvVar('GITHUB_REPOSITORY');
-
 	const [owner, repo] = repoFullName.split('/');
 
-	const octokit = getOctokit(token);
+	if (injectedOctokit) {
+		return { octokit: injectedOctokit, owner, repo };
+	}
+
+	if (!actionsGithub) {
+		throw new Error('No Octokit client: call setOctokit() or install the .github/scripts dependencies');
+	}
+	const token = ensureEnvVar('GITHUB_TOKEN');
+	const octokit = actionsGithub.getOctokit(token);
 
 	return {
 		octokit,

--- a/.github/scripts/github-helpers.test.mjs
+++ b/.github/scripts/github-helpers.test.mjs
@@ -18,7 +18,9 @@ mock.module('@actions/github', {
 	},
 });
 
-const { postOrUpdateComment, writeGithubOutput } = await import('./github-helpers.mjs');
+const { initGithub, postOrUpdateComment, setOctokit, writeGithubOutput } = await import(
+	'./github-helpers.mjs'
+);
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -127,5 +129,40 @@ describe('writeGithubOutput', () => {
 		writeGithubOutput({ ignored: 'value' }, {});
 
 		assert.equal(existsSync(outputPath), false);
+	});
+});
+
+describe('initGithub', () => {
+	beforeEach(() => {
+		process.env.GITHUB_REPOSITORY = 'n8n-io/n8n';
+		delete process.env.GITHUB_TOKEN;
+	});
+
+	afterEach(() => {
+		setOctokit(null);
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it('uses the injected client and needs no token', () => {
+		const injected = { rest: {} };
+		setOctokit(injected);
+
+		const result = initGithub();
+
+		assert.equal(result.octokit, injected);
+		assert.equal(result.owner, 'n8n-io');
+		assert.equal(result.repo, 'n8n');
+	});
+
+	it('builds a client from GITHUB_TOKEN when nothing is injected', () => {
+		const built = { rest: {} };
+		octokitImpl = () => built;
+		process.env.GITHUB_TOKEN = 'token';
+
+		assert.equal(initGithub().octokit, built);
+	});
+
+	it('requires GITHUB_TOKEN when nothing is injected', () => {
+		assert.throws(() => initGithub(), /GITHUB_TOKEN/);
 	});
 });

--- a/.github/scripts/glob.mjs
+++ b/.github/scripts/glob.mjs
@@ -1,0 +1,49 @@
+/**
+ * Minimal glob matcher for changed-file paths.
+ *
+ * Supports `**` (any number of path segments), `*` (any run of characters
+ * inside one segment) and literal text. Dot segments match like any other,
+ * so patterns reach files under `.github/`. Only node builtins, so scripts
+ * that run through `run-workflow-script` can use it without an install.
+ */
+
+/** @type { Map<string, RegExp> } */
+const cache = new Map();
+
+/**
+ * @param { string } pattern
+ * @returns { RegExp }
+ */
+export function globToRegExp(pattern) {
+	const cached = cache.get(pattern);
+	if (cached) return cached;
+
+	let source = '';
+	const segments = pattern.split('/');
+	for (const [index, segment] of segments.entries()) {
+		const last = index === segments.length - 1;
+		if (segment === '**') {
+			// `**/` matches zero or more segments; a trailing `**` matches the rest.
+			source += last ? '.*' : '(?:[^/]+/)*';
+			continue;
+		}
+		source += segment
+			.split('*')
+			.map((literal) => literal.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+			.join('[^/]*');
+		if (!last) source += '/';
+	}
+
+	const regExp = new RegExp(`^${source}$`);
+	cache.set(pattern, regExp);
+	return regExp;
+}
+
+/**
+ * @param { string } file Repository-relative path with `/` separators.
+ * @param { string } pattern
+ * @returns { boolean }
+ */
+export function matchesGlob(file, pattern) {
+	return globToRegExp(pattern).test(file);
+}

--- a/.github/scripts/glob.test.mjs
+++ b/.github/scripts/glob.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { minimatch } from 'minimatch';
+
+import { matchesGlob } from './glob.mjs';
+import { EXCLUDE_PATTERNS } from './quality/check-pr-size.mjs';
+
+/**
+ * Run with:
+ * node --test --experimental-test-module-mocks ./.github/scripts/glob.test.mjs
+ * */
+
+describe('matchesGlob', () => {
+	it('matches a file extension anywhere in the tree', () => {
+		assert.equal(matchesGlob('a.test.ts', '**/*.test.ts'), true);
+		assert.equal(matchesGlob('packages/cli/src/a.test.ts', '**/*.test.ts'), true);
+		assert.equal(matchesGlob('packages/cli/src/a.ts', '**/*.test.ts'), false);
+	});
+
+	it('matches dot segments', () => {
+		assert.equal(matchesGlob('.github/scripts/a.test.mjs', '**/*.test.mjs'), true);
+		assert.equal(matchesGlob('.github/scripts/glob.mjs', '**/*.test.mjs'), false);
+	});
+
+	it('matches a directory at any depth', () => {
+		assert.equal(matchesGlob('test/a.ts', '**/test/**'), true);
+		assert.equal(matchesGlob('packages/x/test/deep/a.ts', '**/test/**'), true);
+		assert.equal(matchesGlob('packages/x/tests/a.ts', '**/test/**'), false);
+		assert.equal(matchesGlob('packages/x/testing/a.ts', '**/test/**'), false);
+	});
+
+	it('matches a prefix pattern', () => {
+		assert.equal(matchesGlob('packages/testing/playwright/a.ts', 'packages/testing/**'), true);
+		assert.equal(matchesGlob('packages/testing', 'packages/testing/**'), false);
+		assert.equal(matchesGlob('packages/cli/a.ts', 'packages/testing/**'), false);
+	});
+
+	it('matches a literal path only exactly', () => {
+		assert.equal(matchesGlob('pnpm-lock.yaml', 'pnpm-lock.yaml'), true);
+		assert.equal(matchesGlob('packages/cli/pnpm-lock.yaml', 'pnpm-lock.yaml'), false);
+		assert.equal(matchesGlob('pnpm-lockXyaml', 'pnpm-lock.yaml'), false);
+	});
+
+	it('keeps `*` inside one segment', () => {
+		assert.equal(matchesGlob('a/b.snap', '**/*.snap'), true);
+		assert.equal(matchesGlob('a/b/c.md', 'a/*.md'), false);
+	});
+
+	it('agrees with minimatch on the PR size patterns', () => {
+		const files = [
+			'packages/cli/src/a.ts',
+			'packages/cli/src/a.test.ts',
+			'packages/cli/test/a.ts',
+			'packages/cli/__tests__/a.ts',
+			'packages/cli/__snapshots__/a.ts.snap',
+			'packages/nodes-base/nodes/Foo/test/fixtures/a.json',
+			'packages/frontend/editor-ui/src/__mocks__/a.ts',
+			'packages/testing/playwright/a.ts',
+			'packages/testing',
+			'.github/scripts/glob.test.mjs',
+			'.github/workflows/ci.yml',
+			'a/.hidden/b.spec.js',
+			'pnpm-lock.yaml',
+			'packages/cli/pnpm-lock.yaml',
+			'README.md',
+			'docs/a.mdx',
+			'src/tests.ts',
+			'src/test.ts',
+			'src/testing/a.ts',
+		];
+		for (const pattern of EXCLUDE_PATTERNS) {
+			for (const file of files) {
+				assert.equal(
+					matchesGlob(file, pattern),
+					minimatch(file, pattern, { dot: true }),
+					`${file} against ${pattern}`,
+				);
+			}
+		}
+	});
+});

--- a/.github/scripts/owners/assign-reviewers.mjs
+++ b/.github/scripts/owners/assign-reviewers.mjs
@@ -94,7 +94,11 @@ export async function run(pullRequestNumber) {
 	await removeLabel(pullRequestNumber, AUTO_ASSIGN_LABEL);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+export async function main() {
 	const pullRequestNumber = parseInt(ensureEnvVar('PULL_REQUEST_NUMBER'));
 	await run(pullRequestNumber);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	await main();
 }

--- a/.github/scripts/owners/required-reviews.mjs
+++ b/.github/scripts/owners/required-reviews.mjs
@@ -210,6 +210,8 @@ export async function run() {
 	});
 }
 
+export const main = run;
+
 if (import.meta.url === `file://${process.argv[1]}`) {
-	await run();
+	await main();
 }

--- a/.github/scripts/owners/review-recommendations.mjs
+++ b/.github/scripts/owners/review-recommendations.mjs
@@ -282,7 +282,11 @@ export async function run(pullRequestNumber) {
 	await postOrUpdateComment(pullRequestNumber, body, BOT_MARKER);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+export async function main() {
 	const pullRequestNumber = parseInt(ensureEnvVar('PULL_REQUEST_NUMBER'));
 	await run(pullRequestNumber);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	await main();
 }

--- a/.github/scripts/quality/check-pr-size.mjs
+++ b/.github/scripts/quality/check-pr-size.mjs
@@ -12,8 +12,8 @@
  *   1 – PR exceeds the limit with no valid override
  */
 
-import { minimatch } from 'minimatch';
 import { initGithub, getEventFromGithubEventPath } from '../github-helpers.mjs';
+import { matchesGlob } from '../glob.mjs';
 
 export const SIZE_LIMIT = 1000;
 export const OVERRIDE_COMMAND = '/size-limit-override';
@@ -49,10 +49,6 @@ export const MISC_PATTERNS = [
 
 export const EXCLUDE_PATTERNS = [...TEST_PATTERNS, ...MISC_PATTERNS];
 
-// Without `dot`, `**` refuses dot segments, so nothing under `.github/`
-// would ever match a pattern.
-const MATCH_OPTIONS = { dot: true };
-
 /**
  * Categorize a changed file for line statistics.
  *
@@ -60,8 +56,8 @@ const MATCH_OPTIONS = { dot: true };
  * @returns { 'testFiles' | 'misc' | 'sourceCode' }
  */
 export function categorizeFile(filename) {
-	if (TEST_PATTERNS.some((pattern) => minimatch(filename, pattern, MATCH_OPTIONS))) return 'testFiles';
-	if (MISC_PATTERNS.some((pattern) => minimatch(filename, pattern, MATCH_OPTIONS))) return 'misc';
+	if (TEST_PATTERNS.some((pattern) => matchesGlob(filename, pattern))) return 'testFiles';
+	if (MISC_PATTERNS.some((pattern) => matchesGlob(filename, pattern))) return 'misc';
 	return 'sourceCode';
 }
 
@@ -102,11 +98,11 @@ export async function hasValidOverride(comments, getPermission) {
  */
 export function countFilteredAdditions(files, excludePatterns) {
 	return files
-		.filter((file) => !excludePatterns.some((pattern) => minimatch(file.filename, pattern, MATCH_OPTIONS)))
+		.filter((file) => !excludePatterns.some((pattern) => matchesGlob(file.filename, pattern)))
 		.reduce((sum, file) => sum + file.additions, 0);
 }
 
-async function main() {
+export async function main() {
 	const event = getEventFromGithubEventPath();
 	const pr = event.pull_request;
 	const { octokit, owner, repo } = initGithub();
@@ -173,7 +169,7 @@ async function main() {
 		console.log(
 			`::error::PR adds ${additions.toLocaleString()} lines (test files excluded), exceeding the ${SIZE_LIMIT.toLocaleString()}-line limit. Reduce PR size or ask a maintainer to comment \`${OVERRIDE_COMMAND}\`.`,
 		);
-		process.exit(1);
+		throw new Error(`PR exceeds the ${SIZE_LIMIT.toLocaleString()}-line size limit`);
 	} else {
 		if (botComment) {
 			await octokit.rest.issues.deleteComment({

--- a/.github/scripts/quality/handle-size-override.mjs
+++ b/.github/scripts/quality/handle-size-override.mjs
@@ -32,10 +32,9 @@ export async function run({ octokit, owner, repo, prNumber, commenter, commentId
 	});
 
 	if (!['admin', 'write', 'maintain'].includes(perm.permission)) {
-		console.log(
-			`::error::@${commenter} does not have permission to override the PR size limit (requires write access).`,
+		throw new Error(
+			`@${commenter} does not have permission to override the PR size limit (requires write access).`,
 		);
-		process.exit(1);
 	}
 
 	const { data: pr } = await octokit.rest.pulls.get({
@@ -56,10 +55,9 @@ export async function run({ octokit, owner, repo, prNumber, commenter, commentId
 	});
 
 	if (check_runs.length === 0) {
-		console.log(
-			`::error::No '${CHECK_NAME}' check run found for ${headSha}. Push a new commit to trigger it.`,
+		throw new Error(
+			`No '${CHECK_NAME}' check run found for ${headSha}. Push a new commit to trigger it.`,
 		);
-		process.exit(1);
 	}
 
 	await octokit.rest.checks.rerequestRun({
@@ -78,7 +76,7 @@ export async function run({ octokit, owner, repo, prNumber, commenter, commentId
 	console.log(`Re-requested '${CHECK_NAME}' check run (${check_runs[0].id}) for ${headSha}`);
 }
 
-async function main() {
+export async function main() {
 	const event = getEventFromGithubEventPath();
 	const { octokit, owner, repo } = initGithub();
 

--- a/.github/workflows/ci-owners-assign-reviewers.yml
+++ b/.github/workflows/ci-owners-assign-reviewers.yml
@@ -48,17 +48,16 @@ jobs:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
 
+      # The script reads only `.github/` and the root OWNERS file, which cone
+      # mode always includes.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
         with:
-          build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
-          cache-dependency-path: .github/scripts/pnpm-lock.yaml
+          sparse-checkout: .github
 
       - name: Assign reviewer teams
+        uses: ./.github/actions/run-workflow-script
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-        run: node .github/scripts/owners/assign-reviewers.mjs
+        with:
+          script: .github/scripts/owners/assign-reviewers.mjs
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci-owners-required-reviews.yml
+++ b/.github/workflows/ci-owners-required-reviews.yml
@@ -133,38 +133,19 @@ jobs:
       # Always check out the base branch, never the PR merge ref: the OWNERS
       # file and the scripts must be trusted input. The 'master' fallback
       # covers workflow_dispatch, so a dispatch from another branch cannot
-      # run that branch's policy.
+      # run that branch's policy. The script reads only `.github/` and the
+      # root files, which cone mode always includes.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.ref || 'master' }}
           persist-credentials: false
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
-        with:
-          build-command: ''
-          # pnpm 11 and 12 resolve a relative lockfile directory from different locations.
-          # Use the checkout path because this workflow can run new workflow code against the old base.
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
-          cache-dependency-path: .github/scripts/pnpm-lock.yaml
+          sparse-checkout: .github
 
       - name: Evaluate required reviews
+        uses: ./.github/actions/run-workflow-script
         env:
-          # App token: reading org team membership is beyond GITHUB_TOKEN.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_NUMBER: ${{ inputs.pr_number || '' }}
-          STATUS_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          # Bootstrap: the checkout is the trusted base branch. Until the
-          # enforcement script exists there, there is no policy to enforce.
-          if [ ! -f .github/scripts/owners/required-reviews.mjs ]; then
-            echo "No enforcement script on the base branch; nothing to enforce."
-            if [ -n "$STATUS_SHA" ]; then
-              gh api "repos/${GITHUB_REPOSITORY}/statuses/${STATUS_SHA}" \
-                -f state=success \
-                -f context='Required Reviews' \
-                -f description='Owners enforcement is not on the base branch yet'
-            fi
-            exit 0
-          fi
-          node .github/scripts/owners/required-reviews.mjs
+        with:
+          script: .github/scripts/owners/required-reviews.mjs
+          # App token: reading org team membership is beyond GITHUB_TOKEN.
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci-owners-required-reviews.yml
+++ b/.github/workflows/ci-owners-required-reviews.yml
@@ -141,7 +141,33 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github
 
+      # Bootstrap: the checkout is the trusted base branch. Until the action
+      # exists there, there is nothing to run. Report success so the PR that
+      # introduces it can merge; the check is enforced again from the next PR.
+      - name: Check for the enforcement action on the base branch
+        id: bootstrap
+        shell: bash
+        run: |
+          if [ -f .github/actions/run-workflow-script/action.yml ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "No enforcement action on the base branch; nothing to enforce."
+          fi
+
+      - name: Report the bootstrap state
+        if: steps.bootstrap.outputs.ready != 'true' && github.event.pull_request.head.sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state=success \
+            -f context='Required Reviews' \
+            -f description='Owners enforcement is not on the base branch yet'
+
       - name: Evaluate required reviews
+        if: steps.bootstrap.outputs.ready == 'true'
         uses: ./.github/actions/run-workflow-script
         env:
           PULL_REQUEST_NUMBER: ${{ inputs.pr_number || '' }}

--- a/.github/workflows/ci-owners-review-recommendations.yml
+++ b/.github/workflows/ci-owners-review-recommendations.yml
@@ -39,17 +39,16 @@ jobs:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
 
+      # The script reads only `.github/` and the root OWNERS file, which cone
+      # mode always includes.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
         with:
-          build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
-          cache-dependency-path: .github/scripts/pnpm-lock.yaml
+          sparse-checkout: .github
 
       - name: Post review recommendations
+        uses: ./.github/actions/run-workflow-script
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-        run: node .github/scripts/owners/review-recommendations.mjs
+        with:
+          script: .github/scripts/owners/review-recommendations.mjs
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -30,19 +30,16 @@ jobs:
       issues: write
       pull-requests: read
     steps:
+      # The script reads nothing outside `.github/`.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
         with:
-          build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
-          cache-dependency-path: .github/scripts/pnpm-lock.yaml
+          sparse-checkout: .github
 
       - name: Re-request PR Size Limit check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/quality/handle-size-override.mjs
+        uses: ./.github/actions/run-workflow-script
+        with:
+          script: .github/scripts/quality/handle-size-override.mjs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   check-pr-size:
     name: PR Size Limit
@@ -66,19 +63,16 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # The script reads nothing outside `.github/`.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
         with:
-          build-command: ''
-          install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --lockfile-dir ${{ github.workspace }}/.github/scripts --ignore-workspace
-          cache-dependency-path: .github/scripts/pnpm-lock.yaml
+          sparse-checkout: .github
 
       - name: Check PR size
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/quality/check-pr-size.mjs
+        uses: ./.github/actions/run-workflow-script
+        with:
+          script: .github/scripts/quality/check-pr-size.mjs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   changes:
     name: Detect Changes


### PR DESCRIPTION
## Summary

Script-only CI jobs spent about 38s per run: a 10s full checkout, then about 18s in `setup-nodejs` (five cache restores, `setup-node`, SafeChain) to install 280 packages in 0.4s, for scripts that only call the GitHub API. Six such workflows fire more than 1000 times a week each.

This PR adds `.github/actions/run-workflow-script`, a composite that runs one `.github/scripts` module through `actions/github-script`. That action brings its own Node.js and Octokit client, so the job needs no Node setup and no install. Changes:

- `github-helpers.mjs` loads `@actions/github` and `semver` only when they are present and accepts an injected client through `setOctokit()`. All existing importers keep working unchanged.
- The owners scripts and the PR quality scripts export `main()` and throw errors instead of calling `process.exit`, so github-script reports the failure message.
- `glob.mjs` replaces `minimatch` in the PR size check with a builtin-only matcher. Node's `path.matchesGlob` has no dot-segment option, so it could not match files under `.github/`. The new test cross-checks every PR size pattern against `minimatch`.
- Five jobs switch to the new action and check out only `.github` in cone mode: owners required reviews, owners assign reviewers, owners review recommendations, and the two script jobs in PR quality. Cone mode always includes root files, so `OWNERS` and `package.json` stay available.
- The required reviews workflow keeps a bootstrap guard. It checks out the base branch, so on this PR the new action is not in the checkout yet. When the action is missing, the job reports the "Required Reviews" status as success with the description "Owners enforcement is not on the base branch yet", as the original bootstrap did. From the first PR after this one merges, the guard takes the normal path and enforcement is active again. The guard can go in a follow-up.
- `WORKFLOWS.md` documents the action and when to use it.

Expected per-run effect for those jobs: checkout about 10s to 3s (measured locally: 64 MB to 7 MB transferred), setup about 18s to 1s. On this PR the converted assign and recommend reviewer jobs completed in 8s and 10s. The `setup-nodejs` action itself is unchanged; every step in it is used by build jobs. Note for reviewers: these five jobs no longer pass through SafeChain, because they no longer install anything.

Not converted: backport (needs `semver`), codespace preview (spawns `node scripts/preview.mjs`), new package detection (`child_process`), stale branch cleanup (`minimatch`, weekly).

## How to test

1. `pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace && npm test --prefix .github/scripts`: 749 tests pass, including the new glob and `initGithub` injection tests.
2. Copy `.github/scripts` to a directory without `node_modules`, import `github-helpers.mjs`, call `setOctokit()`, then import each converted module: all load and expose `main()`.
3. On this PR, the "Assign reviewers" and "Recommend reviewers" jobs run the new action against the PR merge commit and pass. The "Required Reviews" status shows the bootstrap description, because that workflow checks out the base branch.
4. `actionlint` passes on the four changed workflows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-1111

Context: the measurement started from the "Required Reviews" check introduced in https://linear.app/n8n/issue/DEVP-887.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
