### PR TITLE
chore: Add code-health rule for derived node output keys (no-changelog)

### DIFF
--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -1310,6 +1310,204 @@
 				"message": "A bare `eslint-disable` directive silences every lint rule in its range, including the encryption guardrails.",
 				"hash": "7d9779f96d99"
 			}
+		],
+		"packages/nodes-base/utils/utilities.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 279,
+				"message": "keysToLowercase: output key `acc[key.toLowerCase()]` is derived from data through `toLowerCase`. A change in the transform silently renames the field for every user.",
+				"hash": "2403dc75ad5f"
+			},
+			{
+				"rule": "derived-output-keys",
+				"line": 322,
+				"message": "flattenObject: output key `returnData[`${key1}.${key2}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "8c83927d862b"
+			}
+		],
+		"packages/nodes-base/nodes/Bannerbear/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 58,
+				"message": "keysToSnakeCase: output key `element[snakeCase(key)]` is derived from data through `snakeCase`. A change in the transform silently renames the field for every user.",
+				"hash": "64e2192720fa"
+			}
+		],
+		"packages/nodes-base/nodes/Baserow/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 247,
+				"message": "createIdToNameMapping: output key `acc[`field_${cur.id}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "4061a6b8c9a9"
+			}
+		],
+		"packages/nodes-base/nodes/Keap/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 80,
+				"message": "keysToSnakeCase: output key `element[snakeCase(key)]` is derived from data through `snakeCase`. A change in the transform silently renames the field for every user.",
+				"hash": "966c2aebe3b8"
+			}
+		],
+		"packages/nodes-base/nodes/PagerDuty/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 98,
+				"message": "keysToSnakeCase: output key `element[snakeCase(key)]` is derived from data through `snakeCase`. A change in the transform silently renames the field for every user.",
+				"hash": "e6ea60792139"
+			}
+		],
+		"packages/nodes-base/nodes/RenameKeys/RenameKeys.node.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 211,
+				"message": "renameObjectKeys: output key `obj[newKey]` is derived from data through `replace`. A change in the transform silently renames the field for every user.",
+				"hash": "6040070b6d40"
+			}
+		],
+		"packages/nodes-base/nodes/Shopify/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 134,
+				"message": "keysToSnakeCase: output key `element[snakeCase(key)]` is derived from data through `snakeCase`. A change in the transform silently renames the field for every user.",
+				"hash": "72bc22a60ba6"
+			}
+		],
+		"packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 577,
+				"message": "webhook: output key `results[`${keys[i]}(${i})`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "e61192461b00"
+			}
+		],
+		"packages/nodes-base/nodes/TheHive/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 135,
+				"message": "prepareCustomFields: output key `acc[`customFields.${curr}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "2c97fe7cf728"
+			},
+			{
+				"rule": "derived-output-keys",
+				"line": 172,
+				"message": "prepareCustomFields: output key `acc[updatedField]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "639a67533c86"
+			}
+		],
+		"packages/nodes-base/nodes/Transform/Summarize/utils.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 282,
+				"message": "flattenAggregationResultToArray: output key `v.returnData[normalizeFieldName(result.fieldName)]` is derived from data through `normalizeFieldName`. A change in the transform silently renames the field for every user.",
+				"hash": "b4ad0cab0683"
+			}
+		],
+		"packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 178,
+				"message": "keysTPascalCase: output key `data[pascalCase(key)]` is derived from data through `pascalCase`. A change in the transform silently renames the field for every user.",
+				"hash": "c620d9086d25"
+			}
+		],
+		"packages/nodes-base/nodes/ItemLists/V1/summarize.operation.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 427,
+				"message": "aggregateData: output key `acc[`${AggregationDisplayNames[aggregation.aggregation]}${aggregation.field}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "603045047261"
+			}
+		],
+		"packages/nodes-base/nodes/ItemLists/V2/summarize.operation.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 328,
+				"message": "parseReturnData: output key `returnData[newKey]` is derived from data through `replace`. A change in the transform silently renames the field for every user.",
+				"hash": "e6aa99e6e08a"
+			},
+			{
+				"rule": "derived-output-keys",
+				"line": 457,
+				"message": "aggregateData: output key `acc[`${AggregationDisplayNames[aggregation.aggregation]}${aggregation.field}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "32ae0206ad1f"
+			}
+		],
+		"packages/nodes-base/nodes/Merge/v2/utils.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 35,
+				"message": "addSuffixToEntriesKeys: output key `json[`${key}_${suffix}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "3bc32193f024"
+			}
+		],
+		"packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 108,
+				"message": "adjustAddresses: output key `results[`address${index + 1}_${key}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "4d4b5e104d96"
+			}
+		],
+		"packages/nodes-base/nodes/Microsoft/Storage/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 356,
+				"message": "parseHeaders: output key `result[newKey]` is derived from data through `camelCase`. A change in the transform silently renames the field for every user.",
+				"hash": "7a1b0f4de60b"
+			},
+			{
+				"rule": "derived-output-keys",
+				"line": 362,
+				"message": "parseHeaders: output key `(result.metadata as IDataObject)[key.replace(HeaderConstants.PREFIX_X_MS_META, '')]` is derived from data through `replace`. A change in the transform silently renames the field for every user.",
+				"hash": "26a10937db1e"
+			}
+		],
+		"packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 666,
+				"message": "prepend: output key `properties[`${stringKey}_${toKey(key)}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "468cddc7e4ca"
+			}
+		],
+		"packages/nodes-base/nodes/Splunk/v1/GenericFunctions.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 111,
+				"message": "extractErrorDescription: output key `{ [messages.msg.$.type.toLowerCase()]: … }` is derived from data through `toLowerCase`. A change in the transform silently renames the field for every user.",
+				"hash": "d8ff53767d06"
+			}
+		],
+		"packages/nodes-base/nodes/Merge/v3/helpers/utils.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 37,
+				"message": "addSuffixToEntriesKeys: output key `json[`${key}_${suffix}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "ad091f67bdcf"
+			}
+		],
+		"packages/nodes-base/nodes/Splunk/v2/helpers/utils.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 79,
+				"message": "extractErrorDescription: output key `{ [messages.msg.$.type.toLowerCase()]: … }` is derived from data through `toLowerCase`. A change in the transform silently renames the field for every user.",
+				"hash": "1053f2293241"
+			}
+		],
+		"packages/nodes-base/nodes/ItemLists/V3/actions/itemList/summarize.operation.ts": [
+			{
+				"rule": "derived-output-keys",
+				"line": 316,
+				"message": "parseReturnData: output key `returnData[newKey]` is derived from data through `replace`. A change in the transform silently renames the field for every user.",
+				"hash": "ca907467b864"
+			},
+			{
+				"rule": "derived-output-keys",
+				"line": 456,
+				"message": "aggregateData: output key `acc[`${AggregationDisplayNames[aggregation.aggregation]}${aggregation.field}`]` is derived from data through `template literal`. A change in the transform silently renames the field for every user.",
+				"hash": "d706dd90dde8"
+			}
 		]
 	}
 }

