### PR TITLE
fix: Scope deployment key lookups by type

### DIFF
--- a/packages/cli/src/encryption/__tests__/get-key-by-id-type-scope.integration.test.ts
+++ b/packages/cli/src/encryption/__tests__/get-key-by-id-type-scope.integration.test.ts
@@ -1,0 +1,56 @@
+import { mockInstance, testDb } from '@n8n/backend-test-utils';
+import { DeploymentKeyRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
+
+import { KeyManagerService } from '@/encryption/key-manager.service';
+
+beforeAll(async () => {
+	mockInstance(InstanceSettings, {
+		encryptionKey: 'get-key-by-id-type-scope-instance-key',
+		n8nFolder: '/tmp/n8n-test',
+		instanceType: 'main',
+		canSeedDeploymentState: true,
+	});
+	await testDb.init();
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+// Locks in that a row of another type cannot be returned for a data-encryption
+// lookup, even though `id` is the table's only primary key across all types.
+describe('getKeyById() type scoping (integration)', () => {
+	it('does not resolve a jwe.private-key row', async () => {
+		const repo = Container.get(DeploymentKeyRepository);
+		const jweRow = await repo.save(
+			repo.create({
+				type: 'jwe.private-key',
+				value: 'jwe-secret',
+				algorithm: 'RSA-OAEP-256',
+				status: 'active',
+			}),
+		);
+
+		const result = await Container.get(KeyManagerService).getKeyById(jweRow.id);
+
+		expect(result).toBeNull();
+	});
+
+	it('does not resolve a signing.hmac row', async () => {
+		const repo = Container.get(DeploymentKeyRepository);
+		const hmacRow = await repo.save(
+			repo.create({
+				type: 'signing.hmac',
+				value: 'hmac-secret',
+				algorithm: null,
+				status: 'active',
+			}),
+		);
+
+		const result = await Container.get(KeyManagerService).getKeyById(hmacRow.id);
+
+		expect(result).toBeNull();
+	});
+});

--- a/packages/cli/src/encryption/__tests__/key-manager.service.test.ts
+++ b/packages/cli/src/encryption/__tests__/key-manager.service.test.ts
@@ -149,7 +149,9 @@ describe('KeyManagerService', () => {
 				algorithm: key.algorithm,
 				format: 'prefixed',
 			});
-			expect(repo.findOne).toHaveBeenCalledWith({ where: { id: 'key-1' } });
+			expect(repo.findOne).toHaveBeenCalledWith({
+				where: { id: 'key-1', type: 'data_encryption' },
+			});
 		});
 
 		it('returns null when key not found', async () => {
@@ -677,6 +679,19 @@ describe('KeyManagerService', () => {
 			const active = await service.getActiveKey();
 			expect(active.id).toBe('old-active');
 			expect(repo.find).toHaveBeenCalledTimes(1);
+		});
+
+		it('never deletes the key row', async () => {
+			const { service, repo } = makeFreshService();
+			repo.find.mockResolvedValue([makeKey({ id: 'old-active' })]);
+
+			await service.markInactive('old-active');
+
+			expect(repo.delete).not.toHaveBeenCalled();
+			expect(repo.remove).not.toHaveBeenCalled();
+			expect(repo.softDelete).not.toHaveBeenCalled();
+			expect(repo.softRemove).not.toHaveBeenCalled();
+			expect(repo.update).toHaveBeenCalledWith('old-active', { status: 'inactive' });
 		});
 	});
 

--- a/packages/cli/src/encryption/key-manager.service.ts
+++ b/packages/cli/src/encryption/key-manager.service.ts
@@ -116,7 +116,9 @@ export class KeyManagerService implements IEncryptionKeyProvider {
 			return cached;
 		}
 
-		const key = await this.deploymentKeyRepository.findOne({ where: { id } });
+		const key = await this.deploymentKeyRepository.findOne({
+			where: { id, type: 'data_encryption' },
+		});
 		if (!key) return null;
 		const keyInfo: KeyInfo = {
 			id: key.id,
@@ -367,9 +369,12 @@ export class KeyManagerService implements IEncryptionKeyProvider {
 		this.activeKeyMemo = undefined;
 	}
 
-	/** Transitions key to 'inactive'. Usage count guard to be added in T13. */
+	/**
+	 * Transitions key to 'inactive'. Never deletes: DeploymentKeyRepository's
+	 * delete/remove/softDelete/softRemove/clear all throw, so a deactivated
+	 * key's value stays intact and readable for any ciphertext still using it.
+	 */
 	async markInactive(id: string): Promise<void> {
-		// TODO: T13 will add usage check — throw ConflictError if usage count > 0
 		await this.deploymentKeyRepository.update(id, { status: 'inactive' });
 		// The active key may be gone now: force the next write to re-read the store.
 		this.activeKeyMemo = undefined;


### PR DESCRIPTION
## Summary

`KeyManagerService.getKeyById` now filters a `deployment_key` lookup by both
`id` and `type: 'data_encryption'`, instead of `id` alone. This is the only
type this method is ever asked to resolve — every `keyId:ciphertext` value
that reaches it comes from `Cipher.encryptV2()`, which always encrypts with
the active `data_encryption` key. The scoped filter means a lookup can never
return a `jwe.private-key`, `signing.hmac`, or other non-data-encryption row.

`KeyManagerService.markInactive` is documented and locked in as
non-destructive: it only ever flips a key's `status` to `inactive` and can
never delete a key row, since `DeploymentKeyRepository` already blocks
`delete`/`remove`/`softDelete`/`softRemove`/`clear` unconditionally. A
deactivated key's value stays intact and readable for any ciphertext still
depending on it.

This closes two defense-in-depth gaps from the July security review, ahead of
key rotation becoming default-on for every instance in v3. Neither gap is
exploitable today — both fail safe already — this is hardening, not a fix for
a live issue.

## How to test manually

1. `cd packages/cli`
2. `pnpm test key-manager.service.test.ts` — unit tests, including a new test
   that asserts `markInactive` never calls a destructive repository method.
3. `pnpm test:integration get-key-by-id-type-scope.integration.test.ts` — a
   new integration test against a real test database. It seeds a
   `jwe.private-key` row and a `signing.hmac` row, then calls `getKeyById`
   with each row's real id and asserts `null` — proving the type filter at
   the SQL level, not just that the service passes the right arguments to a
   mock.
4. `pnpm test:integration key-rotation-cycle.integration.test.ts` — confirms
   the existing rotate/encrypt/decrypt cycle still works unchanged.

## Key implementation decisions

- The ticket's original proposal for `markInactive` was a usage-count check
  against ciphertext still referencing a key. No table or column in the
  schema tracks which rows were encrypted with which key id — the id only
  ever appears embedded as a literal prefix inside ciphertext values, across
  dozens of tables (credentials, executions, MFA, SSO, dynamic credentials,
  external secrets, and more). Building a real usage count would mean either
  a new counter bumped on every encrypt call (a write on every hot-path
  encrypt operation) or an incomplete per-table scan. Given `markInactive`
  already cannot delete a key — the repository's delete surface is fully
  locked down — the data-loss concern is already covered without that
  mechanism, so this PR documents and locks in that existing guarantee
  instead of building a new one.

## Related links

- Linear: https://linear.app/n8n/issue/IAM-1111

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

