### PR TITLE
fix(Confluence Node): Return the page sub-tree in tree order and skip drafts

### DIFF
--- a/packages/nodes-base/nodes/Confluence/actions/page/get.operation.ts
+++ b/packages/nodes-base/nodes/Confluence/actions/page/get.operation.ts
@@ -18,6 +18,18 @@ import type { ConfluenceOperation } from '../router';
 // ("maximum depth of descendants to return"), not an exact-depth filter
 const MAX_DEPTH = 10;
 
+// The batched `/pages` hydration has no `draft` value in its `status` filter, so a
+// draft descendant would spend a Max Pages slot and then be dropped
+const HYDRATABLE_STATUSES = new Set(['current', 'archived']);
+
+function isHydratable(record: IDataObject): boolean {
+	return typeof record.status !== 'string' || HYDRATABLE_STATUSES.has(record.status);
+}
+
+function asId(value: unknown): string {
+	return typeof value === 'string' || typeof value === 'number' ? String(value) : '';
+}
+
 export const description: INodeProperties[] = [
 	{
 		...optionalSpaceRLC,
@@ -52,7 +64,8 @@ export const description: INodeProperties[] = [
 		name: 'includeDescendants',
 		type: 'boolean',
 		default: false,
-		description: 'Whether to also fetch every descendant page of the page, one item per page',
+		description:
+			'Whether to also fetch every descendant page of the page, one item per page. Unpublished drafts are skipped.',
 		displayOptions: {
 			show: {
 				resource: ['page'],
@@ -110,16 +123,17 @@ async function collectDescendantPageIds(
 				);
 				const records = Array.isArray(response.results) ? (response.results as IDataObject[]) : [];
 				for (const record of records) {
-					const id =
-						typeof record.id === 'string' || typeof record.id === 'number' ? String(record.id) : '';
+					const id = asId(record.id);
 					if (id === '' || seen.has(id)) continue;
 					seen.add(id);
-					if (record.type === 'page') pageIds.push(id);
 					// Folders nest pages too; whiteboards/databases have nothing to fetch
 					if ((record.type === 'page' || record.type === 'folder') && record.depth === MAX_DEPTH) {
 						nextFrontier.push(id);
 					}
-					if (pageIds.length >= maxCount) return pageIds;
+					if (record.type === 'page' && isHydratable(record)) {
+						pageIds.push(id);
+						if (pageIds.length >= maxCount) return pageIds;
+					}
 				}
 				cursor = nextUnseenCursor(response, seenCursors);
 			} while (cursor !== undefined);
@@ -131,16 +145,16 @@ async function collectDescendantPageIds(
 
 /**
  * Hydration phase: batched `GET /pages?id=a,b,c` (this endpoint only accepts
- * storage/atlas_doc_format). May return fewer pages than requested — IDs the
- * caller can't read or that were deleted since discovery are dropped silently,
- * which is intended.
+ * storage/atlas_doc_format), re-keyed to `ids` because Confluence answers each batch
+ * in its own order. May return fewer pages than requested — IDs the caller can't read
+ * or that were deleted since discovery are dropped silently, which is intended.
  */
 async function fetchPagesByIds(
 	this: IExecuteFunctions,
 	ids: string[],
 	requestedFormat: Exclude<ConfluenceBodyFormat, 'plainText'>,
 ): Promise<IDataObject[]> {
-	const pages: IDataObject[] = [];
+	const byId = new Map<string, IDataObject>();
 	for (let start = 0; start < ids.length; start += PAGE_LIMIT) {
 		const chunk = ids.slice(start, start + PAGE_LIMIT);
 		const response = await confluenceApiRequest.call(
@@ -151,9 +165,23 @@ async function fetchPagesByIds(
 			{ id: chunk.join(','), 'body-format': requestedFormat, limit: PAGE_LIMIT },
 		);
 		const results = Array.isArray(response.results) ? (response.results as IDataObject[]) : [];
-		for (const page of results) pages.push(page);
+		for (const page of results) byId.set(asId(page.id), page);
 	}
-	return pages;
+	return ids.map((id) => byId.get(id)).filter((page): page is IDataObject => page !== undefined);
+}
+
+async function fetchPage(
+	this: IExecuteFunctions,
+	pageId: string,
+	requestedFormat: Exclude<ConfluenceBodyFormat, 'plainText'>,
+): Promise<IDataObject> {
+	return await confluenceApiRequest.call(
+		this,
+		'GET',
+		`/wiki/api/v2/pages/${encodeURIComponent(pageId)}`,
+		{},
+		{ 'body-format': requestedFormat },
+	);
 }
 
 export const execute: ConfluenceOperation = async function (
@@ -176,14 +204,7 @@ export const execute: ConfluenceOperation = async function (
 	const pageId = await resolvePageId.call(this, itemIndex);
 
 	if (!includeDescendants) {
-		const page = await confluenceApiRequest.call(
-			this,
-			'GET',
-			`/wiki/api/v2/pages/${encodeURIComponent(pageId)}`,
-			{},
-			{ 'body-format': requestedFormat },
-		);
-		return shapeBody(page, bodyFormat);
+		return shapeBody(await fetchPage.call(this, pageId, requestedFormat), bodyFormat);
 	}
 
 	const maxPages = parsePositiveInt.call(
@@ -192,11 +213,9 @@ export const execute: ConfluenceOperation = async function (
 		'Max Pages',
 		itemIndex,
 	);
-	const descendantIds = await collectDescendantPageIds.call(
-		this,
-		pageId,
-		Math.max(maxPages - 1, 0),
-	);
-	const pages = await fetchPagesByIds.call(this, [pageId, ...descendantIds], requestedFormat);
-	return pages.map((page) => shapeBody(page, bodyFormat));
+	// Not a seat in the batch below: the root must lead the output even when it is a draft
+	const root = await fetchPage.call(this, pageId, requestedFormat);
+	const descendantIds = await collectDescendantPageIds.call(this, pageId, maxPages - 1);
+	const descendants = await fetchPagesByIds.call(this, descendantIds, requestedFormat);
+	return [root, ...descendants].map((page) => shapeBody(page, bodyFormat));
 };

--- a/packages/nodes-base/nodes/Confluence/test/actions/page/get.operation.test.ts
+++ b/packages/nodes-base/nodes/Confluence/test/actions/page/get.operation.test.ts
@@ -445,19 +445,29 @@ describe('Confluence page:get operation', () => {
 	});
 
 	describe('sub-tree (includeDescendants)', () => {
-		function mockTree(descendantsByNode: Record<string, IDataObject[]>) {
+		const stubPage = (id: string) => ({ id, title: `Page ${id}` });
+
+		function mockTree(
+			descendantsByNode: Record<string, IDataObject[]>,
+			options: {
+				root?: IDataObject;
+				hydrate?: (ids: string[]) => IDataObject[];
+			} = {},
+		) {
 			apiRequest.mockImplementation(async (_method, endpoint, _body, qs) => {
-				const match = /^\/wiki\/api\/v2\/pages\/(\d+)\/descendants$/.exec(endpoint);
-				if (match) return { results: descendantsByNode[match[1]] ?? [] };
+				const descendantsOf = /^\/wiki\/api\/v2\/pages\/(\d+)\/descendants$/.exec(endpoint);
+				if (descendantsOf) return { results: descendantsByNode[descendantsOf[1]] ?? [] };
+				const single = /^\/wiki\/api\/v2\/pages\/(\d+)$/.exec(endpoint);
+				if (single) return options.root ?? stubPage(single[1]);
 				if (endpoint === '/wiki/api/v2/pages') {
 					const ids = String((qs as IDataObject).id).split(',');
-					return { results: ids.map((id) => ({ id, title: `Page ${id}` })) };
+					return { results: (options.hydrate ?? ((batch) => batch.map(stubPage)))(ids) };
 				}
 				throw new Error(`unexpected endpoint ${endpoint}`);
 			});
 		}
 
-		it('discovers descendants and hydrates them in one batched request, root included', async () => {
+		it('fetches the root on its own and hydrates the descendants in one batched request', async () => {
 			mockTree({
 				'100': [
 					{ id: '101', type: 'page', depth: 1 },
@@ -473,26 +483,75 @@ describe('Confluence page:get operation', () => {
 
 			const result = (await execute.call(ctx, 0)) as IDataObject[];
 
-			expect(apiRequest).toHaveBeenCalledTimes(2);
+			expect(apiRequest).toHaveBeenCalledTimes(3);
 			expect(apiRequest).toHaveBeenNthCalledWith(
 				1,
+				'GET',
+				'/wiki/api/v2/pages/100',
+				{},
+				{ 'body-format': 'storage' },
+			);
+			expect(apiRequest).toHaveBeenNthCalledWith(
+				2,
 				'GET',
 				'/wiki/api/v2/pages/100/descendants',
 				{},
 				{ depth: 10, limit: 250 },
 			);
 			expect(apiRequest).toHaveBeenNthCalledWith(
-				2,
+				3,
 				'GET',
 				'/wiki/api/v2/pages',
 				{},
-				{ id: '100,101,102', 'body-format': 'storage', limit: 250 },
+				{ id: '101,102', 'body-format': 'storage', limit: 250 },
 			);
 			expect(result.map((page) => page.id)).toEqual(['100', '101', '102']);
 		});
 
+		it('emits the walk order, root first, whatever order the hydration returns', async () => {
+			mockTree(
+				{
+					'500': [
+						{ id: '300', type: 'page', depth: 1 },
+						{ id: '100', type: 'page', depth: 2 },
+						{ id: '400', type: 'page', depth: 1 },
+					],
+				},
+				{ hydrate: (ids) => [...ids].sort().map(stubPage) },
+			);
+			const ctx = createContext({
+				page: { mode: 'id', value: '500' },
+				includeDescendants: true,
+			});
+
+			const result = (await execute.call(ctx, 0)) as IDataObject[];
+
+			expect(result.map((page) => page.id)).toEqual(['500', '300', '100', '400']);
+		});
+
+		it('drops a descendant the hydration does not return', async () => {
+			mockTree(
+				{
+					'100': [
+						{ id: '101', type: 'page', depth: 1 },
+						{ id: '102', type: 'page', depth: 1 },
+					],
+				},
+				{ hydrate: (ids) => ids.filter((id) => id !== '102').map(stubPage) },
+			);
+			const ctx = createContext({
+				page: { mode: 'id', value: '100' },
+				includeDescendants: true,
+			});
+
+			const result = (await execute.call(ctx, 0)) as IDataObject[];
+
+			expect(result.map((page) => page.id)).toEqual(['100', '101']);
+		});
+
 		it('follows the discovery cursor and deduplicates repeated records', async () => {
 			apiRequest.mockImplementation(async (_method, endpoint, _body, qs) => {
+				if (endpoint === '/wiki/api/v2/pages/100') return { id: '100' };
 				if (endpoint === '/wiki/api/v2/pages/100/descendants') {
 					if ((qs as IDataObject).cursor === undefined) {
 						return {
@@ -526,6 +585,7 @@ describe('Confluence page:get operation', () => {
 
 		it('stops discovery when the server echoes a cursor it already returned', async () => {
 			apiRequest.mockImplementation(async (_method, endpoint, _body, qs) => {
+				if (endpoint === '/wiki/api/v2/pages/100') return { id: '100' };
 				if (endpoint === '/wiki/api/v2/pages/100/descendants') {
 					return {
 						results:
@@ -582,6 +642,65 @@ describe('Confluence page:get operation', () => {
 			]);
 			// The folder and whiteboard are traversal-only records, never hydrated
 			expect(result.map((page) => page.id)).toEqual(['100', '101', '201', '301']);
+		});
+
+		it('keeps draft descendants out of the hydration and the Max Pages budget', async () => {
+			mockTree({
+				'100': [
+					{ id: '101', type: 'page', status: 'current', depth: 1 },
+					{ id: '102', type: 'page', status: 'draft', depth: 1 },
+					{ id: '103', type: 'page', status: 'current', depth: 2 },
+					{ id: '104', type: 'page', status: 'archived', depth: 2 },
+					{ id: '900', type: 'whiteboard', status: 'current', depth: 1 },
+					{ id: '105', type: 'page', status: 'current', depth: 3 },
+				],
+			});
+			const ctx = createContext({
+				page: { mode: 'id', value: '100' },
+				includeDescendants: true,
+				maxPages: 4,
+			});
+
+			const result = (await execute.call(ctx, 0)) as IDataObject[];
+
+			expect(apiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/wiki/api/v2/pages',
+				{},
+				{ id: '101,103,104', 'body-format': 'storage', limit: 250 },
+			);
+			expect(result.map((page) => page.id)).toEqual(['100', '101', '103', '104']);
+		});
+
+		it('emits the root even when it is a draft', async () => {
+			mockTree(
+				{ '100': [{ id: '101', type: 'page', status: 'current', depth: 1 }] },
+				{ root: { id: '100', status: 'draft', title: 'Unpublished' } },
+			);
+			const ctx = createContext({
+				page: { mode: 'id', value: '100' },
+				includeDescendants: true,
+			});
+
+			const result = (await execute.call(ctx, 0)) as IDataObject[];
+
+			expect(result.map((page) => page.id)).toEqual(['100', '101']);
+			expect(result[0].status).toBe('draft');
+		});
+
+		it('still traverses a draft at the maximum depth to reach its published children', async () => {
+			mockTree({
+				'100': [{ id: '101', type: 'page', status: 'draft', depth: 10 }],
+				'101': [{ id: '201', type: 'page', status: 'current', depth: 1 }],
+			});
+			const ctx = createContext({
+				page: { mode: 'id', value: '100' },
+				includeDescendants: true,
+			});
+
+			const result = (await execute.call(ctx, 0)) as IDataObject[];
+
+			expect(result.map((page) => page.id)).toEqual(['100', '201']);
 		});
 
 		it('stops the walk at Max Pages, root included', async () => {
@@ -650,6 +769,7 @@ describe('Confluence page:get operation', () => {
 			await expect(execute.call(ctx, 0)).rejects.toThrow(
 				'Max Pages must be a finite number of at least 1',
 			);
+			expect(apiRequest).not.toHaveBeenCalled();
 		});
 
 		it('skips discovery entirely when Max Pages is 1', async () => {
@@ -665,9 +785,9 @@ describe('Confluence page:get operation', () => {
 			expect(apiRequest).toHaveBeenCalledTimes(1);
 			expect(apiRequest).toHaveBeenCalledWith(
 				'GET',
-				'/wiki/api/v2/pages',
+				'/wiki/api/v2/pages/100',
 				{},
-				{ id: '100', 'body-format': 'storage', limit: 250 },
+				{ 'body-format': 'storage' },
 			);
 			expect(result.map((page) => page.id)).toEqual(['100']);
 		});
@@ -693,7 +813,7 @@ describe('Confluence page:get operation', () => {
 			);
 			expect(bulkCalls).toHaveLength(2);
 			expect(String((bulkCalls[0][3] as IDataObject).id).split(',')).toHaveLength(250);
-			expect(String((bulkCalls[1][3] as IDataObject).id).split(',')).toHaveLength(11);
+			expect(String((bulkCalls[1][3] as IDataObject).id).split(',')).toHaveLength(10);
 			expect(result).toHaveLength(261);
 		});
 
@@ -703,6 +823,10 @@ describe('Confluence page:get operation', () => {
 				content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body text' }] }],
 			});
 			apiRequest.mockImplementation(async (_method, endpoint, _body, qs) => {
+				if (endpoint === '/wiki/api/v2/pages/100') {
+					expect((qs as IDataObject)['body-format']).toBe('atlas_doc_format');
+					return { id: '100', body: { atlas_doc_format: { value: adf } } };
+				}
 				if (endpoint === '/wiki/api/v2/pages/100/descendants') {
 					return { results: [{ id: '101', type: 'page', depth: 1 }] };
 				}

--- a/packages/nodes-base/nodes/Confluence/test/actions/router.test.ts
+++ b/packages/nodes-base/nodes/Confluence/test/actions/router.test.ts
@@ -298,11 +298,10 @@ describe('Confluence router', () => {
 	});
 
 	it('fans an array response out into one item per page', async () => {
-		apiRequest.mockImplementation(async (_method: string, url: string) =>
-			url.endsWith('/descendants')
-				? { results: [{ id: '2', type: 'page', depth: 1 }] }
-				: { results: [{ id: '1' }, { id: '2' }] },
-		);
+		apiRequest.mockImplementation(async (_method: string, url: string) => {
+			if (url.endsWith('/descendants')) return { results: [{ id: '2', type: 'page', depth: 1 }] };
+			return url === '/wiki/api/v2/pages' ? { results: [{ id: '2' }] } : { id: '1' };
+		});
 
 		const result = await router.call(
 			mockExecuteCtx({ ...getParams, includeDescendants: true, maxPages: 100 }),


### PR DESCRIPTION
## Summary

Two defects in Page → Get with **Include Descendants**.

**Order.** The node kept the order Confluence returned for the batched hydration (`GET /pages?id=…`), which is page-ID ascending. A child could come before its parent. Pages are now re-keyed to the walk order that `/descendants` reports. The root also gets its own request, so it always leads the output — the batch drops a draft root.

**Drafts.** A draft descendant spent a Max Pages slot but never reached the output (Max Pages 8 → 7 items). Discovery now skips them. The ticket's other option, a `status` param on the batch fetch, does not exist: `GET /pages` accepts only `current`, `archived`, `deleted`, `trashed`. Archived pages still count and are still emitted. A draft is still traversed, so published pages below one are still found.

## How to test

1. Run Page → Get with Include Descendants on a root whose ID is not the lowest in its tree, such as a space homepage. The output order matches the Confluence page tree, root first.
2. Add a draft child. Set Max Pages to 8. The node returns 8 items and no draft. Before the fix it returns 7.
3. Set the root itself to a draft page. The node still returns it as item 0.
4. `cd packages/nodes-base && pnpm test nodes/Confluence`

The tree:

<img width="401" height="493" alt="Screenshot 2026-09-11 at 9 09 36" src="https://github.com/user-attachments/assets/2ef64f9c-39db-45ca-bb09-ee38555923e2" />

Order of the pages before (left) and after the fix (rgiht):

<img width="1960" height="621" alt="Screenshot 2026-09-11 at 9 08 59" src="https://github.com/user-attachments/assets/b82f6586-3a37-4e73-b2ae-82519ba06790" />


What is different: before, `TreeTest child 1786709643647` is row 8, but its parent `TreeTest parent 1786709642754` is row 10 — a child above its parent. The Weekly reports also come out `08-44-07, 08-45-06, 08-45-14, 08-45-52`, while `08-45-06` is a sibling of `08-44-07` and belongs last. After matches the Confluence tree row for row. The root was already first here only because `QA Root` holds the lowest ID in its tree.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-410 (bug bash findings 9 and 10)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.


🤖 PR Summary generated by AI