### PR TITLE
feat: Export structured agent artifacts in eval results

### DIFF
--- a/packages/@n8n/ai-utilities/src/index.ts
+++ b/packages/@n8n/ai-utilities/src/index.ts
@@ -4,7 +4,7 @@ export { AI_NODE_SDK_VERSION } from './ai-node-sdk-version';
 // Utils
 export { logWrapper } from './utils/log-wrapper';
 export { logAiEvent } from './utils/log-ai-event';
-export { redactSecrets } from './utils/redact-secrets';
+export { redactSecrets, sanitizeCredentialShapedValues } from './utils/redact-secrets';
 export { parseSSEStream } from './utils/sse';
 export {
 	validateEmbedQueryInput,

--- a/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
@@ -26,25 +26,31 @@ describe('agentHandler', () => {
 		]);
 	});
 
-	it('fetch() resolves the personal project, fetches config + skills, and sanitizes the config', async () => {
+	it('fetch() resolves the personal project and returns a redacted structured preview artifact', async () => {
 		const projectId = 'project-123';
-		// `unsupportedLegacyField` is a top-level key AgentJsonConfigSchema doesn't
-		// know about -- sanitizeAgentJsonConfig strips it. Cast is required because
-		// this deliberately doesn't conform to AgentJsonConfig (that's the point).
+		// Future fields must survive in the raw preview even when this checkout's
+		// AgentJsonConfig type does not know them yet.
 		const rawConfig = {
 			name: 'My Agent',
 			model: { provider: 'anthropic', model: 'claude' },
-			instructions: 'Be helpful.',
-			unsupportedLegacyField: 'should-be-stripped',
+			instructions: 'Use sk-abc123DEF456ghi789jkl012 when needed.',
+			futureDisplayMode: { density: 'compact' },
 		} as unknown as AgentJsonConfig;
-		const skills: Record<string, AgentSkill> = {
+		const skills = {
 			'skill-1': {
 				name: 'Skill One',
 				description: 'Does a thing',
-				instructions: 'Follow these steps to do the thing.',
-				references: [{ path: 'references/guide.md', content: 'Guide content here.' }],
+				instructions: 'Send api_key=skill-secret.',
+				references: [
+					{
+						path: 'references/guide.md',
+						content: 'Authorization: Bearer abcdef1234567890',
+						futureFormat: 'markdown-v2',
+					},
+				],
+				futurePolicy: { mode: 'strict' },
 			},
-		};
+		} as unknown as Record<string, AgentSkill>;
 
 		const getPersonalProjectId: Mock = vi.fn().mockResolvedValue(projectId);
 		const getAgentConfig: Mock = vi.fn().mockResolvedValue(rawConfig);
@@ -60,9 +66,26 @@ describe('agentHandler', () => {
 		expect(getPersonalProjectId).toHaveBeenCalled();
 		expect(getAgentConfig).toHaveBeenCalledWith(projectId, 'agent-1');
 		expect(getAgentSkills).toHaveBeenCalledWith(projectId, 'agent-1');
-		expect(result.skills).toBe(skills);
-		expect(result.config).toMatchObject({ name: 'My Agent', instructions: 'Be helpful.' });
-		expect(JSON.stringify(result.config)).not.toContain('should-be-stripped');
+		expect(result.agentId).toBe('agent-1');
+		expect(result.config).toMatchObject({
+			name: 'My Agent',
+			instructions: 'Use [REDACTED] when needed.',
+			futureDisplayMode: { density: 'compact' },
+		});
+		expect(result.skills['skill-1']).toMatchObject({
+			instructions: 'Send [REDACTED]',
+			references: [
+				{
+					path: 'references/guide.md',
+					content: 'Authorization: [REDACTED]',
+					futureFormat: 'markdown-v2',
+				},
+			],
+			futurePolicy: { mode: 'strict' },
+		});
+		const serialized = JSON.stringify(result);
+		expect(serialized).not.toContain('skill-secret');
+		expect(serialized).not.toContain('abcdef1234567890');
 	});
 
 	it('renderArtifact() surfaces skill instructions and reference content for the judge', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
@@ -1,5 +1,6 @@
+import * as aiUtilities from '@n8n/ai-utilities';
 import type { AgentJsonConfig, AgentSkill } from '@n8n/api-types';
-import type { Mock } from 'vitest';
+import { vi, type Mock } from 'vitest';
 
 import type { N8nClient } from '../clients/n8n-client';
 import {
@@ -36,9 +37,9 @@ describe('agentHandler', () => {
 		]);
 	});
 
-	it('fetch() resolves the personal project and returns a redacted structured preview artifact', async () => {
+	it('fetches a structured preview and renders a redacted judge context', async () => {
 		const projectId = 'project-123';
-		// Future fields must survive in the raw preview even when this checkout's
+		// Future fields must survive in the redacted preview even when this checkout's
 		// AgentJsonConfig type does not know them yet.
 		const rawConfig = {
 			...validConfig,
@@ -78,26 +79,65 @@ describe('agentHandler', () => {
 		expect(result.agentId).toBe('agent-1');
 		expect(result.config).toMatchObject({
 			name: 'My Agent',
-			instructions: 'Use [REDACTED] when needed.',
 			futureDisplayMode: { density: 'compact' },
 		});
 		expect(result.skills['skill-1']).toMatchObject({
-			instructions: 'Send [REDACTED]',
 			references: [
 				{
 					path: 'references/guide.md',
-					content: 'Authorization: [REDACTED]',
 					futureFormat: 'markdown-v2',
 				},
 			],
 			futurePolicy: { mode: 'strict' },
 		});
+
 		const serialized = JSON.stringify(result);
 		expect(serialized).not.toContain('skill-secret');
 		expect(serialized).not.toContain('abcdef1234567890');
+
+		const rendered = agentHandler.renderArtifact(result);
+		expect(rendered).toContain('Use [REDACTED] when needed.');
+		expect(rendered).toContain('Send [REDACTED]');
+		expect(rendered).toContain('Authorization: [REDACTED]');
+		expect(rendered).not.toContain('skill-secret');
+		expect(rendered).not.toContain('abcdef1234567890');
 	});
 
-	it('rejects an artifact when a configured skill body is missing', async () => {
+	it('keeps node-tool credential configs available to the judge and redacts them for export', async () => {
+		const config = {
+			...validConfig,
+			tools: [
+				{
+					type: 'node',
+					name: 'Read Gmail',
+					node: {
+						nodeType: 'n8n-nodes-base.gmail',
+						nodeTypeVersion: 2.1,
+						nodeParameters: { resource: 'message' },
+						credentials: {
+							gmailOAuth2: { id: 'credential-1', name: 'Support Inbox' },
+						},
+					},
+				},
+			],
+		};
+		const client = {
+			getPersonalProjectId: vi.fn().mockResolvedValue('project-123'),
+			getAgentConfig: vi.fn().mockResolvedValue(config),
+			getAgentSkills: vi.fn().mockResolvedValue({}),
+		} as unknown as N8nClient;
+
+		const artifact = await agentHandler.fetch({ type: 'agent', id: 'agent-1' }, client);
+		const sanitized = sanitizeAgentArtifact(artifact);
+
+		expect(sanitized).not.toBeNull();
+		expect(sanitized?.config).toMatchObject({
+			tools: [{ node: { credentials: '[REDACTED]' } }],
+		});
+		expect(agentHandler.renderArtifact(artifact)).toContain('"credentials": "[REDACTED]"');
+	});
+
+	it('keeps an artifact with a missing skill body available to the judge but rejects its export', async () => {
 		const projectId = 'project-123';
 		const getPersonalProjectId: Mock = vi.fn().mockResolvedValue(projectId);
 		const getAgentConfig: Mock = vi.fn().mockResolvedValue({
@@ -111,18 +151,27 @@ describe('agentHandler', () => {
 			getAgentSkills,
 		} as unknown as N8nClient;
 
-		await expect(agentHandler.fetch({ type: 'agent', id: 'agent-1' }, client)).rejects.toThrow(
-			'Agent agent-1 preview could not be sanitized',
-		);
+		const artifact = await agentHandler.fetch({ type: 'agent', id: 'agent-1' }, client);
+		const rendered = agentHandler.renderArtifact(artifact);
+
+		expect(rendered).toContain('missing-skill');
+		expect(rendered).toContain('(no skills authored)');
+		expect(sanitizeAgentArtifact(artifact)).toBeNull();
 	});
 
-	it('rejects malformed known config fields', () => {
-		expect(
-			sanitizeAgentArtifact({
-				config: { ...validConfig, model: { provider: 'anthropic' } },
-				skills: {},
-			}),
-		).toBeNull();
+	it('keeps malformed config available to the judge but rejects its export', async () => {
+		const client = {
+			getPersonalProjectId: vi.fn().mockResolvedValue('project-123'),
+			getAgentConfig: vi
+				.fn()
+				.mockResolvedValue({ ...validConfig, model: { provider: 'anthropic' } }),
+			getAgentSkills: vi.fn().mockResolvedValue({}),
+		} as unknown as N8nClient;
+
+		const artifact = await agentHandler.fetch({ type: 'agent', id: 'agent-1' }, client);
+
+		expect(agentHandler.renderArtifact(artifact)).toContain('"provider": "anthropic"');
+		expect(sanitizeAgentArtifact(artifact)).toBeNull();
 	});
 
 	it('rejects artifacts over the per-iteration UTF-8 byte cap', () => {
@@ -133,6 +182,29 @@ describe('agentHandler', () => {
 				skills: {},
 			}),
 		).toBeNull();
+	});
+
+	it('keeps artifacts over the export cap available to the judge', async () => {
+		const instructions = '界'.repeat(Math.ceil(AGENT_ARTIFACT_ITERATION_CAP_BYTES / 3));
+		const client = {
+			getPersonalProjectId: vi.fn().mockResolvedValue('project-123'),
+			getAgentConfig: vi.fn().mockResolvedValue({ ...validConfig, instructions }),
+			getAgentSkills: vi.fn().mockResolvedValue({}),
+		} as unknown as N8nClient;
+
+		const artifact = await agentHandler.fetch({ type: 'agent', id: 'agent-1' }, client);
+
+		expect(agentHandler.renderArtifact(artifact)).toContain(instructions);
+		expect(sanitizeAgentArtifact(artifact)).toBeNull();
+	});
+
+	it('surfaces unexpected sanitization errors', () => {
+		const error = new Error('sanitizer unavailable');
+		vi.spyOn(aiUtilities, 'sanitizeCredentialShapedValues').mockImplementationOnce(() => {
+			throw error;
+		});
+
+		expect(() => sanitizeAgentArtifact({ config: validConfig, skills: {} })).toThrow(error);
 	});
 
 	it('renderArtifact() surfaces skill instructions and reference content for the judge', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
@@ -2,8 +2,18 @@ import type { AgentJsonConfig, AgentSkill } from '@n8n/api-types';
 import type { Mock } from 'vitest';
 
 import type { N8nClient } from '../clients/n8n-client';
+import {
+	AGENT_ARTIFACT_ITERATION_CAP_BYTES,
+	sanitizeAgentArtifact,
+} from '../harness/artifacts/agent-artifact';
 import { agentHandler } from '../harness/artifacts/agent-handler';
 import type { ArtifactRef } from '../types';
+
+const validConfig = {
+	name: 'My Agent',
+	model: 'anthropic/claude-sonnet-4-5',
+	instructions: 'Triage requests.',
+};
 
 describe('agentHandler', () => {
 	it('declares its type and static execution mode', () => {
@@ -31,8 +41,7 @@ describe('agentHandler', () => {
 		// Future fields must survive in the raw preview even when this checkout's
 		// AgentJsonConfig type does not know them yet.
 		const rawConfig = {
-			name: 'My Agent',
-			model: { provider: 'anthropic', model: 'claude' },
+			...validConfig,
 			instructions: 'Use sk-abc123DEF456ghi789jkl012 when needed.',
 			futureDisplayMode: { density: 'compact' },
 		} as unknown as AgentJsonConfig;
@@ -92,8 +101,7 @@ describe('agentHandler', () => {
 		const projectId = 'project-123';
 		const getPersonalProjectId: Mock = vi.fn().mockResolvedValue(projectId);
 		const getAgentConfig: Mock = vi.fn().mockResolvedValue({
-			name: 'My Agent',
-			instructions: 'Triage requests.',
+			...validConfig,
 			skills: [{ type: 'skill', id: 'missing-skill' }],
 		});
 		const getAgentSkills: Mock = vi.fn().mockResolvedValue({});
@@ -106,6 +114,25 @@ describe('agentHandler', () => {
 		await expect(agentHandler.fetch({ type: 'agent', id: 'agent-1' }, client)).rejects.toThrow(
 			'Agent agent-1 preview could not be sanitized',
 		);
+	});
+
+	it('rejects malformed known config fields', () => {
+		expect(
+			sanitizeAgentArtifact({
+				config: { ...validConfig, model: { provider: 'anthropic' } },
+				skills: {},
+			}),
+		).toBeNull();
+	});
+
+	it('rejects artifacts over the per-iteration UTF-8 byte cap', () => {
+		const instructions = '界'.repeat(Math.ceil(AGENT_ARTIFACT_ITERATION_CAP_BYTES / 3));
+		expect(
+			sanitizeAgentArtifact({
+				config: { ...validConfig, instructions },
+				skills: {},
+			}),
+		).toBeNull();
 	});
 
 	it('renderArtifact() surfaces skill instructions and reference content for the judge', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/artifact-agent-handler.test.ts
@@ -88,6 +88,26 @@ describe('agentHandler', () => {
 		expect(serialized).not.toContain('abcdef1234567890');
 	});
 
+	it('rejects an artifact when a configured skill body is missing', async () => {
+		const projectId = 'project-123';
+		const getPersonalProjectId: Mock = vi.fn().mockResolvedValue(projectId);
+		const getAgentConfig: Mock = vi.fn().mockResolvedValue({
+			name: 'My Agent',
+			instructions: 'Triage requests.',
+			skills: [{ type: 'skill', id: 'missing-skill' }],
+		});
+		const getAgentSkills: Mock = vi.fn().mockResolvedValue({});
+		const client = {
+			getPersonalProjectId,
+			getAgentConfig,
+			getAgentSkills,
+		} as unknown as N8nClient;
+
+		await expect(agentHandler.fetch({ type: 'agent', id: 'agent-1' }, client)).rejects.toThrow(
+			'Agent agent-1 preview could not be sanitized',
+		);
+	});
+
 	it('renderArtifact() surfaces skill instructions and reference content for the judge', () => {
 		const output = agentHandler.renderArtifact({
 			config: { name: 'My Agent' },

--- a/packages/@n8n/instance-ai/evaluations/__tests__/artifact-context.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/artifact-context.test.ts
@@ -48,7 +48,11 @@ describe('resolveArtifactContext', () => {
 	it('fetches and renders a discovered agent ref into the Agent section', async () => {
 		const artifactRefs: ArtifactRef[] = [{ type: 'agent', id: 'agent-x' }];
 		const getPersonalProjectId: Mock = vi.fn().mockResolvedValue('project-1');
-		const getAgentConfig: Mock = vi.fn().mockResolvedValue({ name: 'My Agent' });
+		const getAgentConfig: Mock = vi.fn().mockResolvedValue({
+			name: 'My Agent',
+			model: 'anthropic/claude-sonnet-4-5',
+			instructions: 'Triage requests.',
+		});
 		const getAgentSkills: Mock = vi.fn().mockResolvedValue({});
 		const client = {
 			getPersonalProjectId,

--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
@@ -29,7 +29,7 @@ vi.mock('../harness/agent-execution', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('../harness/agent-execution')>();
 	return {
 		...actual,
-		fetchAgentScenarioContext: vi.fn().mockResolvedValue('AGENT CONTEXT'),
+		fetchAgentScenarioContext: vi.fn().mockResolvedValue({ rendered: 'AGENT CONTEXT' }),
 	};
 });
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
@@ -365,9 +365,16 @@ describe('createCasePipeline', () => {
 			artifactRefs: [{ type: 'agent', id: 'agent-1' }] as never,
 		});
 		const orchestrator = makeOrchestrator({ build, lane, buildDurationMs: 3 });
+		const agentArtifact = {
+			agentId: 'agent-1',
+			config: { name: 'Support agent' },
+			skills: {},
+		};
 		const pipeline = createCasePipeline(
 			makeDeps(orchestrator, {
-				agentContextByKey: new Map([['0:case-a', Promise.resolve('AGENT CONTEXT')]]),
+				agentContextByKey: new Map([
+					['0:case-a', Promise.resolve({ rendered: 'AGENT CONTEXT', artifact: agentArtifact })],
+				]),
 			}),
 		);
 
@@ -378,6 +385,7 @@ describe('createCasePipeline', () => {
 			passed: true,
 			agentId: 'agent-1',
 			agentContext: 'AGENT CONTEXT',
+			agentArtifact,
 			reasoning: 'agent did it',
 		});
 		expect(lane.tracedExecute).not.toHaveBeenCalled();

--- a/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
@@ -195,6 +195,38 @@ describe('createCasePipeline', () => {
 		expect(vi.mocked(lane.tracedExecute)).not.toHaveBeenCalled();
 	});
 
+	it('preserves agent metadata when a prior run failed', async () => {
+		const lane = makeLane();
+		const build = okBuild({
+			priorRunFailed: 'seedWf1: fetch failed',
+			artifactRefs: [{ type: 'agent', id: 'agent-1' }] as never,
+		});
+		const orchestrator = makeOrchestrator({ build, lane, buildDurationMs: 42 });
+		const agentArtifact = {
+			agentId: 'agent-1',
+			config: { name: 'Support agent' },
+			skills: {},
+		};
+		const pipeline = createCasePipeline(
+			makeDeps(orchestrator, {
+				agentContextByKey: new Map([
+					['0:case-a', Promise.resolve({ rendered: 'AGENT CONTEXT', artifact: agentArtifact })],
+				]),
+			}),
+		);
+
+		const output = await pipeline.runRow(rowInputs('happy-path'));
+
+		expect(output).toMatchObject({
+			incomplete: true,
+			failureCategory: 'framework_issue',
+			agentId: 'agent-1',
+			agentContext: 'AGENT CONTEXT',
+			agentArtifact,
+		});
+		expect(vi.mocked(lane.tracedExecute)).not.toHaveBeenCalled();
+	});
+
 	it('keeps everything when --keep-workflows is set', async () => {
 		const lane = makeLane();
 		vi.mocked(lane.tracedExecute).mockResolvedValue({

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import type { CheckOutcome } from '../binaryChecks/types';
-import { AGENT_ARTIFACT_RUN_CAP_BYTES } from '../harness/artifacts/agent-artifact';
+import { AGENT_ARTIFACT_CASE_CAP_BYTES } from '../harness/artifacts/agent-artifact';
 import { aggregateResults } from '../run/aggregator';
 import { writeEvalResults } from '../run/persist';
 import type {
@@ -341,15 +341,31 @@ describe('eval-results.json — dispatcher contract', () => {
 			skills: {},
 		});
 		const evaluation = aggregateResults(
-			[0, 1, 2].map((index) => [{ ...iteration1(), agentArtifact: largeArtifact(index) }]),
-			3,
+			[
+				...[0, 1, 2].map((index) => [{ ...iteration1(), agentArtifact: largeArtifact(index) }]),
+				[
+					{
+						...iteration1(),
+						agentArtifact: {
+							agentId: 'agent-3',
+							config: {
+								name: 'Small agent',
+								model: 'anthropic/claude-sonnet-4-5',
+								instructions: 'Keep the digest concise.',
+							},
+							skills: {},
+						},
+					},
+				],
+			],
+			4,
 		);
 		const dir = mkdtempSync(join(tmpdir(), 'eval-results-contract-'));
 		const { jsonPath } = writeEvalResults(
 			evaluation,
 			1234,
 			dir,
-			'exp-agent-artifact-run-cap',
+			'exp-agent-artifact-case-cap',
 			undefined,
 			undefined,
 			new Map([[testCase, 'daily-digest']]),
@@ -363,6 +379,7 @@ describe('eval-results.json — dispatcher contract', () => {
 		expect(tc.agentArtifactPerRun[0]).toMatchObject({ agentId: 'agent-0' });
 		expect(tc.agentArtifactPerRun[1]).toMatchObject({ agentId: 'agent-1' });
 		expect(tc.agentArtifactPerRun[2]).toBeNull();
+		expect(tc.agentArtifactPerRun[3]).toMatchObject({ agentId: 'agent-3' });
 
 		const formattedArtifactFields = JSON.stringify(
 			{ agentArtifactPerRun: tc.agentArtifactPerRun },
@@ -370,7 +387,7 @@ describe('eval-results.json — dispatcher contract', () => {
 			2,
 		);
 		expect(new TextEncoder().encode(formattedArtifactFields).byteLength).toBeLessThanOrEqual(
-			AGENT_ARTIFACT_RUN_CAP_BYTES,
+			AGENT_ARTIFACT_CASE_CAP_BYTES,
 		);
 	});
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -48,6 +48,7 @@ const agentArtifact = {
 	agentId: 'agent-1',
 	config: {
 		name: 'Digest agent',
+		model: 'anthropic/claude-sonnet-4-5',
 		instructions: 'Use sk-abc123DEF456ghi789jkl012 to call the provider.',
 		credentials: { slack: { id: 'credential-1' } },
 		futureDisplayMode: { density: 'compact' },
@@ -207,6 +208,7 @@ describe('eval-results.json — dispatcher contract', () => {
 			agentId: 'agent-1',
 			config: {
 				name: 'Digest agent',
+				model: 'anthropic/claude-sonnet-4-5',
 				instructions: 'Use [REDACTED] to call the provider.',
 				credentials: '[REDACTED]',
 				futureDisplayMode: { density: 'compact' },
@@ -325,6 +327,41 @@ describe('eval-results.json — dispatcher contract', () => {
 
 		expect(tc).not.toHaveProperty('agentArtifact');
 		expect(tc.agentArtifactPerRun).toEqual([null, null]);
+	});
+
+	it('preserves positions while dropping artifacts after the aggregate UTF-8 byte cap', () => {
+		const largeArtifact = (index: number) => ({
+			agentId: `agent-${index}`,
+			config: {
+				name: `Large agent ${index}`,
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: '界'.repeat(60_000),
+			},
+			skills: {},
+		});
+		const evaluation = aggregateResults(
+			[0, 1, 2].map((index) => [{ ...iteration1(), agentArtifact: largeArtifact(index) }]),
+			3,
+		);
+		const dir = mkdtempSync(join(tmpdir(), 'eval-results-contract-'));
+		const { jsonPath } = writeEvalResults(
+			evaluation,
+			1234,
+			dir,
+			'exp-agent-artifact-run-cap',
+			undefined,
+			undefined,
+			new Map([[testCase, 'daily-digest']]),
+			undefined,
+			undefined,
+		);
+		const report = jsonParse<DispatcherView>(readFileSync(jsonPath, 'utf8'));
+		const tc = report.testCases[0];
+
+		expect(tc.agentArtifact).toEqual(tc.agentArtifactPerRun[0]);
+		expect(tc.agentArtifactPerRun[0]).toMatchObject({ agentId: 'agent-0' });
+		expect(tc.agentArtifactPerRun[1]).toMatchObject({ agentId: 'agent-1' });
+		expect(tc.agentArtifactPerRun[2]).toBeNull();
 	});
 
 	it('serializes per-iteration `claude` build spend when a run recorded it', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -44,6 +44,24 @@ const passingCheck: CheckOutcome = {
 	status: 'pass',
 };
 
+const agentArtifact = {
+	agentId: 'agent-1',
+	config: {
+		name: 'Digest agent',
+		instructions: 'Use sk-abc123DEF456ghi789jkl012 to call the provider.',
+		credentials: { slack: { id: 'credential-1' } },
+		futureDisplayMode: { density: 'compact' },
+	},
+	skills: {
+		digest: {
+			name: 'Digest',
+			description: 'Summarize updates.',
+			instructions: 'Send with api_key=skill-secret.',
+			futurePolicy: { mode: 'strict' },
+		},
+	},
+};
+
 const transcript: TranscriptTurn[] = [
 	{
 		userMessage: 'send me a daily digest',
@@ -66,6 +84,7 @@ function iteration1(): WorkflowTestCaseResult {
 		threadId: '3f0c9a2e-8d41-4b77-9a10-1c2d3e4f5a6b',
 		transcript,
 		workflowChecks: [passingCheck],
+		agentArtifact,
 		workflowJson: {
 			id: 'wf-1',
 			name: 'Digest',
@@ -114,6 +133,8 @@ interface DispatcherView {
 	testCases: Array<{
 		buildSuccessCount: number;
 		workflowJson?: { id: string };
+		agentArtifact?: Record<string, unknown>;
+		agentArtifactPerRun: Array<Record<string, unknown> | null>;
 		totalRuns: number;
 		workflowChecksPerRun: Array<Record<string, string> | null>;
 		buildExpectations: Array<{
@@ -179,6 +200,27 @@ describe('eval-results.json — dispatcher contract', () => {
 		// Produced workflow rides along (first iteration's) — the dispatcher's
 		// Dockerfile patch greps for upstream support of this field and no-ops.
 		expect(tc.workflowJson).toMatchObject({ id: 'wf-1' });
+
+		// The first structured agent artifact supports legacy/single consumers.
+		// The positional array keeps one artifact or null per build iteration.
+		expect(tc.agentArtifact).toEqual({
+			agentId: 'agent-1',
+			config: {
+				name: 'Digest agent',
+				instructions: 'Use [REDACTED] to call the provider.',
+				credentials: '[REDACTED]',
+				futureDisplayMode: { density: 'compact' },
+			},
+			skills: {
+				digest: {
+					name: 'Digest',
+					description: 'Summarize updates.',
+					instructions: 'Send with [REDACTED]',
+					futurePolicy: { mode: 'strict' },
+				},
+			},
+		});
+		expect(tc.agentArtifactPerRun).toEqual([tc.agentArtifact, null]);
 
 		// Per-iteration build signals. Checks serialize as a name→status map (an
 		// iteration without checks serializes as null, not as a hole).
@@ -256,6 +298,33 @@ describe('eval-results.json — dispatcher contract', () => {
 		});
 		// A passing run carries no attribution at all — nobody owns a pass.
 		expect(sc.runs[0]).not.toHaveProperty('attribution');
+	});
+
+	it('keeps positional nulls when an agent build produced no preview artifact', () => {
+		const evaluation = aggregateResults(
+			[
+				[{ ...iteration1(), agentId: 'agent-1', agentArtifact: undefined }],
+				[{ ...iteration2(), agentId: 'agent-1' }],
+			],
+			2,
+		);
+		const dir = mkdtempSync(join(tmpdir(), 'eval-results-contract-'));
+		const { jsonPath } = writeEvalResults(
+			evaluation,
+			1234,
+			dir,
+			'exp-agent-artifact-missing',
+			undefined,
+			undefined,
+			new Map([[testCase, 'daily-digest']]),
+			undefined,
+			undefined,
+		);
+		const report = jsonParse<DispatcherView>(readFileSync(jsonPath, 'utf8'));
+		const tc = report.testCases[0];
+
+		expect(tc).not.toHaveProperty('agentArtifact');
+		expect(tc.agentArtifactPerRun).toEqual([null, null]);
 	});
 
 	it('serializes per-iteration `claude` build spend when a run recorded it', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import type { CheckOutcome } from '../binaryChecks/types';
+import { AGENT_ARTIFACT_RUN_CAP_BYTES } from '../harness/artifacts/agent-artifact';
 import { aggregateResults } from '../run/aggregator';
 import { writeEvalResults } from '../run/persist';
 import type {
@@ -329,7 +330,7 @@ describe('eval-results.json — dispatcher contract', () => {
 		expect(tc.agentArtifactPerRun).toEqual([null, null]);
 	});
 
-	it('preserves positions while dropping artifacts after the aggregate UTF-8 byte cap', () => {
+	it('caps the final formatted artifact fields while preserving positional artifacts', () => {
 		const largeArtifact = (index: number) => ({
 			agentId: `agent-${index}`,
 			config: {
@@ -358,10 +359,19 @@ describe('eval-results.json — dispatcher contract', () => {
 		const report = jsonParse<DispatcherView>(readFileSync(jsonPath, 'utf8'));
 		const tc = report.testCases[0];
 
-		expect(tc.agentArtifact).toEqual(tc.agentArtifactPerRun[0]);
+		expect(tc).not.toHaveProperty('agentArtifact');
 		expect(tc.agentArtifactPerRun[0]).toMatchObject({ agentId: 'agent-0' });
 		expect(tc.agentArtifactPerRun[1]).toMatchObject({ agentId: 'agent-1' });
 		expect(tc.agentArtifactPerRun[2]).toBeNull();
+
+		const formattedArtifactFields = JSON.stringify(
+			{ agentArtifactPerRun: tc.agentArtifactPerRun },
+			null,
+			2,
+		);
+		expect(new TextEncoder().encode(formattedArtifactFields).byteLength).toBeLessThanOrEqual(
+			AGENT_ARTIFACT_RUN_CAP_BYTES,
+		);
 	});
 
 	it('serializes per-iteration `claude` build spend when a run recorded it', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -81,7 +81,11 @@ describe('reshapeLangSmithRuns', () => {
 		const cases = [withFile('agent-case', [scenario('s1')])];
 		const agentArtifact = {
 			agentId: 'agent-1',
-			config: { name: 'Support agent' },
+			config: {
+				name: 'Support agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Triage requests.',
+			},
 			skills: {},
 		};
 		const rows = [

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -77,6 +77,37 @@ describe('reshapeLangSmithRuns', () => {
 		expect(tc.executionScenarioResults.map((r) => r.success)).toEqual([true, true]);
 	});
 
+	it('retains the structured agent artifact from a target row', () => {
+		const cases = [withFile('agent-case', [scenario('s1')])];
+		const agentArtifact = {
+			agentId: 'agent-1',
+			config: { name: 'Support agent' },
+			skills: {},
+		};
+		const rows = [
+			row(
+				{ testCaseFile: 'agent-case', scenarioName: 's1', _iteration: 0 },
+				{
+					buildSuccess: true,
+					passed: true,
+					score: 1,
+					reasoning: 'ok',
+					agentId: 'agent-1',
+					agentContext: 'AGENT CONTEXT',
+					agentArtifact,
+				},
+			),
+		];
+
+		const result = reshapeLangSmithRuns(rows, cases, 1, new Map(), new Map(), undefined);
+
+		expect(result[0][0]).toMatchObject({
+			agentId: 'agent-1',
+			agentArtifactContext: 'AGENT CONTEXT',
+			agentArtifact,
+		});
+	});
+
 	it('grades a build-only case (0 scenarios) from the sentinel row without a scenario unit', () => {
 		const cases = [withFile('build-only', [])];
 		const rows = [

--- a/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
@@ -22,6 +22,7 @@ import {
 import { verifyChecklist } from '../checklist/verifier';
 import type { N8nClient } from '../clients/n8n-client';
 import type {
+	AgentArtifact,
 	ArtifactRef,
 	BuildTrace,
 	ChecklistItem,
@@ -43,19 +44,24 @@ export function findAgentArtifactRef(
  * the workflow JSON block). Falls back to a marker string so a fetch failure
  * degrades verification instead of failing the scenario.
  */
+export interface AgentScenarioContext {
+	rendered: string;
+	artifact?: AgentArtifact;
+}
+
 export async function fetchAgentScenarioContext(
 	client: N8nClient,
 	ref: ArtifactRef,
 	logger: EvalLogger,
-): Promise<string> {
+): Promise<AgentScenarioContext> {
 	try {
-		const agentArtifact = await agentHandler.fetch(ref, client);
-		return agentHandler.renderArtifact(agentArtifact);
+		const artifact = await agentHandler.fetch(ref, client);
+		return { rendered: agentHandler.renderArtifact(artifact), artifact };
 	} catch (error: unknown) {
 		logger.warn(
 			`  Agent config fetch failed — verifying scenarios without it: ${error instanceof Error ? error.message : String(error)}`,
 		);
-		return '(agent configuration could not be fetched)';
+		return { rendered: '(agent configuration could not be fetched)' };
 	}
 }
 

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
@@ -6,13 +6,14 @@ import {
 	sanitizeAgentSkillBodies,
 } from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
+import { UnexpectedError } from 'n8n-workflow';
 
 import type { AgentArtifact } from '../../types';
 
 const utf8Encoder = new TextEncoder();
 
 export const AGENT_ARTIFACT_ITERATION_CAP_BYTES = 262_144;
-export const AGENT_ARTIFACT_RUN_CAP_BYTES = 524_288;
+export const AGENT_ARTIFACT_CASE_CAP_BYTES = 524_288;
 
 function agentArtifactUtf8Bytes(artifact: AgentArtifact): number {
 	return utf8Encoder.encode(JSON.stringify(artifact)).byteLength;
@@ -20,12 +21,45 @@ function agentArtifactUtf8Bytes(artifact: AgentArtifact): number {
 
 /**
  * Validate the known skill contract without projecting away fields introduced
- * by a newer server. The original value is retained for the raw preview.
+ * by a newer server. The original value is retained for the preview.
  */
 function isCompatibleAgentSkill(value: unknown): boolean {
 	const sanitized = sanitizeAgentSkillBodies({ skill: value });
 	if (!isRecord(sanitized)) return false;
 	return agentSkillSchema.safeParse(sanitized.skill).success;
+}
+
+/** The redactor must preserve the artifact structure, but not config validity. */
+function isRedactedAgentArtifact(value: unknown): value is AgentArtifact {
+	if (!isRecord(value)) return false;
+	const { config, skills, agentId } = value;
+	if (!isRecord(config) || !isRecord(skills)) return false;
+	if (agentId !== undefined && typeof agentId !== 'string') return false;
+	return Object.values(skills).every(isCompatibleAgentSkill);
+}
+
+function isUnknownArray(value: unknown): value is unknown[] {
+	return Array.isArray(value);
+}
+
+/** Restore a schema-compatible container after credential redaction replaces it with a sentinel. */
+function normalizeRedactedNodeCredentials(
+	config: Record<string, unknown>,
+): Record<string, unknown> {
+	if (!isUnknownArray(config.tools)) return config;
+
+	const tools = config.tools.map((tool) => {
+		if (
+			!isRecord(tool) ||
+			tool.type !== 'node' ||
+			!isRecord(tool.node) ||
+			tool.node.credentials !== '[REDACTED]'
+		) {
+			return tool;
+		}
+		return { ...tool, node: { ...tool.node, credentials: {} } };
+	});
+	return { ...config, tools };
 }
 
 /** Runtime boundary for structured artifacts carried through eval traces. */
@@ -34,7 +68,10 @@ export function isAgentArtifact(value: unknown): value is AgentArtifact {
 	const { config, skills, agentId } = value;
 	if (!isRecord(config) || !isRecord(skills)) return false;
 	if (agentId !== undefined && typeof agentId !== 'string') return false;
-	if (!AgentJsonConfigSchema.safeParse(sanitizeAgentJsonConfig(config)).success) return false;
+	const configForValidation = normalizeRedactedNodeCredentials(config);
+	if (!AgentJsonConfigSchema.safeParse(sanitizeAgentJsonConfig(configForValidation)).success) {
+		return false;
+	}
 	const skillRefs = config.skills;
 	if (
 		skillRefs !== undefined &&
@@ -52,13 +89,18 @@ export function isAgentArtifact(value: unknown): value is AgentArtifact {
 	return Object.values(skills).every(isCompatibleAgentSkill);
 }
 
-/** Redact the full forward-compatible value, then validate its known contract. */
-export function sanitizeAgentArtifact(value: unknown): AgentArtifact | null {
-	try {
-		const redacted = sanitizeCredentialShapedValues(value);
-		if (!isAgentArtifact(redacted)) return null;
-		return agentArtifactUtf8Bytes(redacted) <= AGENT_ARTIFACT_ITERATION_CAP_BYTES ? redacted : null;
-	} catch {
-		return null;
+/** Redact an artifact for the judge without applying export-only validation or size limits. */
+export function redactAgentArtifact(value: AgentArtifact): AgentArtifact {
+	const redacted = sanitizeCredentialShapedValues(value);
+	if (!isRedactedAgentArtifact(redacted)) {
+		throw new UnexpectedError('Agent artifact redaction changed the artifact structure');
 	}
+	return redacted;
+}
+
+/** Validate the artifact, then apply idempotent redaction and the per-iteration export cap. */
+export function sanitizeAgentArtifact(value: unknown): AgentArtifact | null {
+	if (!isAgentArtifact(value)) return null;
+	const redacted = redactAgentArtifact(value);
+	return agentArtifactUtf8Bytes(redacted) <= AGENT_ARTIFACT_ITERATION_CAP_BYTES ? redacted : null;
 }

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
@@ -14,7 +14,7 @@ const utf8Encoder = new TextEncoder();
 export const AGENT_ARTIFACT_ITERATION_CAP_BYTES = 262_144;
 export const AGENT_ARTIFACT_RUN_CAP_BYTES = 524_288;
 
-export function agentArtifactUtf8Bytes(artifact: AgentArtifact): number {
+function agentArtifactUtf8Bytes(artifact: AgentArtifact): number {
 	return utf8Encoder.encode(JSON.stringify(artifact)).byteLength;
 }
 

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
@@ -1,8 +1,22 @@
 import { sanitizeCredentialShapedValues } from '@n8n/ai-utilities';
-import { agentSkillSchema, sanitizeAgentSkillBodies } from '@n8n/api-types';
+import {
+	AgentJsonConfigSchema,
+	agentSkillSchema,
+	sanitizeAgentJsonConfig,
+	sanitizeAgentSkillBodies,
+} from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
 
 import type { AgentArtifact } from '../../types';
+
+const utf8Encoder = new TextEncoder();
+
+export const AGENT_ARTIFACT_ITERATION_CAP_BYTES = 262_144;
+export const AGENT_ARTIFACT_RUN_CAP_BYTES = 524_288;
+
+export function agentArtifactUtf8Bytes(artifact: AgentArtifact): number {
+	return utf8Encoder.encode(JSON.stringify(artifact)).byteLength;
+}
 
 /**
  * Validate the known skill contract without projecting away fields introduced
@@ -20,6 +34,7 @@ export function isAgentArtifact(value: unknown): value is AgentArtifact {
 	const { config, skills, agentId } = value;
 	if (!isRecord(config) || !isRecord(skills)) return false;
 	if (agentId !== undefined && typeof agentId !== 'string') return false;
+	if (!AgentJsonConfigSchema.safeParse(sanitizeAgentJsonConfig(config)).success) return false;
 	const skillRefs = config.skills;
 	if (
 		skillRefs !== undefined &&
@@ -41,7 +56,8 @@ export function isAgentArtifact(value: unknown): value is AgentArtifact {
 export function sanitizeAgentArtifact(value: unknown): AgentArtifact | null {
 	try {
 		const redacted = sanitizeCredentialShapedValues(value);
-		return isAgentArtifact(redacted) ? redacted : null;
+		if (!isAgentArtifact(redacted)) return null;
+		return agentArtifactUtf8Bytes(redacted) <= AGENT_ARTIFACT_ITERATION_CAP_BYTES ? redacted : null;
 	} catch {
 		return null;
 	}

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
@@ -16,9 +16,25 @@ function isCompatibleAgentSkill(value: unknown): boolean {
 
 /** Runtime boundary for structured artifacts carried through eval traces. */
 export function isAgentArtifact(value: unknown): value is AgentArtifact {
-	if (!isRecord(value) || !isRecord(value.config) || !isRecord(value.skills)) return false;
-	if (value.agentId !== undefined && typeof value.agentId !== 'string') return false;
-	return Object.values(value.skills).every(isCompatibleAgentSkill);
+	if (!isRecord(value)) return false;
+	const { config, skills, agentId } = value;
+	if (!isRecord(config) || !isRecord(skills)) return false;
+	if (agentId !== undefined && typeof agentId !== 'string') return false;
+	const skillRefs = config.skills;
+	if (
+		skillRefs !== undefined &&
+		(!Array.isArray(skillRefs) ||
+			skillRefs.some(
+				(ref) =>
+					!isRecord(ref) ||
+					ref.type !== 'skill' ||
+					typeof ref.id !== 'string' ||
+					!Object.hasOwn(skills, ref.id),
+			))
+	) {
+		return false;
+	}
+	return Object.values(skills).every(isCompatibleAgentSkill);
 }
 
 /** Redact the full forward-compatible value, then validate its known contract. */

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-artifact.ts
@@ -1,0 +1,32 @@
+import { sanitizeCredentialShapedValues } from '@n8n/ai-utilities';
+import { agentSkillSchema, sanitizeAgentSkillBodies } from '@n8n/api-types';
+import { isRecord } from '@n8n/utils/is-record';
+
+import type { AgentArtifact } from '../../types';
+
+/**
+ * Validate the known skill contract without projecting away fields introduced
+ * by a newer server. The original value is retained for the raw preview.
+ */
+function isCompatibleAgentSkill(value: unknown): boolean {
+	const sanitized = sanitizeAgentSkillBodies({ skill: value });
+	if (!isRecord(sanitized)) return false;
+	return agentSkillSchema.safeParse(sanitized.skill).success;
+}
+
+/** Runtime boundary for structured artifacts carried through eval traces. */
+export function isAgentArtifact(value: unknown): value is AgentArtifact {
+	if (!isRecord(value) || !isRecord(value.config) || !isRecord(value.skills)) return false;
+	if (value.agentId !== undefined && typeof value.agentId !== 'string') return false;
+	return Object.values(value.skills).every(isCompatibleAgentSkill);
+}
+
+/** Redact the full forward-compatible value, then validate its known contract. */
+export function sanitizeAgentArtifact(value: unknown): AgentArtifact | null {
+	try {
+		const redacted = sanitizeCredentialShapedValues(value);
+		return isAgentArtifact(redacted) ? redacted : null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-handler.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-handler.ts
@@ -4,7 +4,7 @@
 // builder authored, so the shared assertion judge can grade both.
 // ---------------------------------------------------------------------------
 
-import { sanitizeAgentArtifact } from './agent-artifact';
+import { redactAgentArtifact } from './agent-artifact';
 import { renderAgentArtifact } from './render-agent';
 import type { AgentArtifact, ArtifactHandler } from './types';
 
@@ -23,11 +23,9 @@ export const agentHandler: ArtifactHandler<AgentArtifact> = {
 			client.getAgentConfig(projectId, ref.id),
 			client.getAgentSkills(projectId, ref.id),
 		]);
-		const artifact = sanitizeAgentArtifact({ agentId: ref.id, config, skills });
-		if (!artifact) throw new Error(`Agent ${ref.id} preview could not be sanitized`);
-		return artifact;
+		return redactAgentArtifact({ agentId: ref.id, config, skills });
 	},
 	renderArtifact(artifact) {
-		return renderAgentArtifact(artifact);
+		return renderAgentArtifact(redactAgentArtifact(artifact));
 	},
 };

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-handler.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-handler.ts
@@ -4,8 +4,7 @@
 // builder authored, so the shared assertion judge can grade both.
 // ---------------------------------------------------------------------------
 
-import { sanitizeAgentJsonConfig } from '@n8n/api-types';
-
+import { sanitizeAgentArtifact } from './agent-artifact';
 import { renderAgentArtifact } from './render-agent';
 import type { AgentArtifact, ArtifactHandler } from './types';
 
@@ -24,7 +23,9 @@ export const agentHandler: ArtifactHandler<AgentArtifact> = {
 			client.getAgentConfig(projectId, ref.id),
 			client.getAgentSkills(projectId, ref.id),
 		]);
-		return { config: sanitizeAgentJsonConfig(config), skills }; // sanitize at fetch -> no secrets retained
+		const artifact = sanitizeAgentArtifact({ agentId: ref.id, config, skills });
+		if (!artifact) throw new Error(`Agent ${ref.id} preview could not be sanitized`);
+		return artifact;
 	},
 	renderArtifact(artifact) {
 		return renderAgentArtifact(artifact);

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/types.ts
@@ -13,7 +13,7 @@
 // Composite artifact shapes live here; ArtifactVerdict lives in ../../types to avoid a cycle.
 // ---------------------------------------------------------------------------
 
-import type { AgentSkill, EvaluationConfigDto, InstanceAiMessage } from '@n8n/api-types';
+import type { EvaluationConfigDto, InstanceAiMessage } from '@n8n/api-types';
 
 import type { BinaryCheck } from '../../binaryChecks/types';
 import type {
@@ -21,9 +21,9 @@ import type {
 	DataTableRowsResponse,
 	N8nClient,
 } from '../../clients/n8n-client';
-import type { ArtifactRef, ArtifactType } from '../../types';
+import type { AgentArtifact, ArtifactRef, ArtifactType } from '../../types';
 
-export type { ArtifactRef };
+export type { AgentArtifact, ArtifactRef };
 
 /**
  * Signals available to a handler's discover(). Non-workflow handlers read the
@@ -53,12 +53,6 @@ export interface ArtifactHandler<TArtifact = unknown> {
 	renderArtifact(artifact: TArtifact): string;
 	/** Type-scoped deterministic checks. Optional forward hook — unset for types that ship none. */
 	binaryChecks?: BinaryCheck[];
-}
-
-/** Agent artifact: sanitized JSON config (secrets stripped → typed `unknown`) + full skills map. */
-export interface AgentArtifact {
-	config: unknown;
-	skills: Record<string, AgentSkill>;
 }
 
 /**

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -28,6 +28,7 @@ import { N8nClient } from '../clients/n8n-client';
 import {
 	fetchAgentScenarioContext,
 	findAgentArtifactRef,
+	type AgentScenarioContext,
 	type executeAgentScenario,
 } from '../harness/agent-execution';
 import { resolveArtifactContext } from '../harness/artifacts/artifact-context';
@@ -294,7 +295,7 @@ export interface BuildOrchestratorDeps {
 	transcriptByThreadId: Map<string, TranscriptTurn[]>;
 	buildExpectationsByKey: Map<string, Promise<BuildExpectationResult[]>>;
 	runDebugByThreadId: Map<string, Promise<InstanceAiRunDebugResponse[]>>;
-	agentContextByKey: Map<string, Promise<string>>;
+	agentContextByKey: Map<string, Promise<AgentScenarioContext>>;
 	/** Injectable delay for the provider-outage retry backoff — tests pass a no-op. */
 	sleep?: (ms: number) => Promise<void>;
 }

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -208,8 +208,12 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 		// that succeeded: `buildFailedOnInfra` returns false there, so the case would
 		// otherwise be scored as an agent failure on a premise that never existed.
 		if (build.priorRunFailed) {
+			const capturedAgent = agentRef ? await agentContextByKey.get(cacheKey) : undefined;
 			return await attachExpectations({
 				buildSuccess: build.success,
+				...(agentRef ? { agentId: agentRef.id } : {}),
+				...(capturedAgent ? { agentContext: capturedAgent.rendered } : {}),
+				...(capturedAgent?.artifact ? { agentArtifact: capturedAgent.artifact } : {}),
 				passed: false,
 				// Not graded rather than failed — the same treatment an ungraded expectation
 				// gets, so this stays out of the pass rate instead of landing in the

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -15,7 +15,7 @@ import type { InstanceAiRunDebugResponse } from '@n8n/api-types';
 import type { BuildOrchestrator } from './build-orchestrator';
 import { sentinelOutcomeFromVerdicts, type TargetOutput } from './reshape';
 import type { CliArgs } from '../cli/args';
-import { findAgentArtifactRef } from '../harness/agent-execution';
+import { findAgentArtifactRef, type AgentScenarioContext } from '../harness/agent-execution';
 import { buildFailedOnInfra } from '../harness/build-workflow';
 import { cleanupBuild, effectiveTimeoutMs } from '../harness/cleanup';
 import type { EvalLogger } from '../harness/logger';
@@ -45,7 +45,7 @@ export interface CasePipelineDeps {
 	orchestrator: BuildOrchestrator;
 	// Side-band state written at build time (by the orchestrator), read per row.
 	buildExpectationsByKey: Map<string, Promise<BuildExpectationResult[]>>;
-	agentContextByKey: Map<string, Promise<string>>;
+	agentContextByKey: Map<string, Promise<AgentScenarioContext>>;
 	runDebugByThreadId: Map<string, Promise<InstanceAiRunDebugResponse[]>>;
 }
 
@@ -239,11 +239,13 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 		if (inputs.scenarioName === BUILD_ONLY_SCENARIO_NAME && (build.success || agentRunnable)) {
 			const verdicts = await verdictsPromise;
 			const outcome = sentinelOutcomeFromVerdicts(verdicts);
+			const capturedAgent = agentRef ? await agentContextByKey.get(cacheKey) : undefined;
 			return {
 				buildSuccess: true,
 				workflowId: build.workflowId,
 				...(agentRef ? { agentId: agentRef.id } : {}),
-				...(agentRef ? { agentContext: await agentContextByKey.get(cacheKey) } : {}),
+				...(capturedAgent ? { agentContext: capturedAgent.rendered } : {}),
+				...(capturedAgent?.artifact ? { agentArtifact: capturedAgent.artifact } : {}),
 				passed: outcome.passed,
 				score: outcome.score,
 				reasoning: outcome.reasoning,
@@ -306,8 +308,11 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 					?.executionScenarios?.find((s) => s.name === scenario.name)?.seedDataTables,
 			);
 			const agentExecStart = Date.now();
-			const agentContext =
-				(await agentContextByKey.get(cacheKey)) ?? '(agent configuration could not be fetched)';
+			const capturedAgent = await agentContextByKey.get(cacheKey);
+			const agentContext = capturedAgent?.rendered ?? '(agent configuration could not be fetched)';
+			const agentArtifactFields = capturedAgent?.artifact
+				? { agentArtifact: capturedAgent.artifact }
+				: {};
 			let agentResult;
 			for (let attempt = 1; ; attempt++) {
 				try {
@@ -337,6 +342,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 						buildSuccess: true,
 						agentId: agentRef.id,
 						agentContext,
+						...agentArtifactFields,
 						passed: false,
 						score: 0,
 						reasoning: `Agent scenario execution error: ${errorMessage}`,
@@ -361,6 +367,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				buildSuccess: true,
 				agentId: agentRef.id,
 				agentContext,
+				...agentArtifactFields,
 				agentEvalResult: agentResult.agentEvalResult,
 				passed: agentResult.success,
 				score: agentResult.score,

--- a/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
@@ -23,7 +23,7 @@ import { createCasePipeline, type CasePipeline } from './case-pipeline';
 import { LaneAllocator } from './lane-allocator';
 import type { CliArgs } from '../cli/args';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
-import { executeAgentScenario } from '../harness/agent-execution';
+import { executeAgentScenario, type AgentScenarioContext } from '../harness/agent-execution';
 import {
 	buildWorkflow,
 	scrubLocalSecretsFromBuild,
@@ -235,7 +235,7 @@ export function createEvalSession(config: EvalSessionConfig): EvalSession {
 
 	// Agent config + skills, fetched once per build and shared by every
 	// scenario row of the case (the agent analog of the cached workflow JSON).
-	const agentContextByKey = new Map<string, Promise<string>>();
+	const agentContextByKey = new Map<string, Promise<AgentScenarioContext>>();
 
 	const orchestrator = createBuildOrchestrator({
 		args,

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -19,7 +19,7 @@ import { formatComparisonMarkdown, type RerunHint } from '../comparison/format';
 import { evaluateGate, isGatedTier, type GateResult } from '../comparison/gate';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
 import {
-	AGENT_ARTIFACT_RUN_CAP_BYTES,
+	AGENT_ARTIFACT_CASE_CAP_BYTES,
 	sanitizeAgentArtifact,
 } from '../harness/artifacts/agent-artifact';
 import type { EvalLogger } from '../harness/logger';
@@ -382,17 +382,16 @@ function serializeAgentArtifacts(runs: WorkflowTestCaseResult[]): {
 	);
 	if (!agentAnchored) return {};
 
-	let overflowed = false;
 	const agentArtifactPerRun = runs.map((): AgentArtifact | null => null);
 	for (const [index, run] of runs.entries()) {
-		if (overflowed) continue;
 		const artifact = sanitizeAgentArtifact(run.agentArtifact);
 		if (!artifact) continue;
 
 		agentArtifactPerRun[index] = artifact;
-		if (formattedAgentArtifactFieldsBytes({ agentArtifactPerRun }) > AGENT_ARTIFACT_RUN_CAP_BYTES) {
+		if (
+			formattedAgentArtifactFieldsBytes({ agentArtifactPerRun }) > AGENT_ARTIFACT_CASE_CAP_BYTES
+		) {
 			agentArtifactPerRun[index] = null;
-			overflowed = true;
 		}
 	}
 
@@ -400,7 +399,7 @@ function serializeAgentArtifacts(runs: WorkflowTestCaseResult[]): {
 	if (!agentArtifact) return { agentArtifactPerRun };
 
 	const withCompatibility = { agentArtifact, agentArtifactPerRun };
-	return formattedAgentArtifactFieldsBytes(withCompatibility) <= AGENT_ARTIFACT_RUN_CAP_BYTES
+	return formattedAgentArtifactFieldsBytes(withCompatibility) <= AGENT_ARTIFACT_CASE_CAP_BYTES
 		? withCompatibility
 		: { agentArtifactPerRun };
 }

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -18,10 +18,12 @@ import type { ComparisonOutcome, ComparisonResult } from '../comparison/compare'
 import { formatComparisonMarkdown, type RerunHint } from '../comparison/format';
 import { evaluateGate, isGatedTier, type GateResult } from '../comparison/gate';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import { sanitizeAgentArtifact } from '../harness/artifacts/agent-artifact';
 import type { EvalLogger } from '../harness/logger';
 import { extractErrorMessage } from '../harness/transient-error';
 import { rollupCaseVerification } from '../summary';
 import type {
+	AgentArtifact,
 	BuildExpectationResult,
 	MultiRunEvaluation,
 	WorkflowTestCase,
@@ -347,6 +349,23 @@ export async function runEvalAndPersist(
 	}
 }
 
+function serializeAgentArtifacts(runs: WorkflowTestCaseResult[]): {
+	agentArtifact?: AgentArtifact;
+	agentArtifactPerRun?: Array<AgentArtifact | null>;
+} {
+	const agentAnchored = runs.some(
+		(run) => run.agentId !== undefined || run.agentArtifact !== undefined,
+	);
+	if (!agentAnchored) return {};
+
+	const agentArtifactPerRun = runs.map((run) => sanitizeAgentArtifact(run.agentArtifact));
+	const agentArtifact = agentArtifactPerRun.find((artifact) => artifact !== null);
+	return {
+		...(agentArtifact ? { agentArtifact } : {}),
+		agentArtifactPerRun,
+	};
+}
+
 export function writeEvalResults(
 	evaluation: MultiRunEvaluation,
 	duration: number,
@@ -416,6 +435,9 @@ export function writeEvalResults(
 			// it (its Dockerfile used to sed-inject this exact field; keep the
 			// expression verbatim so that patch detects upstream support and no-ops).
 			workflowJson: tc.runs[0]?.workflowJson,
+			// Keep the single-artifact field for one-run and legacy consumers.
+			// The positional array preserves missing artifacts between iterations.
+			...serializeAgentArtifacts(tc.runs),
 			totalRuns,
 			workflowChecksPerRun: tc.runs.map((run) =>
 				run.workflowChecks ? statusMap(run.workflowChecks) : null,

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -18,7 +18,11 @@ import type { ComparisonOutcome, ComparisonResult } from '../comparison/compare'
 import { formatComparisonMarkdown, type RerunHint } from '../comparison/format';
 import { evaluateGate, isGatedTier, type GateResult } from '../comparison/gate';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
-import { sanitizeAgentArtifact } from '../harness/artifacts/agent-artifact';
+import {
+	AGENT_ARTIFACT_RUN_CAP_BYTES,
+	agentArtifactUtf8Bytes,
+	sanitizeAgentArtifact,
+} from '../harness/artifacts/agent-artifact';
 import type { EvalLogger } from '../harness/logger';
 import { extractErrorMessage } from '../harness/transient-error';
 import { rollupCaseVerification } from '../summary';
@@ -358,7 +362,20 @@ function serializeAgentArtifacts(runs: WorkflowTestCaseResult[]): {
 	);
 	if (!agentAnchored) return {};
 
-	const agentArtifactPerRun = runs.map((run) => sanitizeAgentArtifact(run.agentArtifact));
+	let cumulativeBytes = 0;
+	let overflowed = false;
+	const agentArtifactPerRun = runs.map((run) => {
+		const artifact = sanitizeAgentArtifact(run.agentArtifact);
+		if (!artifact) return null;
+
+		const artifactBytes = agentArtifactUtf8Bytes(artifact);
+		if (overflowed || cumulativeBytes + artifactBytes > AGENT_ARTIFACT_RUN_CAP_BYTES) {
+			overflowed = true;
+			return null;
+		}
+		cumulativeBytes += artifactBytes;
+		return artifact;
+	});
 	const agentArtifact = agentArtifactPerRun.find((artifact) => artifact !== null);
 	return {
 		...(agentArtifact ? { agentArtifact } : {}),

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -20,7 +20,6 @@ import { evaluateGate, isGatedTier, type GateResult } from '../comparison/gate';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
 import {
 	AGENT_ARTIFACT_RUN_CAP_BYTES,
-	agentArtifactUtf8Bytes,
 	sanitizeAgentArtifact,
 } from '../harness/artifacts/agent-artifact';
 import type { EvalLogger } from '../harness/logger';
@@ -353,6 +352,27 @@ export async function runEvalAndPersist(
 	}
 }
 
+type SerializedAgentArtifacts = {
+	agentArtifact?: AgentArtifact;
+	agentArtifactPerRun: Array<AgentArtifact | null>;
+};
+
+const artifactPayloadEncoder = new TextEncoder();
+const artifactPayloadBaselineBytes = artifactPayloadEncoder.encode(
+	JSON.stringify({ testCases: [{ before: null, after: null }] }, null, 2),
+).byteLength;
+
+/** Measure these fields with the same indentation they receive in eval-results.json. */
+function formattedAgentArtifactFieldsBytes(fields: SerializedAgentArtifacts): number {
+	const embeddedFields = {
+		testCases: [{ before: null, ...fields, after: null }],
+	};
+	return (
+		artifactPayloadEncoder.encode(JSON.stringify(embeddedFields, null, 2)).byteLength -
+		artifactPayloadBaselineBytes
+	);
+}
+
 function serializeAgentArtifacts(runs: WorkflowTestCaseResult[]): {
 	agentArtifact?: AgentArtifact;
 	agentArtifactPerRun?: Array<AgentArtifact | null>;
@@ -362,25 +382,27 @@ function serializeAgentArtifacts(runs: WorkflowTestCaseResult[]): {
 	);
 	if (!agentAnchored) return {};
 
-	let cumulativeBytes = 0;
 	let overflowed = false;
-	const agentArtifactPerRun = runs.map((run) => {
+	const agentArtifactPerRun = runs.map((): AgentArtifact | null => null);
+	for (const [index, run] of runs.entries()) {
+		if (overflowed) continue;
 		const artifact = sanitizeAgentArtifact(run.agentArtifact);
-		if (!artifact) return null;
+		if (!artifact) continue;
 
-		const artifactBytes = agentArtifactUtf8Bytes(artifact);
-		if (overflowed || cumulativeBytes + artifactBytes > AGENT_ARTIFACT_RUN_CAP_BYTES) {
+		agentArtifactPerRun[index] = artifact;
+		if (formattedAgentArtifactFieldsBytes({ agentArtifactPerRun }) > AGENT_ARTIFACT_RUN_CAP_BYTES) {
+			agentArtifactPerRun[index] = null;
 			overflowed = true;
-			return null;
 		}
-		cumulativeBytes += artifactBytes;
-		return artifact;
-	});
+	}
+
 	const agentArtifact = agentArtifactPerRun.find((artifact) => artifact !== null);
-	return {
-		...(agentArtifact ? { agentArtifact } : {}),
-		agentArtifactPerRun,
-	};
+	if (!agentArtifact) return { agentArtifactPerRun };
+
+	const withCompatibility = { agentArtifact, agentArtifactPerRun };
+	return formattedAgentArtifactFieldsBytes(withCompatibility) <= AGENT_ARTIFACT_RUN_CAP_BYTES
+		? withCompatibility
+		: { agentArtifactPerRun };
 }
 
 export function writeEvalResults(

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -19,9 +19,11 @@ import { z } from 'zod';
 import { CHECK_DIMENSIONS, type CheckOutcome } from '../binaryChecks/types';
 import type { WorkflowResponse } from '../clients/n8n-client';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import { isAgentArtifact } from '../harness/artifacts/agent-artifact';
 import { EVAL_ATTRIBUTIONS, type EvalAttribution } from '../harness/attribution';
 import { BUILD_ONLY_SCENARIO_NAME } from '../langsmith/dataset-sync';
 import type {
+	AgentArtifact,
 	BuildTrace,
 	BuildExpectationResult,
 	ExecutionScenarioResult,
@@ -76,6 +78,8 @@ const targetOutputSchema = z.object({
 	agentEvalResult: z.unknown().optional(),
 	/** Rendered agent config + skills — attached to every agent row, deduped on reshape (first write wins). */
 	agentContext: z.string().optional(),
+	/** Structured, redacted agent preview artifact. */
+	agentArtifact: z.unknown().optional(),
 	/** Only set on the scenario that initiated the build. */
 	buildDurationMs: z.number().optional(),
 	/** `claude` build spend in USD (--build-via-mcp only). Repeats on every row
@@ -96,10 +100,11 @@ const targetOutputSchema = z.object({
 
 export type TargetOutput = Omit<
 	z.infer<typeof targetOutputSchema>,
-	'evalResult' | 'agentEvalResult' | 'workflowJson' | 'buildTrace'
+	'evalResult' | 'agentEvalResult' | 'agentArtifact' | 'workflowJson' | 'buildTrace'
 > & {
 	evalResult?: InstanceAiEvalExecutionResult;
 	agentEvalResult?: InstanceAiEvalAgentExecutionResult;
+	agentArtifact?: AgentArtifact;
 	workflowJson?: WorkflowResponse;
 	buildTrace?: BuildTrace;
 };
@@ -161,6 +166,9 @@ export function parseTargetOutput(raw: unknown): TargetOutput | undefined {
 		evalResult: isEvalResult(parsed.data.evalResult) ? parsed.data.evalResult : undefined,
 		agentEvalResult: isAgentEvalResult(parsed.data.agentEvalResult)
 			? parsed.data.agentEvalResult
+			: undefined,
+		agentArtifact: isAgentArtifact(parsed.data.agentArtifact)
+			? parsed.data.agentArtifact
 			: undefined,
 		workflowJson: isWorkflowResponse(parsed.data.workflowJson)
 			? parsed.data.workflowJson
@@ -264,6 +272,7 @@ export function reshapeLangSmithRuns(
 			let workflowId: string | undefined;
 			let agentId: string | undefined;
 			let agentArtifactContext: string | undefined;
+			let agentArtifact: AgentArtifact | undefined;
 			let buildError: string | undefined;
 			let threadId: string | undefined;
 			let workflowChecks: CheckOutcome[] | undefined;
@@ -297,6 +306,7 @@ export function reshapeLangSmithRuns(
 				if (output.agentId && !agentId) agentId = output.agentId;
 				if (output.agentContext && !agentArtifactContext)
 					agentArtifactContext = output.agentContext;
+				if (output.agentArtifact && !agentArtifact) agentArtifact = output.agentArtifact;
 				if (output.threadId) threadId = output.threadId;
 				if (!output.buildSuccess && output.reasoning) buildError = output.reasoning;
 				if (output.workflowChecks && !workflowChecks) workflowChecks = output.workflowChecks;
@@ -330,6 +340,7 @@ export function reshapeLangSmithRuns(
 					workflowId = output.workflowId;
 					agentId = output.agentId;
 					agentArtifactContext = output.agentContext;
+					agentArtifact = output.agentArtifact;
 					threadId = output.threadId;
 					if (!output.buildSuccess && output.reasoning) buildError = output.reasoning;
 					workflowChecks = output.workflowChecks;
@@ -349,6 +360,7 @@ export function reshapeLangSmithRuns(
 				workflowId,
 				agentId,
 				agentArtifactContext,
+				agentArtifact,
 				executionScenarioResults,
 				buildError,
 				threadId,

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -78,7 +78,7 @@ const targetOutputSchema = z.object({
 	agentEvalResult: z.unknown().optional(),
 	/** Rendered agent config + skills — attached to every agent row, deduped on reshape (first write wins). */
 	agentContext: z.string().optional(),
-	/** Structured, redacted agent preview artifact. */
+	/** Structured, redacted agent preview. Persistence validates and caps it for export. */
 	agentArtifact: z.unknown().optional(),
 	/** Only set on the scenario that initiated the build. */
 	buildDurationMs: z.number().optional(),

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import type {
+	AgentSkill,
 	InstanceAiEvalAgentExecutionResult,
 	InstanceAiEvalExecutionResult,
 	InstanceAiEvalSeedDataTable,
@@ -185,6 +186,13 @@ export interface ArtifactRef {
 	id: string;
 }
 
+/** Structured agent preview persisted for external eval-result consumers. */
+export interface AgentArtifact {
+	agentId?: string;
+	config: unknown;
+	skills: Record<string, AgentSkill>;
+}
+
 export interface ExecutionScenario {
 	name: string;
 	description: string;
@@ -351,8 +359,10 @@ export interface WorkflowTestCaseResult {
 	workflowId?: string;
 	/** Agent the case's scenarios executed (agent-artifact cases). */
 	agentId?: string;
-	/** Rendered agent config + skills — the agent analog of `workflowJson`, for the report. */
+	/** Rendered agent config + skills, used by the local HTML report. */
 	agentArtifactContext?: string;
+	/** Structured, redacted agent config + skills for external preview consumers. */
+	agentArtifact?: AgentArtifact;
 	workflowBuildSuccess: boolean;
 	buildError?: string;
 	executionScenarioResults: ExecutionScenarioResult[];

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -186,7 +186,7 @@ export interface ArtifactRef {
 	id: string;
 }
 
-/** Structured agent preview persisted for external eval-result consumers. */
+/** Structured agent preview. Capture redacts it; persistence validates and caps it. */
 export interface AgentArtifact {
 	agentId?: string;
 	config: unknown;
@@ -361,7 +361,7 @@ export interface WorkflowTestCaseResult {
 	agentId?: string;
 	/** Rendered agent config + skills, used by the local HTML report. */
 	agentArtifactContext?: string;
-	/** Structured, redacted agent config + skills for external preview consumers. */
+	/** Structured, redacted agent config and skills. Persistence validates and caps this value. */
 	agentArtifact?: AgentArtifact;
 	workflowBuildSuccess: boolean;
 	buildError?: string;


### PR DESCRIPTION
## Summary

Export a structured, redacted agent artifact with Instance AI eval results. The artifact contains the agent ID, config, and skills, and it stays separate from the existing workflow JSON artifact.

The eval pipeline now carries one artifact or `null` for each build iteration. It also keeps a single-artifact compatibility field for consumers that do not read the positional array yet. Agent-anchored cases emit an all-null positional array when no valid artifact was captured.

The capture boundary removes credential-shaped fields and known secret values. It validates known agent-config fields, rejects malformed values instead of emitting a partial canonical artifact, and preserves unknown non-secret fields for forward compatibility. Individual artifacts are capped at 262,144 serialized UTF-8 bytes. The final pretty-printed artifact fields are capped at 524,288 bytes, including the compatibility duplicate when it fits.

## How to test

From `packages/@n8n/instance-ai`:

```sh
pnpm test
pnpm lint
pnpm typecheck
pnpm build > /tmp/instance-ai-build.log 2>&1
pnpm format:check
```

Result: 4,890 tests passed and 1 test skipped. Lint, typecheck, build, and formatting passed.

From `packages/@n8n/ai-utilities`:

```sh
pnpm test
pnpm lint
pnpm typecheck
pnpm build > /tmp/ai-utilities-build.log 2>&1
pnpm format:check
```

Result: 958 tests passed. Lint, typecheck, build, and formatting passed.

The contract tests cover redaction, unknown fields, known config-schema validation, configured skill integrity, prior-run failure propagation, positional nulls, multibyte per-artifact and aggregate limits, and bounded compatibility-field serialization.

## Related Linear tickets, Github issues, and Community forum posts

Linear: https://linear.app/n8n/issue/TRUST-537

Paired LangTracer PR: https://github.com/n8n-io/lang-tracer/pull/296

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] No external documentation change is required for this internal eval artifact contract.
- [x] Tests included.
- [ ] Backport label is not required for this feature.


