### PR TITLE
fix(Microsoft SharePoint Node): Keep the resource dropdowns working when the API omits a label

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/methods/listSearch.test.ts
@@ -532,5 +532,107 @@ describe('Microsoft SharePoint Node', () => {
 				],
 			});
 		});
+
+		it('labels a site without a title by its ID instead of failing the list', async () => {
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [
+					{ id: 'mydomain.sharepoint.com,site-b,web-b', title: 'Site B' },
+					{ id: 'mydomain.sharepoint.com,site-a,web-a' },
+				],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getSites.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{
+					name: 'mydomain.sharepoint.com,site-a,web-a',
+					value: 'mydomain.sharepoint.com,site-a,web-a',
+				},
+				{ name: 'Site B', value: 'mydomain.sharepoint.com,site-b,web-b' },
+			]);
+		});
+
+		it.each([
+			['getSites', []],
+			['getLists', ['site']],
+			['getItems', ['site', 'list']],
+			['getFiles', ['site', 'folder']],
+			['getFolders', ['site']],
+		] as const)('returns no results when %s gets no collection back', async (method, params) => {
+			for (const param of params) {
+				loadOptionsFunctions.getNodeParameter.mockReturnValueOnce(param);
+			}
+			mockRequestWithAuthentication.mockReturnValue({
+				error: { code: 'invalidRequest', message: 'Bad request' },
+			});
+
+			const listSearchResult = await node.methods.listSearch[method].call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([]);
+		});
+
+		it('labels a list without a display name by its ID', async () => {
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('site');
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [{ id: 'zz-list', displayName: 'Alpha' }, { id: 'mm-list' }],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getLists.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{ name: 'Alpha', value: 'zz-list' },
+				{ name: 'mm-list', value: 'mm-list' },
+			]);
+		});
+
+		it('labels an item without a fields object by its ID', async () => {
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('site');
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('list');
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [{ id: '2', fields: { Title: 'Title 2' } }, { id: '1' }],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getItems.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{ name: '1', value: '1' },
+				{ name: 'Title 2', value: '2' },
+			]);
+		});
+
+		it('labels a folder without a name by its ID', async () => {
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('site');
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [
+					{ id: 'folder-b', name: 'folder-b-docs', folder: {} },
+					{ id: 'folder-a', folder: {} },
+				],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getFolders.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{ name: 'folder-a', value: 'folder-a' },
+				{ name: 'folder-b-docs', value: 'folder-b' },
+			]);
+		});
+
+		it('labels a file without a name by its ID', async () => {
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('site');
+			loadOptionsFunctions.getNodeParameter.mockReturnValueOnce('folder');
+			mockRequestWithAuthentication.mockReturnValue({
+				value: [
+					{ id: 'file-b', name: 'file-b.txt', file: {} },
+					{ id: 'file-a', file: {} },
+				],
+			});
+
+			const listSearchResult = await node.methods.listSearch.getFiles.call(loadOptionsFunctions);
+
+			expect(listSearchResult.results).toEqual([
+				{ name: 'file-a', value: 'file-a' },
+				{ name: 'file-b.txt', value: 'file-b' },
+			]);
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v1/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v1/helpers/interfaces.ts
@@ -16,26 +16,26 @@ export interface IListColumnType {
 
 export interface IDriveItem {
 	id: string;
-	name: string;
+	name?: string;
 	file?: IDataObject;
 	folder?: IDataObject;
 }
 
 export interface IListItem {
 	id: string;
-	fields: {
-		Title: string;
+	fields?: {
+		Title?: string;
 	};
 }
 
 export interface IList {
 	id: string;
-	displayName: string;
+	displayName?: string;
 }
 
 export interface ISite {
 	id: string;
-	title: string;
+	title?: string;
 }
 
 export interface IErrorResponse {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v1/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v1/methods/listSearch.ts
@@ -46,12 +46,12 @@ export async function getFiles(
 		);
 	}
 
-	const items: IDriveItem[] = response.value;
+	const items: IDriveItem[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = items
 		.filter((x) => x.file)
 		.map((g) => ({
-			name: g.name,
+			name: g.name ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -95,12 +95,12 @@ export async function getFolders(
 		);
 	}
 
-	const items: IDriveItem[] = response.value;
+	const items: IDriveItem[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = items
 		.filter((x) => x.folder && (!filter || x.name?.toLowerCase()?.includes?.(filter.toLowerCase())))
 		.map((g) => ({
-			name: g.name,
+			name: g.name ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -146,11 +146,11 @@ export async function getItems(
 		);
 	}
 
-	const items: IListItem[] = response.value;
+	const items: IListItem[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = items
 		.map((g) => ({
-			name: g.fields.Title ?? g.id,
+			name: g.fields?.Title ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -194,11 +194,11 @@ export async function getLists(
 		);
 	}
 
-	const lists: IList[] = response.value;
+	const lists: IList[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = lists
 		.map((g) => ({
-			name: g.displayName,
+			name: g.displayName ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>
@@ -235,11 +235,11 @@ export async function getSites(
 		response = await microsoftSharePointApiRequest.call(this, 'GET', '/sites', {}, qs);
 	}
 
-	const sites: ISite[] = response.value;
+	const sites: ISite[] = response.value ?? [];
 
 	const results: INodeListSearchItems[] = sites
 		.map((g) => ({
-			name: g.title,
+			name: g.title ?? g.id,
 			value: g.id,
 		}))
 		.sort((a, b) =>


### PR DESCRIPTION
## Summary

The v1 list-search methods label each dropdown row with a field the SharePoint API can omit, then sort on that label. One row without a label makes the sort comparator throw, so the whole dropdown fails with **"Could not load list - Cannot read properties of undefined (reading 'localeCompare')"**. An Enterprise customer on 2.33.7 hits this on the Site field, where the `_api/v2.0/sites` search omits `title` for a site with a blank title. The fix mirrors v2 in all five v1 methods: fall back to the row id when the label is absent, and treat a response without `value` as empty. `defaultVersion` moved to 2 in 2.37.0 (#36459), but saved nodes keep their `typeVersion`, so v1 needs its own fix.

The omitted `title` is inferred from the SharePoint `SiteTitle` search property, which the server nulls for a blank title; the customer's `/sites` payload requested on 9 Sep is still outstanding. The Excel `FileOpenUserUnauthorized` half of ENT-416 is out of scope here; its cause is not established.

## How to test

1. `cd packages/nodes-base && pnpm test nodes/Microsoft/SharePoint`
2. On a tenant with a title-less site, open a SharePoint node with `typeVersion: 1`, set Site to "From List", and confirm the dropdown loads with that site labelled by its id.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-416

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