--- a/packages/testing/code-health/src/index.ts
+++ b/packages/testing/code-health/src/index.ts
@@ -3,6 +3,7 @@ import type { RuleSettingsMap } from '@n8n/rules-engine';
 
 import type { CodeHealthContext } from './context.js';
 import { CatalogViolationsRule } from './rules/catalog-violations.rule.js';
+import { DerivedOutputKeysRule } from './rules/derived-output-keys.rule.js';
 import { EncryptionBoundaryRule } from './rules/encryption-boundary.rule.js';
 import { EndpointScopeCoverageRule } from './rules/endpoint-scope-coverage.rule.js';
 import { MigrationTimestampRule } from './rules/migration-timestamp.rule.js';
@@ -14,6 +15,7 @@ import { WorkflowPrTargetSafetyRule } from './rules/workflow-pr-target-safety.ru
 
 export type { CodeHealthContext } from './context.js';
 export { CatalogViolationsRule } from './rules/catalog-violations.rule.js';
+export { DerivedOutputKeysRule } from './rules/derived-output-keys.rule.js';
 export { EncryptionBoundaryRule } from './rules/encryption-boundary.rule.js';
 export { EndpointScopeCoverageRule } from './rules/endpoint-scope-coverage.rule.js';
 export { MigrationTimestampRule } from './rules/migration-timestamp.rule.js';
