### PR TITLE
test(editor): Test source control repo URL regexes without mounting the view

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.constants.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.constants.test.ts
@@ -1,0 +1,43 @@
+import {
+	SOURCE_CONTROL_HTTPS_REPO_URL_REGEX,
+	SOURCE_CONTROL_SSH_REPO_URL_REGEX,
+} from './sourceControl.constants';
+
+describe('sourceControl.constants', () => {
+	describe('SOURCE_CONTROL_SSH_REPO_URL_REGEX', () => {
+		test.each([
+			['git@github.com:user/repository.git', true],
+			['git@github.enterprise.com:org-name/repo-name.git', true],
+			['git@192.168.1.101:2222:user/repo.git', true],
+			['git@github.com:user/repo.git/path/to/subdir', true],
+			['git@[2001:db8:100:f101:210:a4ff:fee3:9566]:user/repo.git', true],
+			['git@github.com:org/suborg/repo.git', true],
+			['git@github.com:user-name/repo-name.git', true],
+			['git@github.com:user_name/repo_name.git', true],
+			['git@github.com:user/repository', true],
+			['git@github.enterprise.com:org-name/repo-name', true],
+			['git@192.168.1.101:2222:user/repo', true],
+			['git@ssh.dev.azure.com:v3/User/repo/directory', true],
+			['ssh://git@mydomain.example:2224/gitolite-admin', true],
+			['gituser@192.168.1.1:ABC/Repo4.git', true],
+			['root@192.168.1.1/repo.git', true],
+			['http://github.com/user/repository', false],
+			['https://github.com/user/repository', false],
+			['git@gitlab.com:something.net/n8n.git', true],
+			['user.name@github.com:user/repository.git', true],
+		])('%s -> %s', (url, isValid) => {
+			expect(SOURCE_CONTROL_SSH_REPO_URL_REGEX.test(url)).toBe(isValid);
+		});
+	});
+
+	describe('SOURCE_CONTROL_HTTPS_REPO_URL_REGEX', () => {
+		test.each([
+			['git@github.com:user/repository.git', false],
+			['git@github.enterprise.com:org-name/repo-name.git', false],
+			['http://github.com/user/repository', false],
+			['https://github.com/user/repository.git', true],
+		])('%s -> %s', (url, isValid) => {
+			expect(SOURCE_CONTROL_HTTPS_REPO_URL_REGEX.test(url)).toBe(isValid);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.constants.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.constants.ts
@@ -1,3 +1,7 @@
 export const SOURCE_CONTROL_PUSH_MODAL_KEY = 'sourceControlPush';
 export const SOURCE_CONTROL_PULL_MODAL_KEY = 'sourceControlPull';
 export const SOURCE_CONTROL_PULL_RESULT_MODAL_KEY = 'sourceControlPullResult';
+
+export const SOURCE_CONTROL_SSH_REPO_URL_REGEX =
+	/^(?:git@|ssh:\/\/git@|[\w.-]+@)(?:[\w.-]+|\[[0-9a-fA-F:]+])(?::\d+)?[:\/][\w\-~.]+(?:\/[\w\-~.]+)*(?:\.git)?(?:\/.*)?$/;
+export const SOURCE_CONTROL_HTTPS_REPO_URL_REGEX = /^https:\/\/.+$/;

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/views/SettingsSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/views/SettingsSourceControl.test.ts
@@ -232,91 +232,56 @@ describe('SettingsSourceControl', () => {
 		});
 	});
 
-	describe('should test repo URLs', () => {
+	describe('repo URL validation', () => {
 		beforeEach(() => {
 			settingsStore.settings.enterprise[EnterpriseEditionFeature.SourceControl] = true;
 		});
 
-		describe('for ssh connection', () => {
-			test.each([
-				['git@github.com:user/repository.git', true],
-				['git@github.enterprise.com:org-name/repo-name.git', true],
-				['git@192.168.1.101:2222:user/repo.git', true],
-				['git@github.com:user/repo.git/path/to/subdir', true],
-				// The opening bracket in curly braces makes sure it is not treated as a special character by the 'user-event' library
-				['git@{[}2001:db8:100:f101:210:a4ff:fee3:9566]:user/repo.git', true],
-				['git@github.com:org/suborg/repo.git', true],
-				['git@github.com:user-name/repo-name.git', true],
-				['git@github.com:user_name/repo_name.git', true],
-				['git@github.com:user/repository', true],
-				['git@github.enterprise.com:org-name/repo-name', true],
-				['git@192.168.1.101:2222:user/repo', true],
-				['git@ssh.dev.azure.com:v3/User/repo/directory', true],
-				['ssh://git@mydomain.example:2224/gitolite-admin', true],
-				['gituser@192.168.1.1:ABC/Repo4.git', true],
-				['root@192.168.1.1/repo.git', true],
-				['http://github.com/user/repository', false],
-				['https://github.com/user/repository', false],
-				['git@gitlab.com:something.net/n8n.git', true],
-				// Test cases for usernames containing dots
-				['user.name@github.com:user/repository.git', true],
-			])('%s', async (url: string, isValid: boolean) => {
-				await nextTick();
-				const { container, queryByText } = renderComponent({
-					pinia,
-				});
-
-				await waitFor(() => expect(sourceControlStore.preferences.publicKey).not.toEqual(''));
-
-				const repoUrlInput = container.querySelector('input[name="repoUrl"]')!;
-
-				await userEvent.click(repoUrlInput);
-				await userEvent.type(repoUrlInput, url);
-				await userEvent.tab();
-
-				const inputError = expect(queryByText('The Git repository URL is not valid'));
-
-				if (isValid) {
-					inputError.not.toBeInTheDocument();
-				} else {
-					inputError.toBeInTheDocument();
-				}
+		async function typeSshRepoUrl(url: string) {
+			await nextTick();
+			const { container, queryByText } = renderComponent({
+				pinia,
 			});
+
+			await waitFor(() => expect(sourceControlStore.preferences.publicKey).not.toEqual(''));
+
+			const repoUrlInput = container.querySelector('input[name="repoUrl"]')!;
+
+			await userEvent.click(repoUrlInput);
+			await userEvent.type(repoUrlInput, url);
+			await userEvent.tab();
+
+			return queryByText('The Git repository URL is not valid');
+		}
+
+		it('should accept a valid ssh URL', async () => {
+			expect(await typeSshRepoUrl('git@github.com:user/repository.git')).not.toBeInTheDocument();
 		});
 
-		describe('for https connection', () => {
-			test.each([
-				['git@github.com:user/repository.git', false],
-				['git@github.enterprise.com:org-name/repo-name.git', false],
-				['http://github.com/user/repository', false],
-				['https://github.com/user/repository.git', true],
-			])('%s', async (url: string, isValid: boolean) => {
-				await nextTick();
-				const { container, queryByText, queryByTestId } = renderComponent({
-					pinia,
-				});
+		it('should reject an invalid ssh URL', async () => {
+			expect(await typeSshRepoUrl('http://github.com/user/repository')).toBeInTheDocument();
+		});
 
-				await waitFor(() => expect(sourceControlStore.preferences.publicKey).not.toEqual(''));
-				// Change to HTTPS protocol
-				const connectionTypeSelect = queryByTestId('source-control-connection-type-select')!;
-				await userEvent.click(within(connectionTypeSelect).getByRole('combobox'));
-				await waitFor(() => expect(screen.getByText('HTTPS')).toBeVisible());
-				await userEvent.click(screen.getByText('HTTPS'));
-
-				const repoUrlInput = container.querySelector('input[name="repoUrl"]')!;
-
-				await userEvent.click(repoUrlInput);
-				await userEvent.type(repoUrlInput, url);
-				await userEvent.tab();
-
-				const inputError = expect(queryByText('Please enter a valid HTTPS URL'));
-
-				if (isValid) {
-					inputError.not.toBeInTheDocument();
-				} else {
-					inputError.toBeInTheDocument();
-				}
+		it('should reject a non-https URL for https connection', async () => {
+			await nextTick();
+			const { container, queryByText, queryByTestId } = renderComponent({
+				pinia,
 			});
+
+			await waitFor(() => expect(sourceControlStore.preferences.publicKey).not.toEqual(''));
+			// Change to HTTPS protocol
+			const connectionTypeSelect = queryByTestId('source-control-connection-type-select')!;
+			await userEvent.click(within(connectionTypeSelect).getByRole('combobox'));
+			await waitFor(() => expect(screen.getByText('HTTPS')).toBeVisible());
+			await userEvent.click(screen.getByText('HTTPS'));
+
+			const repoUrlInput = container.querySelector('input[name="repoUrl"]')!;
+
+			await userEvent.click(repoUrlInput);
+			await userEvent.type(repoUrlInput, 'git@github.com:user/repository.git');
+			await userEvent.tab();
+
+			expect(queryByText('Please enter a valid HTTPS URL')).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/views/SettingsSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/views/SettingsSourceControl.test.ts
@@ -237,7 +237,8 @@ describe('SettingsSourceControl', () => {
 			settingsStore.settings.enterprise[EnterpriseEditionFeature.SourceControl] = true;
 		});
 
-		async function typeSshRepoUrl(url: string) {
+		// Types the URL into the SSH form and returns the validation error element, or null.
+		async function queryUrlErrorAfterTypingSshUrl(url: string) {
 			await nextTick();
 			const { container, queryByText } = renderComponent({
 				pinia,
@@ -255,11 +256,15 @@ describe('SettingsSourceControl', () => {
 		}
 
 		it('should accept a valid ssh URL', async () => {
-			expect(await typeSshRepoUrl('git@github.com:user/repository.git')).not.toBeInTheDocument();
+			const urlError = await queryUrlErrorAfterTypingSshUrl('git@github.com:user/repository.git');
+
+			expect(urlError).not.toBeInTheDocument();
 		});
 
 		it('should reject an invalid ssh URL', async () => {
-			expect(await typeSshRepoUrl('http://github.com/user/repository')).toBeInTheDocument();
+			const urlError = await queryUrlErrorAfterTypingSshUrl('http://github.com/user/repository');
+
+			expect(urlError).toBeInTheDocument();
 		});
 
 		it('should reject a non-https URL for https connection', async () => {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/views/SettingsSourceControl.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/views/SettingsSourceControl.vue
@@ -7,6 +7,10 @@ import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHe
 import { useToast } from '@n8n/composables/useToast';
 import { MODAL_CONFIRM } from '@/app/constants';
 import { useSourceControlStore } from '../sourceControl.store';
+import {
+	SOURCE_CONTROL_HTTPS_REPO_URL_REGEX,
+	SOURCE_CONTROL_SSH_REPO_URL_REGEX,
+} from '../sourceControl.constants';
 import type { SshKeyTypes, SourceControlPreferences } from '../sourceControl.types';
 import type { TupleToUnion } from '@/app/utils/typeHelpers';
 import type { Rule, RuleGroup } from '@n8n/design-system';
@@ -182,8 +186,7 @@ const repoUrlValidationRules = computed<Array<Rule | RuleGroup>>(() => {
 		baseRules.push({
 			name: 'MATCH_REGEX',
 			config: {
-				regex:
-					/^(?:git@|ssh:\/\/git@|[\w.-]+@)(?:[\w.-]+|\[[0-9a-fA-F:]+])(?::\d+)?[:\/][\w\-~.]+(?:\/[\w\-~.]+)*(?:\.git)?(?:\/.*)?$/,
+				regex: SOURCE_CONTROL_SSH_REPO_URL_REGEX,
 				message: locale.baseText('settings.sourceControl.repoUrlInvalid'),
 			},
 		});
@@ -191,7 +194,7 @@ const repoUrlValidationRules = computed<Array<Rule | RuleGroup>>(() => {
 		baseRules.push({
 			name: 'MATCH_REGEX',
 			config: {
-				regex: /^https:\/\/.+$/,
+				regex: SOURCE_CONTROL_HTTPS_REPO_URL_REGEX,
 				message: locale.baseText('settings.sourceControl.enterValidHttpsUrl'),
 			},
 		});


### PR DESCRIPTION
## Summary

`SettingsSourceControl.test.ts` had 23 parameterised repo URL cases. Each case mounted the whole settings view, waited for the SSH key pair, typed the URL one character at a time, and tabbed out, only to check one regex. Each case took about 1 s. The file took 29 s and was the sixth slowest test file in the repo.

This PR moves the SSH and HTTPS regexes from the view into exported constants in `sourceControl.constants.ts` and tests all 23 cases directly against the constants. The view test keeps three mounted wiring checks: a valid SSH URL, an invalid SSH URL, and one HTTPS case after the protocol switch. The view has no behaviour change.

View test file time: 28.7 s before, 11.9 s after. The 23 regex cases run in 18 ms.

## How to test

```bash
cd packages/frontend/editor-ui
pnpm test src/features/integrations/sourceControl.ee
```

Expect 10 files and 114 tests to pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-1118

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

