### PR TITLE
ci: Shard lint by package group (no-changelog)

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -61,6 +61,7 @@ jobs:
               !**/*.md
               !**/LICENSE
               !**/CHANGELOG.md
+              .github/workflows/test-linting-reusable.yml
             runtime:
               **
               !packages/@n8n/task-runner-python/**

--- a/.github/workflows/test-linting-reusable.yml
+++ b/.github/workflows/test-linting-reusable.yml
@@ -15,14 +15,23 @@ on:
         default: 26.5.1
 
 env:
-  # Inherited by every worker turbo spawns, so the real budget is
-  # concurrency x cap: lint:ci runs 2 x 6 GB, fitting the runner's 15.2 GB.
+  # Each shard runs two workers with a 6 GB cap. This fits the runner's 15.2 GB.
   NODE_OPTIONS: --max-old-space-size=6144
 
 jobs:
   lint:
-    name: Lint
+    name: Lint (${{ matrix.name }})
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Backend
+            command: pnpm turbo run lint --concurrency=2 --cache=local:r,remote:r --filter='!./packages/frontend/**' --filter='!./packages/modules/*/frontend'
+            run-global-checks: true
+          - name: Frontend
+            command: pnpm turbo run lint lint:styles --concurrency=2 --cache=local:r,remote:r --filter='./packages/frontend/**' --filter='./packages/modules/*/frontend'
+            run-global-checks: false
     steps:
       - uses: useblacksmith/checkout@bcec731f1eb1367240608d1c889a75b96db6ec53 # v1.5.0
         with:
@@ -31,5 +40,9 @@ jobs:
       - name: Build and Test
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: pnpm lint:ci
+          build-command: ${{ matrix.command }}
           node-version: ${{ inputs.nodeVersion }}
+
+      - name: Run global lint checks
+        if: matrix.run-global-checks
+        run: pnpm boundaries:check && pnpm check:workspace-private-deps

--- a/.github/workflows/test-linting-reusable.yml
+++ b/.github/workflows/test-linting-reusable.yml
@@ -27,10 +27,10 @@ jobs:
       matrix:
         include:
           - name: Backend
-            command: pnpm turbo run lint --concurrency=2 --cache=local:r,remote:r --filter='!./packages/frontend/**' --filter='!./packages/modules/*/frontend'
+            command: pnpm turbo run lint --concurrency=2 --cache=local:r,remote:r --filter=!./packages/frontend/** --filter=!./packages/modules/*/frontend --filter=!./packages/extensions/**
             run-global-checks: true
           - name: Frontend
-            command: pnpm turbo run lint lint:styles --concurrency=2 --cache=local:r,remote:r --filter='./packages/frontend/**' --filter='./packages/modules/*/frontend'
+            command: pnpm turbo run lint lint:styles --concurrency=2 --cache=local:r,remote:r --filter=./packages/frontend/** --filter=./packages/modules/*/frontend --filter=./packages/extensions/**
             run-global-checks: false
     steps:
       - uses: useblacksmith/checkout@bcec731f1eb1367240608d1c889a75b96db6ec53 # v1.5.0


### PR DESCRIPTION
## Summary

Split lint into backend and frontend jobs. Keep global checks on the backend job. Include extensions with frontend style linting.

**Measured impact:** 8m57s → 6m45s (-25%). Cost/run: $0.0716 → $0.088 (+23%). Projected cost: +$152/month.

## How to test

PR CI passed both lint jobs. Turbo dry-run coverage found 168 tasks with no missing or duplicate tasks.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
