### PR TITLE
test(core): Assert the Postgres teardown timeout path without a long wait

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.recovery.postgres.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.recovery.postgres.test.ts
@@ -325,7 +325,8 @@ describe('DbConnectionMonitor recovery against real Postgres', () => {
 			});
 			await dataSource.initialize();
 
-			const destroyTimeoutMs = 2_000;
+			// Short bound: the frozen socket never self-drains, so the value only sets the wait.
+			const destroyTimeoutMs = 500;
 			const monitor = new DbConnectionMonitor(
 				dataSource,
 				() => {},
@@ -385,7 +386,8 @@ describe('DbConnectionMonitor recovery against real Postgres', () => {
 			);
 			await dataSource.initialize();
 
-			const destroyTimeoutMs = 2_000;
+			// Short bound: the frozen socket never self-drains, so the value only sets the wait.
+			const destroyTimeoutMs = 500;
 			const monitor = new DbConnectionMonitor(
 				dataSource,
 				() => {},

--- a/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.recovery.postgres.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.recovery.postgres.test.ts
@@ -325,15 +325,17 @@ describe('DbConnectionMonitor recovery against real Postgres', () => {
 			});
 			await dataSource.initialize();
 
-			// Short bound: the frozen socket never self-drains, so the value only sets the wait.
-			const destroyTimeoutMs = 500;
+			// The frozen socket never self-drains, so any bound works. The log assertions below
+			// prove the path; the value only sets how long the test waits.
+			const destroyTimeoutMs = 50;
+			const logger = mock<Logger>();
 			const monitor = new DbConnectionMonitor(
 				dataSource,
 				() => {},
 				buildDatabaseConfig({
 					postgresdb: mock<DatabaseConfig['postgresdb']>({ destroyTimeoutMs }),
 				}),
-				mock<Logger>(),
+				logger,
 				mock<ErrorReporter>(),
 				mock<DbConnectionMetrics>(),
 			);
@@ -348,15 +350,17 @@ describe('DbConnectionMonitor recovery against real Postgres', () => {
 			proxy.freezeExisting();
 
 			try {
-				const start = Date.now();
 				// Without the destroy timeout this never resolves (`destroy()` hangs at attempt 1).
 				await (monitor as unknown as MonitorInternals).recoverDataSource();
-				const elapsed = Date.now() - start;
 
-				// `destroy()` was bounded and the frozen client force-closed, so the pool rebuilt.
-				// The lower bound proves recovery went through the timeout path, not a self-drain.
-				expect(elapsed).toBeGreaterThanOrEqual(destroyTimeoutMs);
-				expect(elapsed).toBeLessThan(destroyTimeoutMs + 15_000);
+				// `destroy()` hit the bound, the frozen client was force-closed, and that was enough:
+				// the drain settled inside the grace period, so the pool was not abandoned.
+				expect(logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining(`teardown exceeded ${destroyTimeoutMs}ms`),
+				);
+				expect(logger.error).not.toHaveBeenCalledWith(
+					expect.stringContaining('abandoning the pool'),
+				);
 				expect(dataSource.isInitialized).toBe(true);
 				expect(await dataSource.query('SELECT 1 AS ok')).toEqual([{ ok: 1 }]);
 			} finally {
@@ -386,15 +390,17 @@ describe('DbConnectionMonitor recovery against real Postgres', () => {
 			);
 			await dataSource.initialize();
 
-			// Short bound: the frozen socket never self-drains, so the value only sets the wait.
-			const destroyTimeoutMs = 500;
+			// The frozen socket never self-drains, so any bound works. The log assertions below
+			// prove the path; the value only sets how long the test waits.
+			const destroyTimeoutMs = 50;
+			const logger = mock<Logger>();
 			const monitor = new DbConnectionMonitor(
 				dataSource,
 				() => {},
 				buildDatabaseConfig({
 					postgresdb: mock<DatabaseConfig['postgresdb']>({ destroyTimeoutMs }),
 				}),
-				mock<Logger>(),
+				logger,
 				mock<ErrorReporter>(),
 				mock<DbConnectionMetrics>(),
 			);
@@ -415,14 +421,16 @@ describe('DbConnectionMonitor recovery against real Postgres', () => {
 			proxy.freezeExisting();
 
 			try {
-				const start = Date.now();
 				// Before the fix this never resolves: the post-force-close await was unbounded.
 				await (monitor as unknown as MonitorInternals).recoverDataSource();
-				const elapsed = Date.now() - start;
 
 				// Both bounds were traversed, then the teardown was abandoned and the pool rebuilt.
-				expect(elapsed).toBeGreaterThanOrEqual(destroyTimeoutMs + FORCE_CLOSE_GRACE_MS);
-				expect(elapsed).toBeLessThan(destroyTimeoutMs + FORCE_CLOSE_GRACE_MS + 15_000);
+				expect(logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining(`teardown exceeded ${destroyTimeoutMs}ms`),
+				);
+				expect(logger.error).toHaveBeenCalledWith(
+					expect.stringContaining(`${FORCE_CLOSE_GRACE_MS}ms after force-closing sockets`),
+				);
 				expect(dataSource.isInitialized).toBe(true);
 				expect(await dataSource.query('SELECT 1 AS ok')).toEqual([{ ok: 1 }]);
 			} finally {


### PR DESCRIPTION
## Summary

Two tests in `db-connection-monitor.recovery.postgres.test.ts` wait for a destroy timeout against a frozen socket. The wait is by design, but the tests proved the timeout path only through a lower bound on elapsed time, which forced a 2 s timeout. The tests took 2.0 s and 3.0 s.

This PR makes two changes:

1. The tests assert the path directly through the mocked logger. The monitor logs a distinct warning when the drain exceeds the destroy timeout, and a distinct error when it abandons the pool after the force-close grace period. The first test asserts the warning and asserts that the pool was not abandoned. The second asserts both. A log assertion identifies the path exactly, where an elapsed-time bound only implies it.
2. With no lower bound to satisfy, `destroyTimeoutMs` drops to 50 ms. The frozen socket never self-drains, so any bound works. `DbConnectionMonitor` has no lower clamp on the value, and both tests call recovery directly, so no ping or backoff races the shorter bound.

Result across five runs: 89 to 202 ms and 1086 to 1144 ms. The remaining second in the second test is the production `FORCE_CLOSE_GRACE_MS` constant, which is not configurable.

## How to test

Docker is required (testcontainers).

```bash
cd packages/@n8n/db
pnpm test db-connection-monitor.recovery.postgres
```

Expect 5 tests to pass, with the two changed tests near 0.1 s and 1.1 s.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-1119

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
