### PR TITLE
feat(Slack Trigger Node)!: Require the signature secret on the Slack API credential

### DIFF
--- a/packages/nodes-base/credentials/SlackApi.credentials.ts
+++ b/packages/nodes-base/credentials/SlackApi.credentials.ts
@@ -27,8 +27,9 @@ export class SlackApi implements ICredentialType {
 			type: 'string',
 			typeOptions: { password: true },
 			default: '',
+			required: true,
 			description:
-				'The signature secret is used to verify the authenticity of requests sent by Slack.',
+				'The signing secret of your Slack app. Find it under "Basic Information" in the Slack API dashboard. n8n uses it to verify that incoming requests come from Slack. <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">More info</a>.',
 		},
 		{
 			displayName: 'Managed App ID',
@@ -47,18 +48,6 @@ export class SlackApi implements ICredentialType {
 			name: 'managerCredentialId',
 			type: 'hidden',
 			default: '',
-		},
-		{
-			displayName:
-				'We strongly recommend setting up a <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">signing secret</a> to ensure the authenticity of requests.',
-			name: 'notice',
-			type: 'notice',
-			default: '',
-			displayOptions: {
-				show: {
-					signatureSecret: [''],
-				},
-			},
 		},
 	];
 

--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -53,7 +53,7 @@ export class SlackTrigger implements INodeType {
 			},
 			{
 				displayName:
-					'Set up a webhook in your Slack app to enable this node. <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#configure-a-webhook-in-slack" target="_blank">More info</a>. We also recommend setting up a <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">signing secret</a> to ensure the authenticity of requests.',
+					'Set up a webhook in your Slack app to enable this node. <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#configure-a-webhook-in-slack" target="_blank">More info</a>. The credential must contain the <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">signing secret</a> of your Slack app. Requests that do not carry a valid signature are rejected.',
 				name: 'notice',
 				type: 'notice',
 				default: '',

--- a/packages/nodes-base/nodes/Slack/SlackTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTriggerHelpers.ts
@@ -93,11 +93,17 @@ export async function verifySignature(
 		return false;
 	}
 
+	// The signature secret is a required credential field. A credential saved before it became
+	// required can still lack it, so fail closed instead of skipping verification.
 	const signatureSecret = credential.signatureSecret;
+	if (!signatureSecret || typeof signatureSecret !== 'string') {
+		return false;
+	}
+
 	try {
 		const isValid = verifySignatureGeneric({
 			getExpectedSignature: () => {
-				if (!signatureSecret || typeof signatureSecret !== 'string' || !req.rawBody) {
+				if (!req.rawBody) {
 					return null;
 				}
 
@@ -115,7 +121,6 @@ export async function verifySignature(
 				const computedSignature = `v0=${hmac.digest('hex')}`;
 				return computedSignature;
 			},
-			skipIfNoExpectedSignature: !signatureSecret || typeof signatureSecret !== 'string',
 			getActualSignature: () => {
 				const actualSignature = req.header('x-slack-signature');
 				return typeof actualSignature === 'string' ? actualSignature : null;

--- a/packages/nodes-base/nodes/Slack/test/SlackTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/SlackTriggerHelpers.test.ts
@@ -48,24 +48,36 @@ describe('SlackTriggerHelpers', () => {
 	});
 
 	describe('verifySignature', () => {
-		it('should return true when no credentials are provided', async () => {
+		it('should return false when the credential is empty', async () => {
 			mockWebhookFunctions.getCredentials.mockResolvedValue({});
 
 			const result = await verifySignature.call(mockWebhookFunctions);
 
-			expect(result).toBe(true);
+			expect(result).toBe(false);
+			expect(createHmac).not.toHaveBeenCalled();
 			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('slackApi');
 		});
 
-		it('should return true when no signature secret is provided', async () => {
+		it('should return false when no signature secret is configured', async () => {
 			mockWebhookFunctions.getCredentials.mockResolvedValue({
-				apiToken: 'test-token',
+				accessToken: 'test-token',
 			});
 
 			const result = await verifySignature.call(mockWebhookFunctions);
 
-			expect(result).toBe(true);
-			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('slackApi');
+			expect(result).toBe(false);
+			expect(createHmac).not.toHaveBeenCalled();
+		});
+
+		it('should return false when the signature secret is not a string', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signatureSecret: 12345,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+			expect(createHmac).not.toHaveBeenCalled();
 		});
 
 		it('should return false when signature header is missing', async () => {
@@ -162,27 +174,9 @@ describe('SlackTriggerHelpers', () => {
 			expect(mockHmac.update).toHaveBeenCalledWith(`v0:${testTimestamp}:${testBody}`);
 		});
 
-		it('should verify timestamp even if signature secret is not set', async () => {
-			// No signature secret in credentials
+		it('should return false when no signature secret is configured even if timestamp is valid', async () => {
 			mockWebhookFunctions.getCredentials.mockResolvedValue({
-				apiToken: 'test-token',
-			});
-
-			// Mock Date.now() to return a timestamp that's more than 5 minutes after the request timestamp
-			const futureDate = new Date((parseInt(testTimestamp, 10) + 301) * 1000);
-			vi.spyOn(Date, 'now').mockImplementation(() => futureDate.getTime());
-
-			const result = await verifySignature.call(mockWebhookFunctions);
-
-			// Should return false because timestamp is too old, even though signature secret is not set
-			expect(result).toBe(false);
-			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('slackApi');
-		});
-
-		it('should return true when timestamp is valid even if signature secret is not set', async () => {
-			// No signature secret in credentials
-			mockWebhookFunctions.getCredentials.mockResolvedValue({
-				apiToken: 'test-token',
+				accessToken: 'test-token',
 			});
 
 			// Keep Date.now() at the same time as the request timestamp (within 5 minute window)
@@ -191,9 +185,19 @@ describe('SlackTriggerHelpers', () => {
 
 			const result = await verifySignature.call(mockWebhookFunctions);
 
-			// Should return true because timestamp is valid and signature secret is not required
+			expect(result).toBe(false);
+		});
+
+		it('should read the signature secret from the given credential type', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				signatureSecret: testSignatureSecret,
+			});
+			(timingSafeEqual as Mock).mockReturnValue(true);
+
+			const result = await verifySignature.call(mockWebhookFunctions, 'slackOAuth2Api');
+
 			expect(result).toBe(true);
-			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('slackApi');
+			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('slackOAuth2Api');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Breaking change for v3.

- The `Signature Secret` field of the Slack API credential is now required. The credential modal does not save a credential without it.
- The Slack Trigger node responds with `401` when its credential has no signature secret. Before this change, the node skipped signature verification in that case.
- The "we strongly recommend setting up a signing secret" notice is removed from the credential. The notice on the Slack Trigger node now states that the secret is required.

Existing credentials keep working for the regular Slack node. Only workflows that use the Slack Trigger node with a credential that has no signature secret stop receiving events until the secret is added. The Slack OAuth2 credential is unchanged; the Slack Trigger node does not accept it, and the send-and-wait interaction webhook already rejects requests without a secret.

## How to test

1. Open the credential modal for a new Slack API credential. Confirm that `Signature Secret` is marked as required and that Save is blocked while it is empty.
2. Create a workflow with a Slack Trigger node and a Slack API credential that has no signature secret (create it through the REST API, or use a credential saved before this change). Send a request to the webhook URL. Confirm the response is `401 Unauthorized`.
3. Add the signing secret from "Basic Information" of the Slack app to the credential. Send a signed request (or trigger the event from Slack). Confirm the workflow runs.
4. Run `pnpm test nodes/Slack` in `packages/nodes-base`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-296

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

