### PR TITLE
ci: Add some triggerable primitives for codespace workflows

### DIFF
--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -59,7 +59,8 @@ PR instead of reading it. It is a different box from a `pnpm session`: it uses
 [util-codespace-preview.yml](../../.github/workflows/util-codespace-preview.yml)
 creates the box, serves the PR head, shares port 5678 with the org, and comments
 the URL on the PR. A later push serves the new head in the same box. Remove the
-label, or close the PR, to delete the box.
+label, or close the PR, to delete the box. The same workflow runs by hand from
+the Actions tab: give it a PR number and `up`, `refresh` or `down`.
 
 **From your laptop:** `pnpm preview up <pr>` does the same thing, plus
 `pnpm preview refresh <pr>`, `pnpm preview down <pr>` and `pnpm preview ls`. It
@@ -76,8 +77,12 @@ needs `gh` with the codespace scope, the same as `pnpm session`.
   re-serves the box; it never creates or deletes one. From a laptop the labels
   apply the same way — `pnpm preview refresh <pr>` reads them from the PR. The
   toggles are defined in `scripts/preview-labels.mjs`; add new ones there.
-- **A preview sleeps after 30 minutes** of no use and GitHub deletes it after 24
-  hours. Add the label again to get a new one.
+- **A preview sleeps after 2 hours** of no use and GitHub deletes it after 24
+  hours. A box that slept serves nothing and its port is private again, so wake
+  it with `pnpm preview up <pr>` or a manual run of
+  [util-codespace-preview.yml](../../.github/workflows/util-codespace-preview.yml)
+  with `up`. Removing and adding the label works too, but it deletes the box and
+  builds a new one.
 - **A PR from a fork gets no preview.** A codespace's token is scoped to
   `n8n-io/n8n`, so it cannot check out a fork head.
 - **A PR that predates this tooling has no `scripts/preview-serve.mjs`.** The

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -262,6 +262,29 @@ label, or closing the PR, deletes the box.
 Only a PR from a branch in this repository is eligible: a codespace token is
 scoped to `n8n-io/n8n` and cannot check out a fork head.
 
+#### Running it by hand
+
+A box sleeps after 2 hours of no use, and GitHub makes every forwarded port
+private again at each start. So a preview that slept reaches nobody until
+something shares port 5678 again, and its backend is gone with the container.
+**Actions → Util: Codespace Preview → Run workflow** does both without a commit
+and without a label toggle:
+
+| Input | Meaning |
+|---|---|
+| `pr_number` | The pull request to act on. |
+| `operation` | `up` (default) creates the box if it is gone, starts it if it sleeps, serves the head and shares the port again. `refresh` re-serves the head in a box that already exists. `down` deletes the box. |
+
+Prefer `up` unless you mean to delete: it covers create, wake and re-share.
+
+The button needs write access, and it appears only once the trigger is on
+`master` — GitHub lists dispatchable workflows from the default branch. A manual
+run takes the branch picked in the dropdown, which is the branch GitHub read the
+workflow from, so a branch can test a change to the preview scripts. A fork head
+is still refused, by `preview.mjs` rather than by the job's `if`. There is no
+`ls` operation: it needs no PR and posts no comment — run `pnpm preview ls`
+locally.
+
 #### Preview toggles
 
 A `preview:*` label configures an instance that already exists, so adding or
@@ -334,12 +357,14 @@ better than a person's account for quota attribution, though the token is scoped
 to one repository either way.
 
 The job checks out the base branch, never the PR head, so a PR cannot supply the
-script that reads that token.
+script that reads that token. A manual run checks out the branch chosen in the
+Run-workflow dropdown, which only a user with write access can pick.
 
 ### Other Manual Workflows
 
 | Workflow                    | Purpose                                                 |
 |-----------------------------|---------------------------------------------------------|
+| `util-codespace-preview.yml`| Wake, re-serve or delete a PR preview instance by hand   |
 | `util-data-tooling.yml`     | SQLite/PostgreSQL export/import validation (manual)     |
 | `util-probe-registry.yml`   | Diagnose slow npm metadata fetches (temporary)          |
 
@@ -693,7 +718,7 @@ Scripts in `.github/scripts/`:
 
 | Script                          | Purpose                                                                 | Called By                      |
 |---------------------------------|-------------------------------------------------------------------------|--------------------------------|
