### PR TITLE
fix(core): Redact execution data on partial private-credential runs

### DIFF
--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -71,6 +71,13 @@ export class CredentialsRepository extends BaseRepository<CredentialsEntity> {
 		return rows.map((row) => row.id);
 	}
 
+	/** True when any of the given credentials is a private (resolvable) credential. */
+	async hasResolvableCredential(ids: string[]): Promise<boolean> {
+		if (ids.length === 0) return false;
+		const count = await this.count({ where: { id: In(ids), isResolvable: true } });
+		return count > 0;
+	}
+
 	async findDanglingProjectCredentials(): Promise<CredentialsEntity[]> {
 		return await this.createQueryBuilder('credentials')
 			.leftJoinAndSelect('credentials.shared', 'shared')

--- a/packages/cli/src/credentials/executing-user-identifier-proxy.ts
+++ b/packages/cli/src/credentials/executing-user-identifier-proxy.ts
@@ -1,0 +1,24 @@
+import { Service } from '@n8n/di';
+import type { ICredentialContext } from 'n8n-workflow';
+
+import type { IExecutingUserIdentifier } from './executing-user-identifier.interface';
+
+/**
+ * Proxy between the always-loaded redaction layer and the module-owned identity
+ * resolver. When no provider is registered (dynamic-credentials feature disabled
+ * or module not loaded) identification degrades to undefined, so the run stays
+ * redacted for everyone.
+ */
+@Service()
+export class ExecutingUserIdentifierProxy implements IExecutingUserIdentifier {
+	private provider?: IExecutingUserIdentifier;
+
+	setProvider(provider: IExecutingUserIdentifier): void {
+		this.provider = provider;
+	}
+
+	async identify(context: ICredentialContext): Promise<string | undefined> {
+		if (!this.provider) return undefined;
+		return await this.provider.identify(context);
+	}
+}

--- a/packages/cli/src/credentials/executing-user-identifier.interface.ts
+++ b/packages/cli/src/credentials/executing-user-identifier.interface.ts
@@ -1,0 +1,11 @@
+import type { ICredentialContext } from 'n8n-workflow';
+
+/**
+ * Resolves the n8n user an established identity carrier represents, best-effort.
+ * Owned by the dynamic-credentials module; the redaction layer reads it through
+ * {@link ExecutingUserIdentifierProxy} to attribute a run to its executing user.
+ */
+export interface IExecutingUserIdentifier {
+	/** The user the carrier represents, or undefined when it maps to no n8n user. */
+	identify(context: ICredentialContext): Promise<string | undefined>;
+}

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub-extractor.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub-extractor.test.ts
@@ -1,9 +1,11 @@
 import type { Logger } from '@n8n/backend-common';
 import type { ContextEstablishmentOptions } from '@n8n/decorators';
 import type { Cipher } from 'n8n-core';
-import type { INodeExecutionData } from 'n8n-workflow';
+import type { INodeExecutionData, PlaintextExecutionContext } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
+
+import type { ExecutingUserIdentifierProxy } from '@/credentials/executing-user-identifier-proxy';
 
 import { ChatHubExtractor } from '../chat-hub-extractor';
 
@@ -18,12 +20,15 @@ describe('ChatHubExtractor', () => {
 	let extractor: ChatHubExtractor;
 	let mockLogger: Mocked<Logger>;
 	let mockCipher: Mocked<Cipher>;
+	let mockExecutingUserIdentifierProxy: Mocked<ExecutingUserIdentifierProxy>;
 
 	beforeEach(() => {
 		mockLogger = mock<Logger>();
 		mockLogger.scoped.mockReturnValue(mockLogger);
 		mockCipher = mock<Cipher>();
-		extractor = new ChatHubExtractor(mockLogger, mockCipher);
+		mockExecutingUserIdentifierProxy = mock<ExecutingUserIdentifierProxy>();
+		mockExecutingUserIdentifierProxy.identify.mockResolvedValue(undefined);
+		extractor = new ChatHubExtractor(mockLogger, mockCipher, mockExecutingUserIdentifierProxy);
 	});
 
 	describe('execute', () => {
@@ -90,6 +95,49 @@ describe('ChatHubExtractor', () => {
 					},
 				},
 			});
+			expect(mockExecutingUserIdentifierProxy.identify).not.toHaveBeenCalled();
+		});
+
+		it('attributes the owner when the workflow uses a private credential', async () => {
+			mockCipher.decryptV2.mockResolvedValue(
+				JSON.stringify({ authToken: 'jwt', method: 'POST', endpoint: '/e' }),
+			);
+			mockExecutingUserIdentifierProxy.identify.mockResolvedValue('user-7');
+			const triggerItem = createTriggerItem({ encryptedMetadata: 'enc' });
+			const options = {
+				triggerItems: [triggerItem],
+				context: { usesDynamicCredentials: true } as PlaintextExecutionContext,
+			} as ContextEstablishmentOptions;
+
+			const result = await extractor.execute(options);
+
+			expect(mockExecutingUserIdentifierProxy.identify).toHaveBeenCalledWith({
+				version: 1,
+				identity: 'jwt',
+				metadata: {
+					source: 'chat-hub-injected',
+					browserId: undefined,
+					method: 'POST',
+					endpoint: '/e',
+				},
+			});
+			expect(result.contextUpdate?.executedByUserId).toBe('user-7');
+		});
+
+		it('does not attribute an owner when the workflow uses no private credential', async () => {
+			mockCipher.decryptV2.mockResolvedValue(
+				JSON.stringify({ authToken: 'jwt', method: 'POST', endpoint: '/e' }),
+			);
+			const triggerItem = createTriggerItem({ encryptedMetadata: 'enc' });
+			const options = {
+				triggerItems: [triggerItem],
+				context: { usesDynamicCredentials: false } as PlaintextExecutionContext,
+			} as ContextEstablishmentOptions;
+
+			const result = await extractor.execute(options);
+
+			expect(mockExecutingUserIdentifierProxy.identify).not.toHaveBeenCalled();
+			expect(result.contextUpdate?.executedByUserId).toBeUndefined();
 		});
 
 		it('should extract authToken without browserId', async () => {

--- a/packages/cli/src/modules/chat-hub/chat-hub-extractor.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-extractor.ts
@@ -10,10 +10,11 @@ import {
 import { Container } from '@n8n/di';
 import { Cipher } from 'n8n-core';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
-import { jsonParse } from 'n8n-workflow';
+import { type ICredentialContext, jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { AuthService } from '@/auth/auth.service';
+import { ExecutingUserIdentifierProxy } from '@/credentials/executing-user-identifier-proxy';
 
 const EncryptedMetadataSchema = z.object({
 	encryptedMetadata: z.string(),
@@ -52,6 +53,7 @@ export class ChatHubExtractor implements IContextEstablishmentHook {
 	constructor(
 		private readonly logger: Logger,
 		private readonly cipher: Cipher,
+		private readonly executingUserIdentifierProxy: ExecutingUserIdentifierProxy,
 	) {
 		this.logger = this.logger.scoped('chat-hub');
 	}
@@ -88,20 +90,32 @@ export class ChatHubExtractor implements IContextEstablishmentHook {
 				const parsed = jsonParse(decrypted);
 				const chatHubInformation = ChatHubAuthenticationMetadataSchema.safeParse(parsed);
 				if (chatHubInformation.success) {
+					const credentials: ICredentialContext = {
+						version: 1,
+						identity: chatHubInformation.data.authToken,
+						metadata: {
+							source: 'chat-hub-injected',
+							browserId: chatHubInformation.data.browserId,
+							method: chatHubInformation.data.method,
+							endpoint: chatHubInformation.data.endpoint,
+						},
+					};
+
+					const contextUpdate: ContextEstablishmentResult['contextUpdate'] = { credentials };
+
+					// The private-credential flag is set by the global
+					// DynamicCredentialsContextHook, which runs before node extractors like
+					// this one. The chat-hub identity is only available here, so attribute
+					// the run's owner now — a run that fails before the credential resolves
+					// still grants the initiating user access to their own data.
+					if (options.context?.usesDynamicCredentials) {
+						const executedByUserId = await this.executingUserIdentifierProxy.identify(credentials);
+						if (executedByUserId) contextUpdate.executedByUserId = executedByUserId;
+					}
+
 					return {
 						triggerItems: options.triggerItems,
-						contextUpdate: {
-							credentials: {
-								version: 1,
-								identity: chatHubInformation.data.authToken,
-								metadata: {
-									source: 'chat-hub-injected',
-									browserId: chatHubInformation.data.browserId,
-									method: chatHubInformation.data.method,
-									endpoint: chatHubInformation.data.endpoint,
-								},
-							},
-						},
+						contextUpdate,
 					};
 				} else {
 					this.logger.warn('Invalid format for encryptedMetadata in chathub extractor', {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
@@ -1,4 +1,5 @@
 import type { Mocked } from 'vitest';
+import type { Logger } from '@n8n/backend-common';
 import type { User, UserRepository } from '@n8n/db';
 import { CredentialResolverError } from '@n8n/decorators';
 import { mock } from 'vitest-mock-extended';
@@ -16,6 +17,7 @@ import {
 
 describe('N8NIdentifier', () => {
 	let identifier: N8NIdentifier;
+	let mockLogger: Mocked<Logger>;
 	let mockAuthService: Mocked<AuthService>;
 	let mockOAuthVerifier: Mocked<OAuthTokenVerifierProxy>;
 	let mockUserRepository: Mocked<UserRepository>;
@@ -23,13 +25,19 @@ describe('N8NIdentifier', () => {
 	const mockUser = mock<User>({ id: 'user-123' });
 
 	beforeEach(() => {
+		mockLogger = mock<Logger>();
 		mockAuthService = mock<AuthService>();
 		mockOAuthVerifier = mock<OAuthTokenVerifierProxy>();
 		mockOAuthVerifier.authorizeSealedGrant.mockResolvedValue(true);
 		mockUserRepository = mock<UserRepository>();
 		mockUserRepository.findOneBy.mockResolvedValue(mock<User>({ id: 'user-123', disabled: false }));
 
-		identifier = new N8NIdentifier(mockAuthService, mockOAuthVerifier, mockUserRepository);
+		identifier = new N8NIdentifier(
+			mockLogger,
+			mockAuthService,
+			mockOAuthVerifier,
+			mockUserRepository,
+		);
 	});
 
 	afterEach(() => {
@@ -535,6 +543,92 @@ describe('N8NIdentifier', () => {
 				expect(mockOAuthVerifier.authorizeSealedGrant).not.toHaveBeenCalled();
 				expect(mockUserRepository.findOneBy).toHaveBeenCalledWith({ id: 'user-123' });
 			});
+		});
+	});
+
+	describe('identify', () => {
+		it('validates the cookie for a manual-execution carrier', async () => {
+			mockAuthService.authenticateUserByCookie.mockResolvedValue(mockUser);
+
+			const userId = await identifier.identify({
+				identity: 'cookie-jwt',
+				version: 1,
+				metadata: { source: 'manual-execution' },
+			});
+
+			expect(mockAuthService.authenticateUserByCookie).toHaveBeenCalledWith('cookie-jwt');
+			expect(userId).toBe('user-123');
+		});
+
+		it('returns the sealed subject for an n8n-oauth carrier without verifying the token', async () => {
+			const userId = await identifier.identify({
+				identity: 'token',
+				version: 1,
+				metadata: { source: 'n8n-oauth', resource: 'r', subject: 'user-123' },
+			});
+
+			expect(userId).toBe('user-123');
+			expect(mockOAuthVerifier.verifyOAuthAccessToken).not.toHaveBeenCalled();
+		});
+
+		it('verifies the token for an n8n-oauth carrier without a subject', async () => {
+			mockOAuthVerifier.verifyOAuthAccessToken.mockResolvedValue({ user: mockUser } as never);
+
+			const userId = await identifier.identify({
+				identity: 'token',
+				version: 1,
+				metadata: { source: 'n8n-oauth', resource: 'r' },
+			});
+
+			expect(mockOAuthVerifier.verifyOAuthAccessToken).toHaveBeenCalledWith(
+				'token',
+				'r',
+				undefined,
+			);
+			expect(userId).toBe('user-123');
+		});
+
+		it('validates the request-bound JWT for a chat-hub carrier', async () => {
+			mockAuthService.authenticateUserBasedOnToken.mockResolvedValue(mockUser);
+
+			const userId = await identifier.identify({
+				identity: 'token',
+				version: 1,
+				metadata: {
+					source: 'chat-hub-injected',
+					method: 'POST',
+					endpoint: '/e',
+					browserId: 'b',
+				},
+			});
+
+			expect(userId).toBe('user-123');
+		});
+
+		it('returns undefined for metadata that is not an n8n identity', async () => {
+			const userId = await identifier.identify({
+				identity: 'token',
+				version: 1,
+				metadata: { source: 'http-header', headerName: 'authorization' },
+			});
+
+			expect(userId).toBeUndefined();
+		});
+
+		it('returns undefined instead of throwing when validation fails', async () => {
+			mockAuthService.authenticateUserByCookie.mockRejectedValue(new AuthError('nope'));
+
+			const userId = await identifier.identify({
+				identity: 'bad-cookie',
+				version: 1,
+				metadata: { source: 'manual-execution' },
+			});
+
+			expect(userId).toBeUndefined();
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({ source: 'manual-execution' }),
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import type { ICredentialContext, OAuthResourceGrant } from 'n8n-workflow';
 import { ITokenIdentifier } from './identifier-interface';
@@ -101,6 +102,7 @@ export function carriesN8nIdentity(context: ICredentialContext): boolean {
 @Service()
 export class N8NIdentifier implements ITokenIdentifier {
 	constructor(
+		private readonly logger: Logger,
 		private readonly authService: AuthService,
 		private readonly oauthTokenVerifierProxy: OAuthTokenVerifierProxy,
 		private readonly userRepository: UserRepository,
@@ -199,5 +201,50 @@ export class N8NIdentifier implements ITokenIdentifier {
 			metadataResult.data.browserId,
 		);
 		return user.id;
+	}
+
+	/**
+	 * Best-effort: the n8n user this identity represents, so the redaction layer can
+	 * grant that user access to their own run — including one that failed before a
+	 * private credential resolved. Identification only: unlike {@link resolve} it does
+	 * no execution binding or grant enforcement and never throws. Returns undefined
+	 * when the identity is not an n8n user or cannot be validated, so the run stays
+	 * redacted for everyone. Derives from the same carrier as resolution, so the
+	 * redaction owner cannot drift from the user the credentials resolve as.
+	 */
+	async identify(context: ICredentialContext): Promise<string | undefined> {
+		const metadataResult = N8NIdentifierMetadataSchema.safeParse(context.metadata);
+		if (!metadataResult.success) return undefined;
+
+		try {
+			if (metadataResult.data.source === 'manual-execution') {
+				const user = await this.authService.authenticateUserByCookie(context.identity);
+				return user.id;
+			}
+
+			if (metadataResult.data.source === 'n8n-oauth') {
+				if (metadataResult.data.subject) return metadataResult.data.subject;
+				const verified = await this.oauthTokenVerifierProxy.verifyOAuthAccessToken(
+					context.identity,
+					metadataResult.data.resource,
+					metadataResult.data.grant,
+				);
+				return verified?.user?.id;
+			}
+
+			const user = await this.authService.authenticateUserBasedOnToken(
+				context.identity,
+				metadataResult.data.method,
+				metadataResult.data.endpoint,
+				metadataResult.data.browserId,
+			);
+			return user.id;
+		} catch (error) {
+			this.logger.warn('Could not identify the executing user for redaction attribution', {
+				source: metadataResult.data.source,
+				error,
+			});
+			return undefined;
+		}
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
@@ -57,6 +57,15 @@ export class DynamicCredentialsModule implements ModuleInterface {
 		Container.get(CredentialConnectionStatusProxy).setProvider(
 			Container.get(CredentialConnectionStatusService),
 		);
+
+		// Register the executing-user identifier so the redaction layer can attribute
+		// a run to its user from the established identity carrier — the same source
+		// credential resolution uses.
+		const { ExecutingUserIdentifierProxy } = await import(
+			'../../credentials/executing-user-identifier-proxy.js'
+		);
+		const { N8NIdentifier } = await import('./credential-resolvers/identifiers/n8n-identifier.js');
+		Container.get(ExecutingUserIdentifierProxy).setProvider(Container.get(N8NIdentifier));
 	}
 
 	async entities() {

--- a/packages/cli/src/modules/redaction/__tests__/dynamic-credentials-context-hook.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/dynamic-credentials-context-hook.test.ts
@@ -1,0 +1,170 @@
+import type { Logger } from '@n8n/backend-common';
+import type { CredentialsRepository } from '@n8n/db';
+import type { ContextEstablishmentOptions } from '@n8n/decorators';
+import type { ICredentialContext, INode, PlaintextExecutionContext, Workflow } from 'n8n-workflow';
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+
+import type { ExecutingUserIdentifierProxy } from '@/credentials/executing-user-identifier-proxy';
+
+import { DynamicCredentialsContextHook } from '../dynamic-credentials-context-hook';
+
+describe('DynamicCredentialsContextHook', () => {
+	let logger: MockProxy<Logger>;
+	let credentialsRepository: MockProxy<CredentialsRepository>;
+	let executingUserIdentifierProxy: MockProxy<ExecutingUserIdentifierProxy>;
+	let hook: DynamicCredentialsContextHook;
+
+	// Plain object (not a deep mock) so `context.credentials` reaches the hook as-is.
+	const buildOptions = (
+		nodes: Record<string, INode>,
+		credentials?: ICredentialContext,
+	): ContextEstablishmentOptions =>
+		({
+			workflow: { nodes } as unknown as Workflow,
+			context: credentials
+				? ({
+						version: 1,
+						establishedAt: 0,
+						source: 'manual',
+						credentials,
+					} as PlaintextExecutionContext)
+				: undefined,
+		}) as ContextEstablishmentOptions;
+
+	const node = (credentials?: INode['credentials']): INode =>
+		({
+			name: 'n',
+			type: 't',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+			credentials,
+		}) as INode;
+
+	const carrier = (): ICredentialContext => ({
+		version: 1,
+		identity: 'token',
+		metadata: { source: 'manual-execution' },
+	});
+
+	beforeEach(() => {
+		logger = mock<Logger>();
+		credentialsRepository = mock<CredentialsRepository>();
+		credentialsRepository.hasResolvableCredential.mockResolvedValue(false);
+		executingUserIdentifierProxy = mock<ExecutingUserIdentifierProxy>();
+		executingUserIdentifierProxy.identify.mockResolvedValue(undefined);
+		hook = new DynamicCredentialsContextHook(
+			logger,
+			credentialsRepository,
+			executingUserIdentifierProxy,
+		);
+	});
+
+	describe('usesDynamicCredentials flag', () => {
+		it('stamps the flag when the workflow references a private credential', async () => {
+			credentialsRepository.hasResolvableCredential.mockResolvedValue(true);
+			const options = buildOptions({
+				A: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }),
+				B: node({ httpHeaderAuth: { id: 'cred-2', name: 'c2' } }),
+			});
+
+			const result = await hook.execute(options);
+
+			expect(credentialsRepository.hasResolvableCredential).toHaveBeenCalledWith([
+				'cred-1',
+				'cred-2',
+			]);
+			expect(result).toEqual({ contextUpdate: { usesDynamicCredentials: true } });
+		});
+
+		it('does not stamp the flag when no referenced credential is resolvable', async () => {
+			const options = buildOptions({ A: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }) });
+
+			const result = await hook.execute(options);
+
+			expect(result).toEqual({});
+		});
+
+		it('skips credentials without an id and dedupes repeated ids', async () => {
+			const options = buildOptions({
+				A: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }),
+				B: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }),
+				C: node({ httpHeaderAuth: { id: null, name: 'unsaved' } }),
+				D: node(undefined),
+			});
+
+			await hook.execute(options);
+
+			expect(credentialsRepository.hasResolvableCredential).toHaveBeenCalledWith(['cred-1']);
+		});
+
+		it('over-redacts and does not attribute an owner when the lookup fails', async () => {
+			credentialsRepository.hasResolvableCredential.mockRejectedValue(new Error('db down'));
+			const options = buildOptions(
+				{ A: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }) },
+				carrier(),
+			);
+
+			const result = await hook.execute(options);
+
+			expect(result).toEqual({ contextUpdate: { usesDynamicCredentials: true } });
+			expect(executingUserIdentifierProxy.identify).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalled();
+		});
+	});
+
+	describe('executedByUserId from the identity carrier', () => {
+		beforeEach(() => {
+			// executedByUserId only matters for a private-credential run.
+			credentialsRepository.hasResolvableCredential.mockResolvedValue(true);
+		});
+
+		it('stamps the user the identifier resolves from the carrier', async () => {
+			executingUserIdentifierProxy.identify.mockResolvedValue('user-42');
+			const context = carrier();
+			const options = buildOptions(
+				{ A: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }) },
+				context,
+			);
+
+			const result = await hook.execute(options);
+
+			expect(executingUserIdentifierProxy.identify).toHaveBeenCalledWith(context);
+			expect(result).toEqual({
+				contextUpdate: { usesDynamicCredentials: true, executedByUserId: 'user-42' },
+			});
+		});
+
+		it('stamps only the flag when the identifier resolves no user', async () => {
+			executingUserIdentifierProxy.identify.mockResolvedValue(undefined);
+			const options = buildOptions(
+				{ A: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }) },
+				carrier(),
+			);
+
+			const result = await hook.execute(options);
+
+			expect(result).toEqual({ contextUpdate: { usesDynamicCredentials: true } });
+		});
+
+		it('does not call the identifier when the workflow uses no private credential', async () => {
+			credentialsRepository.hasResolvableCredential.mockResolvedValue(false);
+			const options = buildOptions({ A: node() }, carrier());
+
+			const result = await hook.execute(options);
+
+			expect(executingUserIdentifierProxy.identify).not.toHaveBeenCalled();
+			expect(result).toEqual({});
+		});
+
+		it('does not call the identifier when there is no identity carrier', async () => {
+			const options = buildOptions({ A: node({ httpBasicAuth: { id: 'cred-1', name: 'c1' } }) });
+
+			const result = await hook.execute(options);
+
+			expect(executingUserIdentifierProxy.identify).not.toHaveBeenCalled();
+			expect(result).toEqual({ contextUpdate: { usesDynamicCredentials: true } });
+		});
+	});
+});

--- a/packages/cli/src/modules/redaction/__tests__/redaction.module.hook-registration.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction.module.hook-registration.test.ts
@@ -20,7 +20,7 @@ const moduleEntry = Container.get(ModuleMetadata).get('redaction');
  * test file gets its own fork, which keeps this init the first one.
  */
 describe('RedactionModule hook registration', () => {
-	it('registers RedactionContextHook as a global execution-context hook', async () => {
+	it('registers its execution-context hooks as global hooks', async () => {
 		mockInstance(Logger);
 		Container.set(ExecutionRedactionService, mock<ExecutionRedactionService>());
 		Container.set(ExecutionRedactionServiceProxy, mock<ExecutionRedactionServiceProxy>());
@@ -42,5 +42,8 @@ describe('RedactionModule hook registration', () => {
 			.map((hookClass) => hookClass.name);
 
 		expect(globalHooks).toContain('RedactionContextHook');
+		// Security-sensitive wiring: without this hook a private-credential run that
+		// fails before the credential resolves would not be redacted for everyone.
+		expect(globalHooks).toContain('DynamicCredentialsContextHook');
 	});
 });

--- a/packages/cli/src/modules/redaction/dynamic-credentials-context-hook.ts
+++ b/packages/cli/src/modules/redaction/dynamic-credentials-context-hook.ts
@@ -1,0 +1,86 @@
+import { Logger } from '@n8n/backend-common';
+import { CredentialsRepository } from '@n8n/db';
+import {
+	ContextEstablishmentHook,
+	ContextEstablishmentOptions,
+	ContextEstablishmentResult,
+	HookDescription,
+	IContextEstablishmentHook,
+} from '@n8n/decorators';
+import type { PlaintextExecutionContext } from 'n8n-workflow';
+
+import { ExecutingUserIdentifierProxy } from '@/credentials/executing-user-identifier-proxy';
+
+@ContextEstablishmentHook({
+	alwaysExecute: true,
+	// Re-run for sub-workflows so a child that references a private credential
+	// stamps its own flag, independent of the parent.
+	runForSubExecution: true,
+})
+export class DynamicCredentialsContextHook implements IContextEstablishmentHook {
+	constructor(
+		private readonly logger: Logger,
+		private readonly credentialsRepository: CredentialsRepository,
+		private readonly executingUserIdentifierProxy: ExecutingUserIdentifierProxy,
+	) {}
+
+	hookDescription: HookDescription = {
+		name: 'DynamicCredentialsContextHook',
+	};
+
+	isApplicableToTriggerNode(_nodeType: string): boolean {
+		// Global hook, never user-facing.
+		return false;
+	}
+
+	/**
+	 * Establishes the two signals the redaction layer needs at execution start,
+	 * before any node runs, so a run that fails or stops before a private
+	 * credential resolves is still handled consistently with a successful run:
+	 *
+	 * - `usesDynamicCredentials`: true when the workflow references a private
+	 *   (resolvable) credential. Drives redaction-for-everyone.
+	 * - `executedByUserId`: the n8n user the run executes as, derived from the
+	 *   established identity carrier by the same identifier credential resolution
+	 *   uses — so the redaction owner cannot drift from the resolved user. Grants
+	 *   that user access to their own run. One place covers every identity path
+	 *   (manual, chat, MCP, webhook, form) because they all carry the identity.
+	 *
+	 * Not gated by the data-redaction license: private-credential redaction is
+	 * unconditional, unlike the policy-driven redaction snapshot.
+	 */
+	async execute(options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
+		const contextUpdate: Partial<PlaintextExecutionContext> = {};
+
+		const credentialIds = new Set<string>();
+		for (const node of Object.values(options.workflow.nodes)) {
+			for (const credential of Object.values(node.credentials ?? {})) {
+				if (credential.id) credentialIds.add(credential.id);
+			}
+		}
+		let hasResolvable: boolean;
+		try {
+			hasResolvable = await this.credentialsRepository.hasResolvableCredential([...credentialIds]);
+		} catch (error) {
+			// A redaction-support query must not abort the run. On uncertainty, over-redact:
+			// hide the run from everyone and skip owner attribution.
+			this.logger.warn('Could not check for resolvable credentials; redacting run for everyone', {
+				error,
+			});
+			return { contextUpdate: { usesDynamicCredentials: true } };
+		}
+		if (!hasResolvable) return {};
+		contextUpdate.usesDynamicCredentials = true;
+
+		// Only a private-credential run needs its owner attributed, so identify here
+		// rather than for every identity run. The token is still valid at execution
+		// start, so a later view (after it expires) still finds the persisted user.
+		const credentials = options.context?.credentials;
+		if (credentials) {
+			const executedByUserId = await this.executingUserIdentifierProxy.identify(credentials);
+			if (executedByUserId) contextUpdate.executedByUserId = executedByUserId;
+		}
+
+		return { contextUpdate };
+	}
+}

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -58,6 +58,7 @@ describe('ExecutionRedactionService', () => {
 			workflowSettingsPolicy?: 'none' | 'all' | 'non-manual';
 			withRuntimeData?: boolean;
 			withDynamicCredentials?: boolean;
+			usesDynamicCredentials?: boolean;
 			executedByUserId?: string | null;
 		} = {},
 	): RedactableExecution => {
@@ -69,6 +70,7 @@ describe('ExecutionRedactionService', () => {
 			workflowSettingsPolicy,
 			withRuntimeData = true,
 			withDynamicCredentials = false,
+			usesDynamicCredentials = false,
 			executedByUserId = null,
 		} = overrides;
 
@@ -97,6 +99,20 @@ describe('ExecutionRedactionService', () => {
 				establishedAt: Date.now(),
 				source: mode,
 				credentials: 'encrypted-credential-context',
+			};
+		}
+
+		// Stamp the private-credential flag onto runtimeData, mirroring what
+		// `DynamicCredentialsContextHook` does at execution start. Set without a
+		// runData `usedDynamicCredentials` flag, this models a run that failed or
+		// stopped before the private credential resolved.
+		if (usesDynamicCredentials) {
+			executionData.runtimeData = {
+				version: 1 as const,
+				establishedAt: Date.now(),
+				source: mode,
+				...executionData.runtimeData,
+				usesDynamicCredentials: true,
 			};
 		}
 
@@ -704,6 +720,34 @@ describe('ExecutionRedactionService', () => {
 			).rejects.toThrow(ForbiddenError);
 		});
 
+		it('emits execution-data-reveal-failure before the ForbiddenError on the reveal path', async () => {
+			const execution = makeExecution({
+				policy: 'none',
+				mode: 'manual',
+				withDynamicCredentials: true,
+				executedByUserId: 'another-user-id',
+			});
+
+			await expect(
+				service.processExecution(execution, {
+					user: mockUser,
+					redactExecutionData: false,
+					ipAddress: '1.2.3.4',
+					userAgent: 'TestAgent/1.0',
+				}),
+			).rejects.toThrow(ForbiddenError);
+
+			expect(eventService.emit).toHaveBeenCalledWith('execution-data-reveal-failure', {
+				user: mockUser,
+				executionId: execution.id,
+				workflowId: execution.workflowId,
+				ipAddress: '1.2.3.4',
+				userAgent: 'TestAgent/1.0',
+				redactionPolicy: 'none',
+				rejectionReason: 'Not the executing user of a private-credential execution',
+			});
+		});
+
 		it('does not force-redact when execution has no dynamic credentials', async () => {
 			const execution = makeExecution({
 				policy: 'none',
@@ -854,6 +898,67 @@ describe('ExecutionRedactionService', () => {
 			await service.processExecution(execution, { user: mockUser });
 
 			expect(execution.data.executionData?.runtimeData?.credentials).toBeUndefined();
+		});
+	});
+
+	describe('dynamic credentials from context flag (failed/partial run)', () => {
+		it('force-redacts a run that used no runData flag but references a private credential', async () => {
+			const execution = makeExecution({
+				policy: 'none',
+				mode: 'manual',
+				usesDynamicCredentials: true,
+			});
+
+			// No runData node ran, so the per-node flag is absent.
+			expect(execution.data.resultData.runData).toEqual({});
+
+			await service.processExecution(execution, { user: mockUser });
+
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
+			const [, context] = fullItemRedactionStrategy.apply.mock.calls[0];
+			expect(context.enforceDynCredRedaction).toBe(true);
+			expect(context.userCanReveal).toBe(false);
+		});
+
+		it('lets the executing user reveal their own failed run', async () => {
+			const execution = makeExecution({
+				policy: 'none',
+				mode: 'manual',
+				usesDynamicCredentials: true,
+				executedByUserId: mockUser.id,
+			});
+
+			await service.processExecution(execution, { user: mockUser });
+
+			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
+		});
+
+		it('rejects reveal for a different user even with execution:reveal scope', async () => {
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
+			const execution = makeExecution({
+				policy: 'none',
+				mode: 'manual',
+				usesDynamicCredentials: true,
+				executedByUserId: 'another-user-id',
+			});
+
+			await expect(
+				service.processExecution(execution, { user: mockUser, redactExecutionData: false }),
+			).rejects.toThrow(ForbiddenError);
+		});
+
+		it('leaves a run with no private credential and no flag unchanged', async () => {
+			const execution = makeExecution({
+				policy: 'none',
+				mode: 'manual',
+				usesDynamicCredentials: false,
+			});
+
+			await service.processExecution(execution, { user: mockUser });
+
+			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -119,6 +119,15 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 					this.hasDynamicCredentials(execution) &&
 					!this.isOwnDynamicCredentialsExecution(execution, options.user.id)
 				) {
+					this.eventService.emit('execution-data-reveal-failure', {
+						user: options.user,
+						executionId: execution.id ?? '',
+						workflowId: execution.workflowId,
+						ipAddress: options.ipAddress ?? '',
+						userAgent: options.userAgent ?? '',
+						redactionPolicy: this.resolvePolicy(execution),
+						rejectionReason: 'Not the executing user of a private-credential execution',
+					});
 					throw new ForbiddenError();
 				}
 			}
@@ -267,15 +276,27 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	}
 
 	/**
-	 * Returns true when the execution used dynamic credential resolution.
-	 * Such executions must always be redacted with canReveal = false.
+	 * Returns true when the execution resolved a dynamic credential, or its
+	 * workflow references one. Such executions must always be redacted with
+	 * canReveal = false.
 	 *
-	 * Checks per-node `usedDynamicCredentials` flag which is only set when
-	 * resolution actually happened at runtime, rather than checking for the
-	 * mere presence of credential context infrastructure.
+	 * Two signals, either sufficient:
+	 * - the per-node `usedDynamicCredentials` runData flag, set only after a node
+	 *   resolves a private credential at runtime;
+	 * - the `usesDynamicCredentials` context flag, stamped at execution start when
+	 *   the workflow references a private credential. This covers a run that
+	 *   failed or stopped before the credential node ran, where no runData flag
+	 *   exists, so a failed/partial run redacts consistently with a successful one.
+	 *
+	 * Presence of encrypted credential context (`runtimeData.credentials`) is not
+	 * used: it is established for every identity-context run, including ordinary
+	 * manual runs that use no private credential.
 	 */
 	private hasDynamicCredentials(execution: RedactableExecution): boolean {
-		return runDataUsedDynamicCredentials(execution.data.resultData?.runData);
+		return (
+			runDataUsedDynamicCredentials(execution.data.resultData?.runData) ||
+			execution.data.executionData?.runtimeData?.usesDynamicCredentials === true
+		);
 	}
 
 	/**

--- a/packages/cli/src/modules/redaction/redaction.module.ts
+++ b/packages/cli/src/modules/redaction/redaction.module.ts
@@ -15,6 +15,10 @@ export class RedactionModule implements ModuleInterface {
 		// Import side-effect registers RedactionContextHook.
 		await import('./redaction-context-hook.js');
 
+		// Import side-effect registers DynamicCredentialsContextHook, which stamps
+		// the private-credential flag at execution start (unconditional of license).
+		await import('./dynamic-credentials-context-hook.js');
+
 		// Importing the service here registers its @OnPubSubEvent handler with the
 		// pubsub metadata before PubSubRegistry.init() wires up the listeners.
 		// The decorator runs at class-evaluation (import) time, so the import

--- a/packages/cli/test/integration/database/repositories/credentials.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/credentials.repository.test.ts
@@ -769,4 +769,40 @@ describe('CredentialsRepository', () => {
 			expect(reverseContamination).toHaveLength(0);
 		});
 	});
+
+	describe('hasResolvableCredential', () => {
+		let credentialsRepository: CredentialsRepository;
+
+		beforeEach(() => {
+			credentialsRepository = Container.get(CredentialsRepository);
+		});
+
+		it('returns true when any given credential is resolvable', async () => {
+			const { createCredentials } = await import('../../shared/db/credentials.js');
+			const staticCred = await createCredentials({ name: 'Static', type: 'googleApi', data: '' });
+			const privateCred = await createCredentials({
+				name: 'Private',
+				type: 'googleApi',
+				data: '',
+				isResolvable: true,
+			});
+
+			await expect(
+				credentialsRepository.hasResolvableCredential([staticCred.id, privateCred.id]),
+			).resolves.toBe(true);
+		});
+
+		it('returns false when no given credential is resolvable', async () => {
+			const { createCredentials } = await import('../../shared/db/credentials.js');
+			const staticCred = await createCredentials({ name: 'Static', type: 'googleApi', data: '' });
+
+			await expect(credentialsRepository.hasResolvableCredential([staticCred.id])).resolves.toBe(
+				false,
+			);
+		});
+
+		it('returns false for an empty id list without querying', async () => {
+			await expect(credentialsRepository.hasResolvableCredential([])).resolves.toBe(false);
+		});
+	});
 });

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -833,6 +833,60 @@ describe('establishExecutionContext', () => {
 				'parent-execution-id',
 			);
 		});
+
+		it('re-runs sub-execution hooks for inheritance via start-item metadata (error workflow)', async () => {
+			// Error workflows inherit through `startItem.metadata.parentExecution`, not
+			// the top-level `parentExecution`, so the child's own hooks must still run.
+			const runExecutionData = createRunExecutionData({
+				startData: {},
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							node: mock<INode>({
+								name: 'Error Trigger',
+								type: 'n8n-nodes-base.errorTrigger',
+							}),
+							data: { main: [[{ json: {} }]] },
+							source: null,
+							metadata: {
+								parentExecution: {
+									executionId: 'parent-execution-id',
+									workflowId: 'parent-workflow-id',
+									executionContext: {
+										version: 1,
+										establishedAt: 1000,
+										source: 'manual',
+										redaction: { version: 2, production: false, manual: false },
+									},
+								},
+							},
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+			});
+			const rederived: IExecutionContext = {
+				version: 1,
+				establishedAt: 2000,
+				source: 'error',
+				parentExecutionId: 'parent-execution-id',
+				usesDynamicCredentials: true,
+			};
+			mockExecutionContextService.augmentSubExecutionContext.mockResolvedValue(rederived);
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, mockAdditionalData, 'error');
+
+			expect(mockExecutionContextService.augmentSubExecutionContext).toHaveBeenCalledWith(
+				mockWorkflow,
+				runExecutionData.executionData!.nodeExecutionStack[0],
+				expect.objectContaining({ parentExecutionId: 'parent-execution-id' }),
+			);
+			expect(runExecutionData.executionData!.runtimeData).toBe(rederived);
+		});
 	});
 
 	describe('error workflow context inheritance', () => {

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -222,6 +222,19 @@ export const establishExecutionContext = async (
 			additionalData?.executionId,
 			{ allowInherit: true },
 		);
+
+		// Re-run the global sub-execution hooks against the child workflow so its own
+		// record reflects context derived from itself (redaction policy, private-
+		// credential flag), merged with the inherited parent context. An error
+		// workflow reaches inheritance through this branch, so without this a
+		// policy'd or private-credential error workflow called by a policy-less
+		// parent would not redact its own record. Mirrors the
+		// `runExecutionData.parentExecution` branch above.
+		executionData.runtimeData = await executionContextService.augmentSubExecutionContext(
+			workflow,
+			startItem,
+			executionData.runtimeData,
+		);
 		return;
 	}
 

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -229,14 +229,27 @@ const ExecutionContextSchemaV1 = z.object({
 	redaction: RedactionSettingSchema.optional(),
 
 	/**
-	 * The n8n user the execution ran as. Set during dynamic credential
-	 * resolution to the n8n user a private credential resolved to (covers manual
-	 * and chat-hub runs alike). Used by the redaction layer to grant that user
-	 * access to their own data. Absent when the resolved identity is not an n8n
-	 * user (external Slack/OAuth resolvers) or when no dynamic credential
-	 * resolved, so those executions stay redacted for everyone.
+	 * The n8n user the execution ran as. Stamped at context establishment by
+	 * deriving the user from the identity carrier with the same identifier that
+	 * credential resolution uses, so the redaction owner cannot drift from the
+	 * resolved user. Dynamic credential resolution re-affirms it on success. Used
+	 * by the redaction layer to grant that user access to their own data, including
+	 * a run that failed before the credential resolved. Absent when the identity is
+	 * not an n8n user (external Slack/OAuth resolvers) or cannot be validated, so
+	 * those executions stay redacted for everyone.
 	 */
 	executedByUserId: z.string().optional(),
+
+	/**
+	 * True when the workflow references a private (resolvable) credential.
+	 * Stamped at context establishment, before any node runs, so a run that
+	 * fails or stops before the credential resolves is still recognised as a
+	 * dynamic-credential execution and redacted for everyone but the executing
+	 * user — consistent with a successful run. The per-node
+	 * `usedDynamicCredentials` runData flag only appears after resolution, so it
+	 * cannot cover the failed/partial path on its own.
+	 */
+	usesDynamicCredentials: z.boolean().optional(),
 });
 
 export type IExecutionContextV1 = z.output<typeof ExecutionContextSchemaV1>;


### PR DESCRIPTION
## Summary

A workflow that uses a private (dynamic) credential redacts its execution data for
every viewer except the user who ran it. This redaction now also applies when the
run fails or stops **before** the private credential resolves, not only on
successful runs. The run is attributed to its executing user, so that user keeps
access to their own data.

Before this change, a shared-workflow viewer without reveal access could see the
upstream node data of another user's failed run, while the same successful run was
redacted for them. This makes the two consistent.

### How to test manually

Prerequisites:

- An instance with private (dynamic) credentials enabled.
- A workflow that uses a private credential, shared with a second user (user B has
  workflow access but not the `execution:reveal` scope).

Steps:

1. Build the workflow: an upstream node that outputs data, then a node that uses a
   private credential.
2. As user A, run it so it fails before the private-credential node — for example,
   make the upstream node error, or run it while A is not connected so credential
   resolution throws.
3. As user B, open that execution. Expect the upstream node data to be redacted,
   the same as a successful run.
4. As user A, open the same failed execution. Expect the upstream node data to be
   visible.
5. Run a workflow that uses only static credentials and make it fail. As user B,
   confirm this run is unaffected — its data is not force-redacted.

### Key implementation decisions

- Detection uses a durable flag stamped at execution start when the workflow
  references a private (resolvable) credential. The per-node "used dynamic
  credentials" flag only appears after the credential resolves, so it cannot cover
  a run that never reached the credential node.
- The executing user is derived from the identity carrier with the same identifier
  credential resolution uses, then stored at execution start. One source keeps the
  redaction owner from drifting from the resolved user, and the identity token is
  still valid at start — it can expire before the execution is later viewed.

Automated coverage: unit tests for the context hook, the identifier, and the
redaction service, plus an integration test for the credential lookup.

## Related Links

closes Linear: https://linear.app/n8n/issue/IAM-814

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

