### PR TITLE
fix(core): Select sandbox npm install flags by provider

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -140,6 +140,7 @@ function mockDaytonaExecuteCommand(command: string): {
 function createFilesystemWorkspace(
 	writeFile: Mock<(...args: [string, string | Buffer, { recursive?: boolean }?]) => Promise<void>>,
 	mkdir?: Mock<(...args: [string, { recursive?: boolean }?]) => Promise<void>>,
+	sandboxProvider: 'daytona' | 'n8n-sandbox' = 'daytona',
 ): SandboxWorkspace {
 	return {
 		filesystem: {
@@ -150,6 +151,7 @@ function createFilesystemWorkspace(
 				vi.fn<(...args: [string, { recursive?: boolean }?]) => Promise<void>>(async () => {}),
 		},
 		sandbox: {
+			provider: sandboxProvider,
 			executeCommand: vi.fn(async (command: string) => {
 				await Promise.resolve();
 				return mockDaytonaExecuteCommand(command);
@@ -495,6 +497,104 @@ describe('setupSandboxWorkspace', () => {
 			'/home/daytona/workspace/.sandbox-initialized',
 			expect.any(String),
 			{ recursive: true },
+		]);
+	});
+
+	it('installs from the npm cache on the Daytona provider', async () => {
+		const runInSandbox: RunInSandboxMock =
+			vi.fn<
+				(
+					...args: [SandboxWorkspace, string, string?]
+				) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+			>();
+		runInSandbox.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+		const readFileViaSandbox: ReadFileViaSandboxMock =
+			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
+		readFileViaSandbox.mockResolvedValue(null);
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
+			runInSandbox,
+			readFileViaSandbox,
+		);
+		const writeFile = vi.fn<
+			(...args: [string, string | Buffer, { recursive?: boolean }?]) => Promise<void>
+		>(async () => {});
+
+		await setupSandboxWorkspace(
+			createFilesystemWorkspace(writeFile, undefined, 'daytona'),
+			createSetupContext(),
+		);
+
+		// The snapshot bake runs the same pinned package.json, so the cached packument
+		// always resolves the pinned SDK version.
+		expect(installCommandsFrom(runInSandbox)).toEqual([
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-offline',
+		]);
+	});
+
+	it('refreshes registry metadata on the n8n-sandbox provider', async () => {
+		const runInSandbox: RunInSandboxMock =
+			vi.fn<
+				(
+					...args: [SandboxWorkspace, string, string?]
+				) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+			>();
+		runInSandbox.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+		const readFileViaSandbox: ReadFileViaSandboxMock =
+			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
+		readFileViaSandbox.mockResolvedValue(null);
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
+			runInSandbox,
+			readFileViaSandbox,
+		);
+		const writeFile = vi.fn<
+			(...args: [string, string | Buffer, { recursive?: boolean }?]) => Promise<void>
+		>(async () => {});
+
+		await setupSandboxWorkspace(
+			createFilesystemWorkspace(writeFile, undefined, 'n8n-sandbox'),
+			createSetupContext(),
+		);
+
+		// The image cache can lag the pinned SDK version, so revalidate up front.
+		expect(installCommandsFrom(runInSandbox)).toEqual([
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-online',
+		]);
+	});
+
+	it('does not retry the install on a provider that already refreshes metadata', async () => {
+		const runInSandbox: RunInSandboxMock =
+			vi.fn<
+				(
+					...args: [SandboxWorkspace, string, string?]
+				) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+			>();
+		runInSandbox.mockImplementation(async (_workspace, command) => {
+			await Promise.resolve();
+			if (command.startsWith('npm install')) {
+				return { exitCode: 1, stdout: '', stderr: 'npm error code ETARGET' };
+			}
+			return { exitCode: 0, stdout: '', stderr: '' };
+		});
+		const readFileViaSandbox: ReadFileViaSandboxMock =
+			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
+		readFileViaSandbox.mockResolvedValue(null);
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
+			runInSandbox,
+			readFileViaSandbox,
+		);
+		const writeFile = vi.fn<
+			(...args: [string, string | Buffer, { recursive?: boolean }?]) => Promise<void>
+		>(async () => {});
+
+		await expect(
+			setupSandboxWorkspace(
+				createFilesystemWorkspace(writeFile, undefined, 'n8n-sandbox'),
+				createSetupContext(),
+			),
+		).rejects.toThrow('Sandbox npm install failed');
+
+		expect(installCommandsFrom(runInSandbox)).toEqual([
+			'npm install --ignore-scripts --no-audit --no-fund --prefer-online',
 		]);
 	});
 

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -95,27 +95,49 @@ function resolveHostDepVersion(name: string): string {
 }
 
 /**
- * Flags for every `npm install` that runs inside a sandbox or a snapshot build.
+ * Flags shared by every `npm install` that runs inside a sandbox or a snapshot build.
  * `--no-audit` matters most: npm otherwise posts the whole tree to the registry's
  * advisories endpoint and blocks until it answers or its 300s fetch timeout expires,
  * so a slow registry turns a 10s install into minutes. Nobody reads the audit or
- * funding output in a sandbox. `--prefer-offline` lets a warm npm cache skip
- * freshness checks against the registry.
+ * funding output in a sandbox.
  */
-export const NPM_INSTALL_FLAGS = '--ignore-scripts --no-audit --no-fund --prefer-offline';
+const NPM_INSTALL_BASE_FLAGS = '--ignore-scripts --no-audit --no-fund';
 
 /**
- * Same flags, but revalidate registry metadata. The snapshot bake populates the
- * sandbox's npm cache, so a sandbox created from an older snapshot holds a packument
- * that predates a newly published SDK version. `--prefer-offline` trusts that stale
- * packument and fails to resolve the pinned version. Used only to retry a failed
- * install, never as the first attempt.
+ * Install from the warm npm cache and skip freshness checks. Correct only where the
+ * cache was baked from the same pinned `PACKAGE_JSON`: the Daytona snapshot and the
+ * snapshot bake that produces it.
  */
-export const NPM_INSTALL_FLAGS_REFRESH_METADATA =
-	'--ignore-scripts --no-audit --no-fund --prefer-online';
+export const NPM_INSTALL_FLAGS = `${NPM_INSTALL_BASE_FLAGS} --prefer-offline`;
 
 /**
- * Budget for the whole install step, both attempts together. A healthy install runs
+ * Same flags, but revalidate registry metadata before resolving. A cache that predates
+ * the pinned SDK version holds a packument without it, and `--prefer-offline` trusts
+ * that stale packument and fails the install.
+ */
+export const NPM_INSTALL_FLAGS_REFRESH_METADATA = `${NPM_INSTALL_BASE_FLAGS} --prefer-online`;
+
+/**
+ * Pick install flags for the sandbox the workspace runs on. The two providers do not
+ * offer the same cache guarantee:
+ *
+ *   - Daytona installs from a snapshot that `SnapshotManager` bakes per n8n version,
+ *     running this same pinned `PACKAGE_JSON`. The cached packument therefore always
+ *     resolves the pinned SDK version, so take the fast offline path.
+ *   - n8n-sandbox installs against an image cache that can lag the pin, so refresh
+ *     metadata up front rather than pay a failed install first.
+ *
+ * Unknown providers get the refresh path: it works against any cache and only costs
+ * latency, while the offline path fails outright once the pin moves ahead.
+ */
+export function resolveNpmInstallFlags(workspace: SandboxWorkspace): string {
+	return workspace.sandbox?.provider === 'daytona'
+		? NPM_INSTALL_FLAGS
+		: NPM_INSTALL_FLAGS_REFRESH_METADATA;
+}
+
+/**
+ * Budget for the whole install step, every attempt together. A healthy install runs
  * in under a second and the sandbox gateway already cuts a single command at 30s, so
  * this is generous. It exists for the fault case: the sandbox terminates a command at
  * its own timeout and reports that as a non-zero exit code, so without a shared
@@ -237,7 +259,7 @@ export async function linkWorkspaceSdkIfEnabled(
 		.join(' ');
 	const install = await runInSandbox(
 		workspace,
-		`npm install ${tarballArgs} --no-save --force ${NPM_INSTALL_FLAGS}`,
+		`npm install ${tarballArgs} --no-save --force ${resolveNpmInstallFlags(workspace)}`,
 		root,
 	);
 	if (install.exitCode !== 0) {
@@ -528,11 +550,17 @@ export async function setupSandboxWorkspace(
 						abortSignal: AbortSignal.timeout(Math.max(1, deadline - Date.now())),
 					});
 
-				let npmResult = await install(NPM_INSTALL_FLAGS);
-				if (npmResult.exitCode !== 0 && Date.now() < deadline) {
-					// The cached packument can be too old to resolve the pinned SDK version. That is
-					// the one failure the cache causes, and refreshing metadata is the only way out,
-					// so retry once with whatever budget is left.
+				const flags = resolveNpmInstallFlags(workspace);
+				let npmResult = await install(flags);
+				if (
+					npmResult.exitCode !== 0 &&
+					flags !== NPM_INSTALL_FLAGS_REFRESH_METADATA &&
+					Date.now() < deadline
+				) {
+					// A snapshot older than the pinned SDK version holds a packument that cannot
+					// resolve it. That is the one failure the cache causes, and refreshing metadata
+					// is the only way out, so retry once with whatever budget is left. Providers
+					// that already refresh have nothing left to try.
 					context.logger.warn('Sandbox npm install failed against the cache; refreshing metadata', {
 						stderr: npmResult.stderr.slice(0, 500),
 						remainingMs: deadline - Date.now(),


### PR DESCRIPTION
## Summary

The `install-dependencies` sandbox setup step sent `--prefer-offline` to both sandbox providers. The two providers do not offer the same cache guarantee:

- **Daytona** installs from a snapshot that `SnapshotManager` bakes per n8n version, running this same pinned `PACKAGE_JSON`. Its cached packument always resolves the pinned `@n8n/workflow-sdk` version, so the offline path is correct and fast.
- **n8n-sandbox** installs against an image cache that can lag the pin. `--prefer-offline` makes npm trust that stale packument, so the install stops with `ETARGET No matching version found for @n8n/workflow-sdk@<pinned>`.

The failure blocks the whole workspace: `setupStep` wraps it in a `SandboxWorkspaceSetupError`, and every later workspace operation fails, `get-as-code` and file writes included.

This PR picks the install flags from the sandbox provider:

| Path | Flags |
| --- | --- |
| Daytona sandbox | `--prefer-offline` |
| Daytona snapshot bake (`snapshot-manager.ts`) | `--prefer-offline`, unchanged |
| n8n-sandbox | `--prefer-online` |
| Unknown provider | `--prefer-online` |

An unknown provider takes the refresh path on purpose: it works against any cache and only costs latency, while the offline path fails outright once the pin moves ahead.

The provider comes from `workspace.sandbox?.provider`, the same discriminator `getFallbackHome` already uses in `@n8n/agents`. Reading the live sandbox rather than `N8N_INSTANCE_AI_SANDBOX_PROVIDER` keeps the admin-settings override of that env var working.

The `--prefer-online` retry added in #38136 now runs only when the first attempt used the cache. A provider that already refreshes metadata has nothing left to try, so it no longer pays a duplicate install on failure. The retry stays as a backstop on Daytona, where a pinned or older snapshot can still fall behind.

`linkWorkspaceSdkIfEnabled` (local development, installs packed tarballs) now uses the same resolver for consistency.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1404
https://n8nio.slack.com/archives/C069KJBJ8HE/p1789038458711029

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.**
- [x] Tests included.

  Three new cases in `sandbox-setup.test.ts`: Daytona gets `--prefer-offline`, n8n-sandbox gets `--prefer-online`, and a failed n8n-sandbox install does not retry. The existing `snapshot-manager.test.ts` case already asserts the bake stays on `--prefer-offline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