-| `codespace-preview.mjs`         | Map a `pull_request` event onto a preview operation, comment the result  | `util-codespace-preview.yml`   |
+| `codespace-preview.mjs`         | Map a `pull_request` event or a manual operation onto a preview operation, comment the result | `util-codespace-preview.yml` |
 | `../../scripts/preview.mjs`     | One codespace for each PR: `up`, `refresh`, `down`, `ls`. `--json` for CI | `codespace-preview.mjs`, developers |
 
 `scripts/preview.mjs` is also the developer entry point (`pnpm preview up <pr>`).

--- a/.github/scripts/codespace-preview.mjs
+++ b/.github/scripts/codespace-preview.mjs
@@ -8,6 +8,8 @@
 //   unlabeled    -> down     delete the box
 //   closed       -> down
 //
+// A manual run sets PREVIEW_OPERATION instead, which wins over the event mapping.
+//
 // `refresh` never creates a box. A box that GitHub already deleted (24 h
 // retention) is reported as expired, not as a failure.
 import { spawnSync } from 'node:child_process';
@@ -18,11 +20,16 @@ import { ensureEnvVar, postOrUpdateComment } from './github-helpers.mjs';
 
 export const BOT_MARKER = '<!-- codespace-preview -->';
 export const PREVIEW_LABEL = 'codespace-preview';
-// Copied from `preview.mjs`, which owns them. They cannot be imported: that module
-// runs its command switch on import. They appear in the comment so a reviewer knows
-// how long the instance lasts without reading the script.
-const IDLE_TIMEOUT = '30 minutes';
+// Copied from `preview.mjs`, which owns them, so they move together. They cannot be
+// imported: that module runs its command switch on import. They appear in the comment
+// so a reviewer knows how long the instance lasts without reading the script.
+const IDLE_TIMEOUT = '2 hours';
 const RETENTION_PERIOD = '24 hours';
+// A slept box comes back with a private port, so every recovery hint points here.
+export const WORKFLOW_URL =
+	'https://github.com/n8n-io/n8n/actions/workflows/util-codespace-preview.yml';
+// What a manual run may ask for. `ls` is absent: it needs no PR and posts no comment.
+export const DISPATCH_OPERATIONS = ['up', 'refresh', 'down'];
 // Resolved against this file, so the script runs the same from any directory.
 const PREVIEW_SCRIPT = fileURLToPath(new URL('../../scripts/preview.mjs', import.meta.url));
 
@@ -48,6 +55,19 @@ export function operationFor(action, label) {
 		default:
 			return undefined;
 	}
