### PR TITLE
fix(Convert to File Node): Support data URIs and validate base64 in toBinary

### DIFF
--- a/packages/nodes-base/utils/__tests__/binary.test.ts
+++ b/packages/nodes-base/utils/__tests__/binary.test.ts
@@ -1,12 +1,13 @@
 import { type WorkSheet, utils as xlsxUtils, write as xlsxWrite } from '@e965/xlsx';
 import {
 	convertJsonToSpreadsheetBinary,
+	createBinaryFromJson,
 	extractDataFromPDF,
 	prepareBinariesDataList,
 	routeBinaryProperties,
 } from '@utils/binary';
 import type { IBinaryData, IDataObject, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { BINARY_ENCODING, jsonParse } from 'n8n-workflow';
+import { BINARY_ENCODING, jsonParse, NodeOperationError } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -349,3 +350,98 @@ describe('routeBinaryProperties', () => {
 		expect(binary.blob).toBe(binaryData);
 	});
 });
+
+describe('createBinaryFromJson', () => {
+	const helpers = mock<IExecuteFunctions['helpers']>();
+	const executeFunctions = mock<IExecuteFunctions>({
+		helpers,
+		getNode: vi.fn().mockReturnValue({ name: 'Convert to File' }),
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		helpers.prepareBinaryData.mockImplementation(async (buffer, fileName, mimeType) => ({
+			data: buffer.toString('base64'),
+			fileName,
+			mimeType,
+		}));
+	});
+
+	it('should decode a valid base64 string', async () => {
+		const base64 = Buffer.from('hello world').toString('base64');
+		const result = await createBinaryFromJson.call(executeFunctions, base64, {
+			fileName: 'test.txt',
+			mimeType: 'text/plain',
+		});
+
+		expect(helpers.prepareBinaryData).toHaveBeenCalledWith(
+			Buffer.from('hello world'),
+			'test.txt',
+			'text/plain',
+		);
+		expect(result.fileName).toBe('test.txt');
+	});
+
+	it('should strip data: URI prefix and extract mimeType if not provided', async () => {
+		const pngBase64 =
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+		const dataUri = `data:image/png;base64,${pngBase64}`;
+
+		const result = await createBinaryFromJson.call(executeFunctions, dataUri);
+
+		expect(helpers.prepareBinaryData).toHaveBeenCalledWith(
+			Buffer.from(pngBase64, 'base64'),
+			undefined,
+			'image/png',
+		);
+		const decodedBuffer = (helpers.prepareBinaryData as Mock).mock.calls[0][0] as Buffer;
+		expect(decodedBuffer.subarray(0, 4)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+		expect(result.fileName).toBe('file');
+	});
+
+	it('should not override options.mimeType when data: URI is provided', async () => {
+		const pngBase64 =
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+		const dataUri = `data:image/png;base64,${pngBase64}`;
+
+		await createBinaryFromJson.call(executeFunctions, dataUri, {
+			mimeType: 'application/octet-stream',
+		});
+
+		expect(helpers.prepareBinaryData).toHaveBeenCalledWith(
+			Buffer.from(pngBase64, 'base64'),
+			undefined,
+			'application/octet-stream',
+		);
+	});
+
+	it('should handle base64 string with whitespace and newlines', async () => {
+		const raw = 'valid base64 content';
+		const base64 = Buffer.from(raw).toString('base64');
+		const base64WithWhitespace = `\n  ${base64}  \r\n`;
+
+		const result = await createBinaryFromJson.call(executeFunctions, base64WithWhitespace, {
+			fileName: 'spaced.txt',
+		});
+
+		expect(helpers.prepareBinaryData).toHaveBeenCalledWith(
+			Buffer.from(raw),
+			'spaced.txt',
+			undefined,
+		);
+		expect(result.fileName).toBe('spaced.txt');
+	});
+
+	it('should throw NodeOperationError if input contains non-base64 characters', async () => {
+		const invalidInput = 'this is plain text, not base64!';
+
+		await expect(createBinaryFromJson.call(executeFunctions, invalidInput)).rejects.toThrow(
+			NodeOperationError,
+		);
+
+		await expect(createBinaryFromJson.call(executeFunctions, invalidInput)).rejects.toThrow(
+			'The provided string is not valid base64 data. If you are trying to write plain text to a file, use the "Convert to Text File" operation instead.',
+		);
+	});
+});
+

--- a/packages/nodes-base/utils/binary.ts
+++ b/packages/nodes-base/utils/binary.ts
@@ -118,8 +118,30 @@ export async function createBinaryFromJson(
 		buffer = iconv.encode(valueAsString, options.encoding || 'utf8', {
 			addBOM: options.addBOM,
 		});
+	} else if (Buffer.isBuffer(value)) {
+		buffer = value;
 	} else {
-		buffer = Buffer.from(value as unknown as string, BINARY_ENCODING);
+		let base64String = typeof value === 'string' ? value : String(value ?? '');
+		const trimmed = base64String.trim();
+		const dataUriMatch = /^data:(.*?);base64,(.*)$/s.exec(trimmed);
+		if (dataUriMatch) {
+			const mediaType = dataUriMatch[1].split(';')[0].trim();
+			if (!options.mimeType && mediaType) {
+				options.mimeType = mediaType;
+			}
+			base64String = dataUriMatch[2];
+		}
+
+		const cleaned = base64String.replace(/\s+/g, '');
+		if (cleaned.length > 0 && !/^[A-Za-z0-9+/=_-]+$/.test(cleaned)) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'The provided string is not valid base64 data. If you are trying to write plain text to a file, use the "Convert to Text File" operation instead.',
+				{ itemIndex: options.itemIndex || 0 },
+			);
+		}
+
+		buffer = Buffer.from(base64String, BINARY_ENCODING);
 	}
 
 	const binaryData = await this.helpers.prepareBinaryData(


### PR DESCRIPTION
## Summary

When using the **Convert to File** node with operation **Move Base64 String to File** (`toBinary`), users frequently pass base64 data URIs generated by AI models, web APIs, or canvas exports (e.g. `data:image/png;base64,iVBORw0KGgo...`).

Previously, `createBinaryFromJson` passed the entire string directly into `Buffer.from(value, 'base64')`. In Node.js, `Buffer.from(..., 'base64')` strips non-base64 characters and decodes the ASCII header characters (`data:image/png;base64,`) as base64 payload bytes. This shifts byte alignment and injects garbage bytes at the start of the decoded file, corrupting files (such as PNGs, JPEGs, and PDFs) while silently reporting success.

Furthermore, when users mistakenly passed arbitrary plain text into this operation instead of using the "Convert to Text File" operation, `Buffer.from(..., 'base64')` silently decoded the ASCII characters into mangled bytes without warning.

### Solution
1. **Data URI Support:** Detect `data:<mimeType>;base64,<payload>` URIs, cleanly stripping the header so `Buffer.from` receives only the valid base64 payload without byte-shift corruption.
2. **Automatic MIME type detection:** If `options.mimeType` is not explicitly set, extract the MIME type directly from the `data:` URI (e.g. `image/png`).
3. **Base64 Validation:** Validate that the base64 payload only contains valid base64 characters (allowing whitespace/newlines). If invalid characters are present (such as plain text), throw a descriptive `NodeOperationError` guiding the user to the "Convert to Text File" operation.
4. **Unit Tests:** Added regression tests covering standard base64 decoding, `data:` URI stripping, MIME type extraction, whitespace handling, and plain-text validation error in `packages/nodes-base/utils/__tests__/binary.test.ts`.

## How to test

1. Create a workflow with a **Convert to File** node using operation **Move Base64 String to File** (`toBinary`).
2. Supply a data URI (e.g. `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==`).
3. Execute the node:
   - Before: Produces a corrupt file starting with bytes `75ab5a8a...` instead of valid PNG magic header `89504e47...`.
   - After: Produces a valid PNG file with the exact PNG magic header `89504e47...` and automatically sets MIME type to `image/png`.
4. Supply invalid plain text (e.g. `hello world`):
   - Throws a descriptive `NodeOperationError`: *"The provided string is not valid base64 data. If you are trying to write plain text to a file, use the "Convert to Text File" operation instead."*
5. Verify unit tests in `packages/nodes-base/utils/__tests__/binary.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #37612
- https://linear.app/n8n/issue/GHC-9390

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