@@ -59,6 +61,13 @@ const defaultRuleSettings: RuleSettingsMap = {
 		enabled: true,
 		severity: 'warning',
 		options: { workspaceFile: 'pnpm-workspace.yaml', lockFile: 'pnpm-lock.yaml' },
+	},
+	'derived-output-keys': {
+		// Existing sites are grandfathered via the baseline; only new derived keys fail.
+		// `--rule=derived-output-keys --ignore-baseline` lists every site.
+		enabled: true,
+		severity: 'warning',
+		options: { packages: ['packages/nodes-base'] },
 	},
 	'endpoint-scope-coverage': {
 		// Disabled by default: enabling gates CI on ~129 existing authenticated-unscoped
@@ -136,6 +145,7 @@ export function createDefaultRunner(settings?: RuleSettingsMap): RuleRunner<Code
 	runner.registerRule(new SingleInstanceLibsRule());
 	runner.registerRule(new SingleInstanceLockfileRule());
 	runner.registerRule(new EncryptionBoundaryRule());
+	runner.registerRule(new DerivedOutputKeysRule());
 	runner.registerRule(new StaleOverridesRule());
 	runner.registerRule(new EndpointScopeCoverageRule());
 	runner.registerRule(new SubpathPurityRule());

--- a/packages/testing/code-health/src/rules/derived-output-keys.rule.test.ts
+++ b/packages/testing/code-health/src/rules/derived-output-keys.rule.test.ts
@@ -1,0 +1,260 @@
+import { createInMemoryProject } from '@n8n/rules-engine/ast';
+import { describe, expect, it } from 'vitest';
+
+import { DerivedOutputKeysRule } from './derived-output-keys.rule.js';
+
+describe('DerivedOutputKeysRule', () => {
+	const rule = new DerivedOutputKeysRule();
+
+	const analyze = (code: string) => {
+		const project = createInMemoryProject();
+		project.createSourceFile('node.ts', code);
+		return rule.analyzeProject(project).map((v) => v.message);
+	};
+
+	describe('flags derived keys that reach output', () => {
+		it('a template literal key on a returned object', () => {
+			const messages = analyze(`
+				function prepend(prefix: string, properties: Record<string, unknown>) {
+					for (const key of Object.keys(properties)) {
+						properties[\`\${prefix}_\${snakeCase(key)}\`] = properties[key];
+					}
+					return properties;
+				}
+			`);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toContain('prepend');
+			expect(messages[0]).toContain('template literal');
+		});
+
+		it('a transform call on an element of a returned array', () => {
+			const messages = analyze(`
+				function keysToSnakeCase(elements: IDataObject[]) {
+					for (const element of elements) {
+						for (const key of Object.keys(element)) {
+							element[snakeCase(key)] = element[key];
+						}
+					}
+					return elements;
+				}
+			`);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toContain('snakeCase');
+		});
+
+		it('a key computed one statement earlier', () => {
+			const messages = analyze(`
+				function rename(obj: IDataObject, key: string) {
+					const newKey = key.replace(/\\s/g, '_');
+					obj[newKey] = obj[key];
+					return obj;
+				}
+			`);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toContain('replace');
+		});
+
+		it('a write into item.json', () => {
+			const messages = analyze(`
+				function fill(item: INodeExecutionData, name: string) {
+					item.json[name.toLowerCase()] = true;
+				}
+			`);
+
+			expect(messages).toHaveLength(1);
+		});
+
+		it('an object pushed onto the returned array', () => {
+			const messages = analyze(`
+				function run(rows: IDataObject[]) {
+					const returnData: INodeExecutionData[] = [];
+					for (const row of rows) {
+						const json: IDataObject = {};
+						json[normalizeFieldName(row.name as string)] = row.value;
+						returnData.push({ json });
+					}
+					return returnData;
+				}
+			`);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toContain('normalizeFieldName');
+		});
+
+		it('an object passed to returnJsonArray', () => {
+			const messages = analyze(`
+				function run(this: IExecuteFunctions, data: IDataObject) {
+					const simplified: IDataObject = {};
+					for (const key of Object.keys(data)) {
+						simplified[camelCase(key)] = data[key];
+					}
+					return this.helpers.returnJsonArray(simplified);
+				}
+			`);
+
+			expect(messages).toHaveLength(1);
+		});
+
+		it('a write inside a nested callback on an object declared outside it', () => {
+			const messages = analyze(`
+				function addSuffixToEntriesKeys(data: INodeExecutionData[], suffix: string) {
+					return data.map((entry) => {
+						const json: IDataObject = {};
+						Object.keys(entry.json).forEach((key) => {
+							json[\`\${key}_\${suffix}\`] = entry.json[key];
+						});
+						return { ...entry, json };
+					});
+				}
+			`);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toContain('addSuffixToEntriesKeys');
+		});
+
+		it('a computed property in a returned object literal', () => {
+			const messages = analyze(`
+				const toEntry = (key: string, value: unknown) => ({ [\`field_\${key}\`]: value });
+			`);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toContain('toEntry');
+		});
+	});
+
+	describe('ignores', () => {
+		it('a key produced by deriveOutputKey', () => {
+			expect(
+				analyze(`
+					function prepend(prefix: string, properties: IDataObject, version: number) {
+						const strategy = version >= 3 ? 'snake_case_unicode' : 'snake_case_ascii';
+						for (const key of Object.keys(properties)) {
+							properties[deriveOutputKey(key, { strategy, prefix })] = properties[key];
+						}
+						return properties;
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a key produced by deriveOutputKey one statement earlier', () => {
+			expect(
+				analyze(`
+					function keysToSnakeCase(elements: IDataObject[]) {
+						for (const element of elements) {
+							for (const key of Object.keys(element)) {
+								const snakeKey = deriveOutputKey(key, { strategy: 'snake_case_unicode' });
+								if (key !== snakeKey) element[snakeKey] = element[key];
+							}
+						}
+						return elements;
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a template literal that only converts the key to a string', () => {
+			expect(
+				analyze(`
+					function wrap(values: Array<{ key: string; value: unknown }>) {
+						return values.map((value) => ({ [\`\${value.key}\`]: value.value }));
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a reduce accumulator that ends up in a request body', () => {
+			expect(
+				analyze(`
+					async function send(this: IExecuteFunctions, attributes: Array<{ name: string }>) {
+						const requested = attributes.reduce<IDataObject>((acc, cur) => {
+							acc[cur.name.toUpperCase()] = true;
+							return acc;
+						}, {});
+						return await this.helpers.httpRequest({ method: 'POST', body: { requested } });
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a key forwarded unchanged', () => {
+			expect(
+				analyze(`
+					function copy(source: IDataObject) {
+						const result: IDataObject = {};
+						for (const key of Object.keys(source)) {
+							result[key] = source[key];
+						}
+						return result;
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a derived key on a request body', () => {
+			expect(
+				analyze(`
+					async function send(this: IExecuteFunctions, fields: IDataObject) {
+						const body: IDataObject = {};
+						for (const key of Object.keys(fields)) {
+							body[snakeCase(key)] = fields[key];
+						}
+						return await this.helpers.httpRequest({ method: 'POST', body });
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a literal key', () => {
+			expect(
+				analyze(`
+					function tag(result: IDataObject) {
+						result['created_at'] = Date.now();
+						return result;
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a numeric index', () => {
+			expect(
+				analyze(`
+					function fill(result: IDataObject[]) {
+						for (let i = 0; i < 3; i++) {
+							result[i] = { index: i };
+						}
+						return result;
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a binary property name built from a prefix and index', () => {
+			expect(
+				analyze(`
+					function attach(item: INodeExecutionData, index: number, data: IBinaryData) {
+						item.binary![\`attachment_\${index}\`] = data;
+						return item;
+					}
+				`),
+			).toEqual([]);
+		});
+
+		it('a derived key on an object that never reaches output', () => {
+			expect(
+				analyze(`
+					function index(items: IDataObject[]) {
+						const lookup: IDataObject = {};
+						for (const item of items) {
+							lookup[String(item.id).toLowerCase()] = item;
+						}
+						log(lookup);
+					}
+				`),
+			).toEqual([]);
+		});
+	});
+});

--- a/packages/testing/code-health/src/rules/derived-output-keys.rule.ts
+++ b/packages/testing/code-health/src/rules/derived-output-keys.rule.ts
@@ -1,0 +1,502 @@
+import type { Violation } from '@n8n/rules-engine';
+import { AstRule } from '@n8n/rules-engine/ast';
+import type { AstProjectConfig } from '@n8n/rules-engine/ast';
+import { Node, SyntaxKind } from 'ts-morph';
+import type { Expression, Project, SourceFile } from 'ts-morph';
+
+import type { CodeHealthContext } from '../context.js';
+
+/** Functions that reshape a key. */
+const KEY_TRANSFORMS = new Set([
+	'camelCase',
+	'capitalCase',
+	'constantCase',
+	'kebabCase',
+	'paramCase',
+	'pascalCase',
+	'snakeCase',
+	'encodeURIComponent',
+	'normalize',
+	'replace',
+	'replaceAll',
+	'slugify',
+	'toLowerCase',
+	'toUpperCase',
+	'trim',
+]);
+
+/** Prefixes of local helpers that reshape keys, e.g. `normalizeFieldName`. */
+const KEY_TRANSFORM_PREFIXES = ['normalize', 'sanitize', 'fold', 'toKey'];
+
+/** Keys from this helper are not flagged: its strategies are frozen and tested. */
+const SANCTIONED_HELPER = 'deriveOutputKey';
+
+/** Calls whose argument becomes node output. */
+const OUTPUT_SINKS = /\b(returnJsonArray|constructExecutionMetaData|prepareOutputData)$/;
+
+/** Calls that send their argument to a provider. */
+const REQUEST_SINKS = /(request|fetch|axios)/i;
+
+/** Variables that hold node output by convention. */
+const OUTPUT_NAMES = new Set([
+	'returnData',
+	'output',
+	'result',
+	'results',
+	'newItem',
+	'simplified',
+]);
+
+/** Variables that hold a request by convention. */
+const REQUEST_NAMES = new Set([
+	'body',
+	'qs',
+	'query',
+	'headers',
+	'formData',
+	'requestOptions',
+	'options',
+	'params',
+	'filter',
+	'filters',
+	'payload',
+]);
+
+interface KeyWrite {
+	/** The assignment or property assignment that performs the write. */
+	node: Node;
+	/** The object that receives the key. */
+	target: Expression;
+	/** The expression that computes the key. */
+	key: Expression;
+}
+
+/**
+ * Flags output keys computed from data through a text transform. A change in
+ * the transform renames the field for every user without a failing test.
+ * Existing sites are grandfathered via the baseline.
+ */
+export class DerivedOutputKeysRule extends AstRule<CodeHealthContext> {
+	readonly id = 'derived-output-keys';
+	readonly name = 'Derived Output Keys';
+	readonly description =
+		'Node output keys computed from data through a text transform are an implicit contract; pin them with tests or pass the source key through unchanged';
+	readonly severity = 'warning' as const;
+
+	protected projectConfig(): AstProjectConfig {
+		const packages = (this.getOptions().packages as string[]) ?? ['packages/nodes-base'];
+		return {
+			packages,
+			spec: {
+				globs: [
+					'nodes/**/*.ts',
+					'utils/**/*.ts',
+					'!**/*.test.ts',
+					'!**/test/**',
+					'!**/__tests__/**',
+					'!**/__schema__/**',
+				],
+			},
+		};
+	}
+
+	analyze(context: CodeHealthContext): Violation[] {
+		return this.projects(context).flatMap(({ project }) => this.analyzeProject(project));
+	}
+
+	/** Exposed for unit tests against an in-memory project. */
+	analyzeProject(project: Project): Violation[] {
+		return project.getSourceFiles().flatMap((file) => this.analyzeFile(file));
+	}
+
+	private analyzeFile(file: SourceFile): Violation[] {
+		const violations: Violation[] = [];
+
+		for (const write of findKeyWrites(file)) {
+			if (isBinaryTarget(write.target)) continue;
+			if (!isStringKey(write.key)) continue;
+
+			const transform = findTransform(write.key);
+			if (!transform) continue;
+
+			if (flowOf(write.target) !== 'output') continue;
+
+			const fn = enclosingFunctionName(write.node);
+			const site = Node.isObjectLiteralExpression(write.target)
+				? `{ [${write.key.getText()}]: … }`
+				: `${write.target.getText()}[${write.key.getText()}]`;
+			violations.push(
+				this.nodeViolation(
+					write.node,
+					`${fn}: output key \`${site}\` is derived from data through \`${transform}\`. A change in the transform silently renames the field for every user.`,
+					'Derive the key with `deriveOutputKey` from n8n-workflow, whose strategies are frozen and tested, or pass the source key through unchanged.',
+				),
+			);
+		}
+
+		return violations;
+	}
+}
+
+/** `obj[key] = value` and `{ [key]: value }` with a non-literal key. */
+function findKeyWrites(file: SourceFile): KeyWrite[] {
+	const writes: KeyWrite[] = [];
+
+	for (const assignment of file.getDescendantsOfKind(SyntaxKind.BinaryExpression)) {
+		if (assignment.getOperatorToken().getKind() !== SyntaxKind.EqualsToken) continue;
+		const left = assignment.getLeft();
+		if (!Node.isElementAccessExpression(left)) continue;
+		const key = left.getArgumentExpression();
+		if (!key || isLiteral(key)) continue;
+		writes.push({ node: assignment, target: left.getExpression(), key });
+	}
+
+	for (const property of file.getDescendantsOfKind(SyntaxKind.PropertyAssignment)) {
+		const name = property.getNameNode();
+		if (!Node.isComputedPropertyName(name)) continue;
+		const key = name.getExpression();
+		if (isLiteral(key)) continue;
+		const literal = property.getParent();
+		if (!Node.isObjectLiteralExpression(literal)) continue;
+		writes.push({ node: property, target: literal, key });
+	}
+
+	return writes;
+}
+
+function isLiteral(expression: Expression): boolean {
+	return (
+		Node.isStringLiteral(expression) ||
+		Node.isNoSubstitutionTemplateLiteral(expression) ||
+		Node.isNumericLiteral(expression)
+	);
+}
+
+/** Binary property names such as `attachment_0` are fixed prefixes plus an index, not data. */
+function isBinaryTarget(target: Expression): boolean {
+	if (targetPath(target).at(-1) === 'binary') return true;
+	return /binary/i.test(rootIdentifier(target) ?? '');
+}
+
+/** Array indexes are not keys. Unresolved types count as strings. */
+function isStringKey(key: Expression): boolean {
+	const type = key.getType();
+	if (type.isNumber() || type.isNumberLiteral()) return false;
+	if (type.isUnion())
+		return !type.getUnionTypes().every((t) => t.isNumber() || t.isNumberLiteral());
+	return true;
+}
+
+/** The transform a key passes through, looking one variable back, or undefined. */
+function findTransform(key: Expression): string | undefined {
+	if (isSanctioned(key)) return undefined;
+	const direct = transformIn(key);
+	if (direct) return direct;
+
+	for (const identifier of identifiersIn(key)) {
+		for (const declaration of identifier.getSymbol()?.getDeclarations() ?? []) {
+			if (!Node.isVariableDeclaration(declaration)) continue;
+			const initializer = declaration.getInitializer();
+			if (!initializer || isSanctioned(initializer)) continue;
+			const viaVariable = transformIn(initializer);
+			if (viaVariable) return viaVariable;
+		}
+	}
+
+	return undefined;
+}
+
+/** True when the key comes out of the sanctioned helper. */
+function isSanctioned(expression: Node): boolean {
+	return [expression, ...expression.getDescendants()].some(
+		(node) => Node.isCallExpression(node) && calleeName(node.getExpression()) === SANCTIONED_HELPER,
+	);
+}
+
+function calleeName(callee: Node): string {
+	return Node.isPropertyAccessExpression(callee) ? callee.getName() : callee.getText();
+}
+
+function transformIn(expression: Node): string | undefined {
+	if (Node.isTemplateExpression(expression)) {
+		return isCoercionOnly(expression) ? undefined : 'template literal';
+	}
+
+	for (const call of [expression, ...expression.getDescendants()]) {
+		if (!Node.isCallExpression(call)) continue;
+		const name = calleeName(call.getExpression());
+		if (KEY_TRANSFORMS.has(name) || KEY_TRANSFORM_PREFIXES.some((p) => name.startsWith(p))) {
+			return name;
+		}
+	}
+
+	if (
+		Node.isBinaryExpression(expression) &&
+		expression.getOperatorToken().getKind() === SyntaxKind.PlusToken
+	) {
+		return 'string concatenation';
+	}
+
+	return undefined;
+}
+
+/** `${key}` alone converts to a string and changes nothing. */
+function isCoercionOnly(template: Node): boolean {
+	if (!Node.isTemplateExpression(template)) return false;
+	const spans = template.getTemplateSpans();
+	return (
+		template.getHead().getLiteralText() === '' &&
+		spans.length === 1 &&
+		spans[0].getLiteral().getLiteralText() === ''
+	);
+}
+
+function identifiersIn(expression: Node): Node[] {
+	const own = Node.isIdentifier(expression) ? [expression] : [];
+	return [...own, ...expression.getDescendantsOfKind(SyntaxKind.Identifier)];
+}
+
+type Flow = 'output' | 'request' | 'unclear';
+
+/** Hops through variables, returns and callbacks before giving up. */
+const MAX_DEPTH = 8;
+
+/**
+ * Where the written object ends up, following it through assignments, pushes,
+ * `json` properties, calls and returns. A callback's return value flows into the
+ * call that received the callback.
+ */
+function flowOf(target: Expression): Flow {
+	if (targetPath(target).includes('json')) return 'output';
+	if (Node.isObjectLiteralExpression(target)) return flowOfExpression(target, 0);
+
+	const root = rootIdentifierNode(target);
+	if (!root) return 'unclear';
+	return flowOfName(root.getText(), declarationScope(root), 0);
+}
+
+/** Scope of the variable's declaration, so uses outside the writing callback are seen. */
+function declarationScope(identifier: Node): Node {
+	const declaration = identifier.getSymbol()?.getDeclarations()[0];
+	return enclosingScope(declaration ?? identifier);
+}
+
+function flowOfName(name: string, scope: Node, depth: number): Flow {
+	if (depth > MAX_DEPTH) return 'unclear';
+	if (REQUEST_NAMES.has(name)) return 'request';
+	if (OUTPUT_NAMES.has(name)) return 'output';
+
+	const flows = new Set<Flow>();
+	for (const reference of referencesTo(name, scope)) {
+		flows.add(flowOfExpression(reference, depth + 1));
+	}
+	for (const alias of aliasesOf(name, scope)) {
+		flows.add(flowOfName(alias, scope, depth + 1));
+	}
+	return combine(flows);
+}
+
+function combine(flows: Set<Flow>): Flow {
+	if (flows.has('request')) return 'request';
+	if (flows.has('output')) return 'output';
+	return 'unclear';
+}
+
+/** Follows one expression to the place that consumes its value. */
+function flowOfExpression(expression: Node, depth: number): Flow {
+	if (depth > MAX_DEPTH) return 'unclear';
+
+	let node: Node = expression;
+	let parent = node.getParent();
+	while (
+		parent &&
+		(Node.isParenthesizedExpression(parent) ||
+			Node.isAsExpression(parent) ||
+			Node.isNonNullExpression(parent) ||
+			Node.isAwaitExpression(parent) ||
+			Node.isSpreadAssignment(parent) ||
+			Node.isSpreadElement(parent) ||
+			Node.isConditionalExpression(parent) ||
+			Node.isArrayLiteralExpression(parent))
+	) {
+		node = parent;
+		parent = parent.getParent();
+	}
+	if (!parent) return 'unclear';
+
+	if (Node.isVariableDeclaration(parent)) {
+		return flowOfName(parent.getName(), enclosingScope(parent), depth + 1);
+	}
+
+	if (Node.isBinaryExpression(parent) && parent.getRight() === node) {
+		const left = parent.getLeft();
+		if (targetPath(left).includes('json')) return 'output';
+		const root = rootIdentifier(left);
+		return root ? flowOfName(root, enclosingScope(parent), depth + 1) : 'unclear';
+	}
+
+	if (Node.isReturnStatement(parent)) {
+		return flowOfReturn(enclosingScope(parent), depth + 1);
+	}
+	if (Node.isArrowFunction(parent) && parent.getBody() === node) {
+		return flowOfReturn(parent, depth + 1);
+	}
+
+	if (Node.isPropertyAssignment(parent)) {
+		if (parent.getName() === 'json') return 'output';
+		return flowOfExpression(parent.getParentOrThrow(), depth + 1);
+	}
+	if (Node.isShorthandPropertyAssignment(parent)) {
+		if (parent.getName() === 'json') return 'output';
+		return flowOfExpression(parent.getParentOrThrow(), depth + 1);
+	}
+
+	if (Node.isCallExpression(parent) && parent.getArguments().includes(node)) {
+		return flowOfCallArgument(parent, node, depth);
+	}
+
+	return 'unclear';
+}
+
+function flowOfCallArgument(call: Node, argument: Node, depth: number): Flow {
+	if (!Node.isCallExpression(call)) return 'unclear';
+	const callee = call.getExpression();
+	const calleeText = callee.getText();
+
+	if (OUTPUT_SINKS.test(calleeText)) return 'output';
+	if (REQUEST_SINKS.test(calleeText)) return 'request';
+
+	if (Node.isPropertyAccessExpression(callee)) {
+		const method = callee.getName();
+		if (method === 'push' || method === 'unshift') {
+			const array = rootIdentifier(callee.getExpression());
+			return array ? flowOfName(array, enclosingScope(call), depth + 1) : 'unclear';
+		}
+		// `Object.assign(acc, { [k]: v })` writes into `acc`.
+		if (calleeText === 'Object.assign' && call.getArguments()[0] !== argument) {
+			const receiver = rootIdentifier(call.getArguments()[0]);
+			return receiver ? flowOfName(receiver, enclosingScope(call), depth + 1) : 'unclear';
+		}
+	}
+
+	// Any other call: the value travels on with the call result.
+	return flowOfExpression(call, depth + 1);
+}
+
+/** A value returned from a callback flows into the call that received the callback. */
+function flowOfReturn(scope: Node, depth: number): Flow {
+	if (Node.isSourceFile(scope)) return 'unclear';
+	const parent = scope.getParent();
+	if (parent && Node.isCallExpression(parent) && parent.getArguments().includes(scope)) {
+		return flowOfExpression(parent, depth + 1);
+	}
+	// Returned from a named function or method: the caller receives it as data.
+	return 'output';
+}
+
+/** Identifier uses of `name` in the scope, excluding its own declaration sites. */
+function referencesTo(name: string, scope: Node): Node[] {
+	return scope.getDescendantsOfKind(SyntaxKind.Identifier).filter((identifier) => {
+		if (identifier.getText() !== name) return false;
+		const parent = identifier.getParent();
+		if (Node.isVariableDeclaration(parent) || Node.isParameterDeclaration(parent)) {
+			return parent.getNameNode() !== identifier;
+		}
+		if (Node.isBindingElement(parent)) return false;
+		if (Node.isPropertyAccessExpression(parent) && parent.getNameNode() === identifier)
+			return false;
+		return true;
+	});
+}
+
+/** `for (const element of elements)` → `elements`. Also `const element = elements[i]`. */
+function aliasesOf(name: string, scope: Node): string[] {
+	const aliases: string[] = [];
+	for (const loop of scope.getDescendantsOfKind(SyntaxKind.ForOfStatement)) {
+		const declaration = loop.getInitializer();
+		if (!Node.isVariableDeclarationList(declaration)) continue;
+		if (declaration.getDeclarations().some((d) => d.getName() === name)) {
+			const source = rootIdentifier(loop.getExpression());
+			if (source) aliases.push(source);
+		}
+	}
+	for (const declaration of scope.getDescendantsOfKind(SyntaxKind.VariableDeclaration)) {
+		if (declaration.getName() !== name) continue;
+		const initializer = declaration.getInitializer();
+		if (initializer && Node.isElementAccessExpression(initializer)) {
+			const source = rootIdentifier(initializer.getExpression());
+			if (source) aliases.push(source);
+		}
+	}
+	return aliases;
+}
+
+/** Property names along an access chain, e.g. `item.json.data` → ['json', 'data']. */
+function targetPath(target: Node): string[] {
+	const names: string[] = [];
+	let current: Node = target;
+	while (true) {
+		if (Node.isPropertyAccessExpression(current)) {
+			names.unshift(current.getName());
+			current = current.getExpression();
+		} else if (Node.isElementAccessExpression(current)) {
+			current = current.getExpression();
+		} else if (Node.isNonNullExpression(current) || Node.isAsExpression(current)) {
+			current = current.getExpression();
+		} else if (Node.isParenthesizedExpression(current)) {
+			current = current.getExpression();
+		} else {
+			return names;
+		}
+	}
+}
+
+function rootIdentifier(node: Node | undefined): string | undefined {
+	return rootIdentifierNode(node)?.getText();
+}
+
+function rootIdentifierNode(node: Node | undefined): Node | undefined {
+	let current: Node | undefined = node;
+	while (current) {
+		if (Node.isIdentifier(current)) return current;
+		if (
+			Node.isPropertyAccessExpression(current) ||
+			Node.isElementAccessExpression(current) ||
+			Node.isNonNullExpression(current) ||
+			Node.isAsExpression(current) ||
+			Node.isParenthesizedExpression(current)
+		) {
+			current = current.getExpression();
+		} else {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+function enclosingScope(node: Node): Node {
+	const fn = node.getFirstAncestor(
+		(ancestor) =>
+			Node.isFunctionDeclaration(ancestor) ||
+			Node.isFunctionExpression(ancestor) ||
+			Node.isArrowFunction(ancestor) ||
+			Node.isMethodDeclaration(ancestor),
+	);
+	return fn ?? node.getSourceFile();
+}
+
+/** Nearest named function, method, or variable-assigned arrow that contains the node. */
+function enclosingFunctionName(node: Node): string {
+	let fn = enclosingScope(node);
+	while (!Node.isSourceFile(fn)) {
+		if (Node.isFunctionDeclaration(fn) || Node.isMethodDeclaration(fn)) {
+			return fn.getName() ?? '<anonymous>';
+		}
+		const parent = fn.getParent();
+		if (!parent) return '<module>';
+		if (Node.isVariableDeclaration(parent)) return parent.getName();
+		if (Node.isPropertyAssignment(parent)) return parent.getName();
+		fn = enclosingScope(parent);
+	}
+	return '<module>';
+}


### PR DESCRIPTION
## Summary

Adds the `derived-output-keys` code-health rule. It flags nodes-base code that writes an output key computed from data through a text transform (`snakeCase`, `replace`, `toLowerCase`, a template literal with prefix or suffix, local `normalize*`/`sanitize*` helpers) when the written object reaches node output: returned, pushed onto a returned array, set as `json`, or passed to `returnJsonArray`. Callback return values are followed into the receiving call, so `reduce` accumulators are judged by where the result goes.

Ignored: request bodies, binary property names, numeric indexes, `${key}` templates that only coerce, and keys produced by `deriveOutputKey` (#38393).

Enabled with the current 26 sites in the baseline. Only new sites fail.

Context: change-case v4 → v5 renamed Notion output keys (NODE-5421, #33965).

## How to test

```bash
pnpm --filter=@n8n/code-health test src/rules/derived-output-keys.rule.test.ts
pnpm --filter=@n8n/code-health check --rule=derived-output-keys --ignore-baseline   # lists every site
pnpm --filter=@n8n/code-health check                                                # exits 0
```

Known noise in the baseline: Baserow, TheHive and Microsoft Dynamics build request payloads through a helper's return value.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5421

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)