+}
+
+/**
+ * A manual run says what to do, so its operation wins over the event mapping. An
+ * operation that is not one of ours stops here: `preview.mjs` would only print
+ * usage and exit 1, which reads as a broken preview rather than a bad input.
+ *
+ * @param {{action?: string, label?: string, operation?: string}} context
+ * @returns {'up' | 'refresh' | 'down' | undefined}
+ */
+export function resolveOperation({ action, label, operation }) {
+	if (operation) return DISPATCH_OPERATIONS.includes(operation) ? operation : undefined;
+	return operationFor(action ?? '', label);
 }
 
 /**
@@ -122,7 +142,9 @@ export function readyComment({ url, codespace, sha, orgVisible, pr }) {
 		access,
 		'',
 		`The instance sleeps after ${IDLE_TIMEOUT} of no use and is deleted after ${RETENTION_PERIOD}.`,
-		`Push a commit to serve it again. Remove the \`${PREVIEW_LABEL}\` label to delete it now.`,
+		`A box that slept comes back private, so wake it with [the preview workflow](${WORKFLOW_URL})`,
+		'(`Run workflow` → this PR number → `up`), or by pushing a commit.',
+		`Remove the \`${PREVIEW_LABEL}\` label to delete it now.`,
 	].join('\n');
 }
 
@@ -143,7 +165,7 @@ export function expiredComment({ pr }) {
 		`### Preview instance expired`,
 		'',
 		`The preview box for PR #${pr} no longer exists — GitHub deletes one after ${RETENTION_PERIOD}.`,
-		`Remove and add the \`${PREVIEW_LABEL}\` label to get a new one.`,
+		`Run [the preview workflow](${WORKFLOW_URL}) with \`up\` to get a new one.`,
 	].join('\n');
 }
 
@@ -155,7 +177,8 @@ export function failureComment({ operation, runUrl, message }) {
 		'',
 		`\`preview ${operation}\` did not finish: ${message}`,
 		'',
-		`See [the workflow run](${runUrl}) for the full log. Remove and add the \`${PREVIEW_LABEL}\` label to try again.`,
+		`See [the workflow run](${runUrl}) for the full log.`,
+		`Run [the preview workflow](${WORKFLOW_URL}) with \`${operation}\` to try again.`,
 	].join('\n');
 }
 
@@ -176,19 +199,25 @@ function runPreview(args) {
 
 async function main() {
 	const pr = ensureEnvVar('PULL_REQUEST_NUMBER');
-	const action = ensureEnvVar('EVENT_ACTION');
 	const runUrl = ensureEnvVar('RUN_URL');
+	const requested = process.env.PREVIEW_OPERATION;
+	// A manual run carries no event action, so it cannot be required there.
+	const action = requested ? '' : ensureEnvVar('EVENT_ACTION');
 	const label = process.env.LABEL_NAME;
 
-	const operation = operationFor(action, label);
-	console.log("Operations: ", {
-		action,
-		label,
-		operation
-	})
+	// The dispatch input is free text. Refuse a non-number before anything tries to
+	// comment on it: postOrUpdateComment(NaN) 404s inside the catch below and
+	// reports that instead of the real cause.
+	if (!/^\d+$/.test(pr)) {
+		console.error(`::error::PULL_REQUEST_NUMBER must be a number, got "${pr}".`);
+		process.exitCode = 1;
+		return;
+	}
+
+	const operation = resolveOperation({ action, label, operation: requested });
 	if (!operation) {
 		console.log(
-			`No preview operation for a "${action}" event on "${label ?? ''}" — nothing to do.`,
+			`No preview operation for action="${action}" label="${label ?? ''}" operation="${requested ?? ''}" — nothing to do.`,
 		);
 		return;
 	}

--- a/.github/scripts/codespace-preview.test.mjs
+++ b/.github/scripts/codespace-preview.test.mjs
@@ -3,6 +3,8 @@ import { describe, it } from 'node:test';
 
 import {
 	BOT_MARKER,
+	DISPATCH_OPERATIONS,
+	WORKFLOW_URL,
 	downComment,
 	expiredComment,
 	failureComment,
@@ -11,6 +13,7 @@ import {
 	parsePreviewJson,
 	portFromUrl,
 	readyComment,
+	resolveOperation,
 } from './codespace-preview.mjs';
 
 const PREVIEW = {
@@ -53,6 +56,30 @@ describe('operationFor', () => {
 		assert.equal(operationFor('opened'), undefined);
 		assert.equal(operationFor('reopened'), undefined);
 		assert.equal(operationFor(''), undefined);
+	});
+});
+
+describe('resolveOperation', () => {
+	it('falls back to the event mapping when no operation is requested', () => {
+		assert.equal(resolveOperation({ action: 'labeled', label: 'codespace-preview' }), 'up');
+		assert.equal(resolveOperation({ action: 'synchronize' }), 'refresh');
+		assert.equal(resolveOperation({ action: 'labeled', label: 'bug' }), undefined);
+		// The workflow sets the variable to '' on a pull_request run, not undefined.
+		assert.equal(resolveOperation({ action: 'closed', operation: '' }), 'down');
+	});
+
+	it('lets a manual run choose, over the event', () => {
+		for (const operation of DISPATCH_OPERATIONS) {
+			assert.equal(resolveOperation({ action: '', operation }), operation);
+		}
+		assert.equal(resolveOperation({ action: 'synchronize', operation: 'down' }), 'down');
+	});
+
+	it('rejects an operation that is not one of ours', () => {
+		// `ls` posts no comment and needs no PR, so the workflow does not offer it.
+		assert.equal(resolveOperation({ action: '', operation: 'ls' }), undefined);
+		assert.equal(resolveOperation({ action: '', operation: 'UP' }), undefined);
+		assert.equal(resolveOperation({ action: '', operation: 'up; rm -rf /' }), undefined);
 	});
 });
 
@@ -158,5 +185,16 @@ describe('comment bodies', () => {
 	it('the failure comment carries the cause and the run link', () => {
 		assert.match(bodies.failure, /exited 1/);
 		assert.match(bodies.failure, /actions\/runs\/1/);
+	});
+
+	it('quotes the idle timeout preview.mjs actually sets', () => {
+		// preview.mjs creates a box with --idle-timeout 2h.
+		assert.match(bodies.ready, /sleeps after 2 hours/);
+	});
+
+	it('points a slept, expired or failed box at the manual run', () => {
+		for (const name of ['ready', 'expired', 'failure']) {
+			assert.ok(bodies[name].includes(WORKFLOW_URL), `${name} must link the workflow`);
+		}
 	});
 });

--- a/.github/workflows/util-codespace-preview.yml
+++ b/.github/workflows/util-codespace-preview.yml
@@ -1,5 +1,5 @@
 name: 'Util: Codespace Preview'
-run-name: Codespace preview for PR ${{ github.event.pull_request.number }}
+run-name: Codespace preview for PR ${{ github.event.pull_request.number || inputs.pr_number }}${{ inputs.operation && format(' ({0})', inputs.operation) || '' }}
 
 # Runs a preview instance of a pull request in a GitHub Codespace, then reports
 # the URL back to the PR in one comment that later runs edit in place.
@@ -9,6 +9,10 @@ run-name: Codespace preview for PR ${{ github.event.pull_request.number }}
 #  - synchronize -> `preview refresh`, which serves the new head in the same box
 #  - unlabeled   -> `preview down`
 #  - closed      -> `preview down`, so a merged PR does not hold a box for 24 h
+#
+# It also runs by hand from the Actions tab. A box sleeps after 2 h, and GitHub
+# makes every forwarded port private again at each start, so a slept preview
+# answers nobody until `up` runs again — with no commit and no label toggle.
 #
 # Output: a `<!-- codespace-preview -->` comment on the PR with the instance URL,
 # a one-click sign-in link, and the commit it serves.
@@ -22,6 +26,21 @@ on:
       - closed
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to act on.'
+        required: true
+        type: string
+      operation:
+        description: '`up` creates or wakes the box, serves the head and shares port 5678 again. `refresh` re-serves in a box that already exists. `down` deletes it.'
+        required: true
+        default: up
+        type: choice
+        options:
+          - up
+          - refresh
+          - down
 
 permissions: {}
 
@@ -29,7 +48,7 @@ concurrency:
   # Never cancel a run in progress. Cancelling during `gh codespace create` leaves
   # a box that nothing tracks and the org still pays for. Keyed on the PR, so the
   # up, refresh and down runs for one PR happen one after another.
-  group: codespace-preview-${{ github.event.pull_request.number }}
+  group: codespace-preview-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -39,17 +58,27 @@ jobs:
     # the set of labels the PR carries now, which is what a push, a close, or a
     # `preview:*` toggle needs. A toggle only matters on a PR that already has a
     # preview, so it is gated on `codespace-preview` being present.
+    #
+    # A manual run carries no pull_request payload, so it has to short-circuit the
+    # whole clause: `head.repo.full_name` is null there and would skip every run.
+    # It needs no label gate — dispatch already requires write access, and
+    # `preview.mjs` still refuses a fork head.
     if: |
       github.repository == 'n8n-io/n8n' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-          github.event.label.name == 'codespace-preview') ||
-        ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-          startsWith(github.event.label.name, 'preview:') &&
-          contains(github.event.pull_request.labels.*.name, 'codespace-preview')) ||
-        ((github.event.action == 'synchronize' || github.event.action == 'closed') &&
-          contains(github.event.pull_request.labels.*.name, 'codespace-preview'))
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+              github.event.label.name == 'codespace-preview') ||
+            ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+              startsWith(github.event.label.name, 'preview:') &&
+              contains(github.event.pull_request.labels.*.name, 'codespace-preview')) ||
+            ((github.event.action == 'synchronize' || github.event.action == 'closed') &&
+              contains(github.event.pull_request.labels.*.name, 'codespace-preview'))
+          )
+        )
       )
     runs-on: ubuntu-latest
     environment: codespaces
@@ -59,9 +88,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout base branch
+        # A manual run has no base ref. It takes the branch picked in the
+        # Run-workflow dropdown, which is where this file came from, so the
+        # workflow and the scripts it runs stay from one commit.
         uses: useblacksmith/checkout@bcec731f1eb1367240608d1c889a75b96db6ec53 # v1.5.0
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.ref || github.ref_name }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -79,8 +111,10 @@ jobs:
           # TODO: move CODESPACE_PREVIEW_TOKEN to a service account.
           GH_TOKEN: ${{ secrets.CODESPACE_PREVIEW_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
+          # Empty on a pull_request run, where the event decides instead.
+          PREVIEW_OPERATION: ${{ inputs.operation }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: node .github/scripts/codespace-preview.mjs


### PR DESCRIPTION
## Summary

Allow dispatching the workflow for codespace control to allow external automations to trigger codespace actions while also triggering the scaffolding we have in place. A regular codespace start doesn't expose the port to org and set the service up easily so it's better we handle these through our workflows.

## How to test

Once this is merged, we'll create workflows on internal to allow us to trigger these via webhooks.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

