### PR TITLE
fix(core): Return Instance AI node output grouped per output branch

### DIFF
--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -575,7 +575,9 @@ Get the output data of a specific node from an execution.
 
 **Returns**: `{ nodeName, outputs: [{ index, name?, totalItems, items }], totalItems, returned: { from, to } }`.
 One `outputs` entry per node output, in output order; a Filter reports `Kept` and
-`Discarded` separately. `totalItems` and `returned` count across all outputs.
+`Discarded` separately. `name` follows the node's output pane labels, including
+renamed Switch outputs and `Success` / `Error` for nodes that route errors to an
+extra output. `totalItems` and `returned` count across all outputs.
 
 ### `executions(action="get-resolved-node-parameters")`
 

--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -573,7 +573,9 @@ Get the output data of a specific node from an execution.
 | `startIndex` | number | no | First item index to return. Defaults to `0` |
 | `maxItems` | number | no | Maximum items to return. Defaults to `10`; maximum `50` |
 
-**Returns**: `{ nodeName, data?, error? }`
+**Returns**: `{ nodeName, outputs: [{ index, name?, totalItems, items }], totalItems, returned: { from, to } }`.
+One `outputs` entry per node output, in output order; a Filter reports `Kept` and
+`Discarded` separately. `totalItems` and `returned` count across all outputs.
 
 ### `executions(action="get-resolved-node-parameters")`
 

--- a/packages/@n8n/instance-ai/evaluations/harness/stub-services.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/stub-services.ts
@@ -253,7 +253,7 @@ export async function createStubServices(
 		async getNodeOutput(_executionId: string, nodeName: string) {
 			return {
 				nodeName,
-				items: [],
+				outputs: [],
 				totalItems: 0,
 				returned: { from: 0, to: 0 },
 			};

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -685,6 +685,7 @@ export type {
 	WorkflowVersionDetail,
 	ExecutionResult,
 	ExecutionDebugInfo,
+	NodeOutputBranch,
 	NodeOutputResult,
 	ResolvedNodeParametersResult,
 	ResolvedParametersDebugBundle,

--- a/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
@@ -741,7 +741,7 @@ describe('executions tool', () => {
 		it('should call executionService.getNodeOutput with parameters', async () => {
 			const nodeOutput = {
 				nodeName: 'Set',
-				items: [{ key: 'value' }],
+				outputs: [{ index: 0, totalItems: 1, items: [{ key: 'value' }] }],
 				totalItems: 1,
 				returned: { from: 0, to: 0 },
 			};
@@ -772,7 +772,7 @@ describe('executions tool', () => {
 			const context = createMockContext();
 			(context.executionService.getNodeOutput as Mock).mockResolvedValue({
 				nodeName: 'Set',
-				items: [],
+				outputs: [],
 				totalItems: 0,
 				returned: { from: 0, to: 0 },
 			});

--- a/packages/@n8n/instance-ai/src/tools/executions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions.tool.ts
@@ -88,7 +88,9 @@ const debugAction = z.object({
 const getNodeOutputAction = z.object({
 	action: z
 		.literal('get-node-output')
-		.describe('Retrieve raw output of a specific node from an execution'),
+		.describe(
+			"Retrieve raw output of a specific node from an execution, grouped per output (e.g. a Filter's Kept and Discarded). Only an output wired to a downstream node feeds it.",
+		),
 	executionId: z.string().describe('Execution ID'),
 	nodeName: z.string().describe("Name of the node (must exist in the execution's workflow)"),
 	startIndex: z.number().int().min(0).optional().describe('Item index to start from (default 0)'),

--- a/packages/@n8n/instance-ai/src/tools/executions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions.tool.ts
@@ -89,7 +89,7 @@ const getNodeOutputAction = z.object({
 	action: z
 		.literal('get-node-output')
 		.describe(
-			"Retrieve raw output of a specific node from an execution, grouped per output (e.g. a Filter's Kept and Discarded). Only an output wired to a downstream node feeds it.",
+			"Retrieve raw output of a specific node from an execution, grouped per output (e.g. a Filter's Kept and Discarded). All outputs are listed, including outputs with no downstream connection; only items on a connected output continue through the workflow.",
 		),
 	executionId: z.string().describe('Execution ID'),
 	nodeName: z.string().describe("Name of the node (must exist in the execution's workflow)"),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
@@ -894,6 +894,38 @@ describe('verify-built-workflow tool', () => {
 		).toBe(14);
 	});
 
+	it('reports per-output counts for a multi-output node', async () => {
+		const { ctx, updateBuildOutcome } = makeContext(makeBuildOutcome(), {
+			executionId: 'exec-outputs',
+			status: 'success',
+			data: {
+				Filter: wrapExecutionOutput({
+					outputs: [
+						{ index: 0, name: 'Kept', items: [{ id: 1 }] },
+						{ index: 1, name: 'Discarded', items: [{ id: 2 }, { id: 3 }] },
+					],
+					totalItems: 3,
+				}),
+			},
+		});
+
+		const result = await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(result.nodePreviews).toEqual([
+			expect.objectContaining({
+				nodeName: 'Filter',
+				itemCount: 3,
+				outputs: [
+					{ index: 0, name: 'Kept', itemCount: 1 },
+					{ index: 1, name: 'Discarded', itemCount: 2 },
+				],
+			}),
+		]);
+		expect(
+			updateBuildOutcome.mock.calls.at(-1)![1].verification?.evidence?.producedOutputRows,
+		).toBe(3);
+	});
+
 	it('treats a waiting status with output as a successful run (e.g. Form Trigger response page)', async () => {
 		const { ctx, updateBuildOutcome } = makeContext(makeBuildOutcome(), {
 			executionId: 'exec-form-1',

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
@@ -90,6 +90,17 @@ function countOutputItems(nodeOutput: unknown): number | undefined {
 	return 1;
 }
 
+/** Per-output counts when the adapter grouped a multi-output node's items per output. */
+function countOutputBranchItems(nodeOutput: unknown): VerificationNodePreview['outputs'] {
+	const output = outputForInspection(nodeOutput);
+	if (!isRecord(output) || !Array.isArray(output.outputs)) return undefined;
+	return output.outputs.filter(isRecord).map((branch, position) => ({
+		index: typeof branch.index === 'number' ? branch.index : position,
+		...(typeof branch.name === 'string' ? { name: branch.name } : {}),
+		itemCount: countOutputItems(branch.items),
+	}));
+}
+
 function previewValue(value: unknown, maxChars: number): { preview: string; truncated: boolean } {
 	const serialized = stringifyForToolOutput(value);
 	if (maxChars <= 0) {
@@ -111,9 +122,11 @@ export function buildNodePreviews(
 	return Object.entries(resultData).map(([nodeName, nodeOutput]) => {
 		const serialized = stringifyForToolOutput(nodeOutput);
 		const preview = previewValue(nodeOutput, maxChars);
+		const outputs = countOutputBranchItems(nodeOutput);
 		return {
 			nodeName,
 			itemCount: countOutputItems(nodeOutput),
+			...(outputs ? { outputs } : {}),
 			preview: preview.preview,
 			truncated: preview.truncated,
 			chars: serialized.length,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/types.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/types.ts
@@ -33,6 +33,8 @@ export type ExecutionRunResult = Awaited<
 export interface VerificationNodePreview {
 	nodeName: string;
 	itemCount?: number;
+	/** Per-output counts for multi-output nodes (Filter, IF, Switch); `itemCount` sums them. */
+	outputs?: Array<{ index: number; name?: string; itemCount?: number }>;
 	preview: string;
 	truncated: boolean;
 	chars: number;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
@@ -131,6 +131,15 @@ const verifyBuiltWorkflowOutputSchema = z.object({
 			z.object({
 				nodeName: z.string(),
 				itemCount: z.number().optional(),
+				outputs: z
+					.array(
+						z.object({
+							index: z.number(),
+							name: z.string().optional(),
+							itemCount: z.number().optional(),
+						}),
+					)
+					.optional(),
 				preview: z.string(),
 				truncated: z.boolean(),
 				chars: z.number(),

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -173,7 +173,7 @@ export interface ExecutionResult {
 export interface NodeOutputBranch {
 	/** Position of the output on the node; 0 is the first output. */
 	index: number;
-	/** Label the canvas shows for the output, e.g. a Filter's "Kept" / "Discarded". */
+	/** Label the node's output pane shows for the output, e.g. a Filter's "Kept" / "Discarded". */
 	name?: string;
 	/** Item count on this output, before pagination. */
 	totalItems: number;
@@ -184,8 +184,8 @@ export interface NodeOutputResult {
 	nodeName: string;
 	/**
 	 * One entry per output of the node's last run, in output order. Multi-output
-	 * nodes (Filter, IF, Switch) route each output to a different downstream
-	 * node, so their items are never merged into one list.
+	 * nodes (Filter, IF, Switch) keep each output separate, so their items are
+	 * never merged into one list.
 	 */
 	outputs: NodeOutputBranch[];
 	/** Item count across all outputs. */

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -170,10 +170,27 @@ export interface ExecutionResult {
 	finishedAt?: string;
 }
 
+export interface NodeOutputBranch {
+	/** Position of the output on the node; 0 is the first output. */
+	index: number;
+	/** Label the canvas shows for the output, e.g. a Filter's "Kept" / "Discarded". */
+	name?: string;
+	/** Item count on this output, before pagination. */
+	totalItems: number;
+	items: unknown[];
+}
+
 export interface NodeOutputResult {
 	nodeName: string;
-	items: unknown[];
+	/**
+	 * One entry per output of the node's last run, in output order. Multi-output
+	 * nodes (Filter, IF, Switch) route each output to a different downstream
+	 * node, so their items are never merged into one list.
+	 */
+	outputs: NodeOutputBranch[];
+	/** Item count across all outputs. */
 	totalItems: number;
+	/** Page position over the items of all outputs, first output first. */
 	returned: { from: number; to: number };
 }
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -199,11 +199,14 @@ function makeTaskData(
 	} as unknown as ITaskData;
 }
 
-/** Build a task data entry for a multi-output node, one item list per output. */
-function makeMultiOutputTaskData(outputs: IDataObject[][]): ITaskData {
+/**
+ * Build a task data entry for a multi-output node, one item list per output.
+ * `null` marks an output that never received data.
+ */
+function makeMultiOutputTaskData(outputs: Array<IDataObject[] | null>): ITaskData {
 	return {
 		...makeTaskData([]),
-		data: { main: outputs.map((items) => items.map((json) => ({ json }))) },
+		data: { main: outputs.map((items) => items?.map((json) => ({ json })) ?? null) },
 	};
 }
 
@@ -408,6 +411,26 @@ describe('extractExecutionResult', () => {
 				{ index: 1, name: 'Error', items: [{ error: 'timeout' }] },
 			],
 			totalItems: 2,
+		});
+	});
+
+	it('reports a null output as empty', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				runData: { Filter: [makeMultiOutputTaskData([null, [{ id: 1 }]])] },
+			}),
+		);
+
+		const result = await extractExecutionResult('exec-1', true);
+
+		const wrapped = result.data!.Filter as string;
+		expect(JSON.parse(wrapped.split('\n').slice(1, -1).join('\n'))).toEqual({
+			outputs: [
+				{ index: 0, items: [] },
+				{ index: 1, items: [{ id: 1 }] },
+			],
+			totalItems: 1,
 		});
 	});
 
@@ -1386,6 +1409,21 @@ describe('extractNodeOutput', () => {
 		expect(result.outputs[1]).toMatchObject({ index: 1, totalItems: 2 });
 		expect(result.outputs[1].items).toHaveLength(2);
 		expect(result.outputs[1]).not.toHaveProperty('name');
+	});
+
+	it('lists a null output as empty', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				runData: { Filter: [makeMultiOutputTaskData([null, [{ id: 1 }]])] },
+			}),
+		);
+
+		const result = await extractNodeOutput('exec-1', 'Filter');
+
+		expect(result.totalItems).toBe(1);
+		expect(result.outputs[0]).toEqual({ index: 0, totalItems: 0, items: [] });
+		expect(result.outputs[1].items[0]).toContain('"id": 1');
 	});
 
 	it('paginates across outputs as one sequence', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -56,6 +56,7 @@ import { Expression } from 'n8n-workflow';
 import type {
 	ExecutionError,
 	IConnections,
+	IDataObject,
 	INode,
 	INodeParameters,
 	IPinData,
@@ -196,6 +197,23 @@ function makeTaskData(
 	} as unknown as ITaskData;
 }
 
+/** Build a task data entry for a multi-output node, one item list per output. */
+function makeMultiOutputTaskData(outputs: IDataObject[][]): ITaskData {
+	return {
+		...makeTaskData([]),
+		data: { main: outputs.map((items) => items.map((json) => ({ json }))) },
+	};
+}
+
+/** Node types that resolve every node to a two-output Filter (Kept / Discarded). */
+function filterNodeTypes(): NodeTypes {
+	const nodeTypes = mock<NodeTypes>();
+	nodeTypes.getByNameAndVersion.mockReturnValue({
+		description: { outputNames: ['Kept', 'Discarded'] },
+	} as never);
+	return nodeTypes;
+}
+
 // ---------------------------------------------------------------------------
 // extractExecutionResult
 // ---------------------------------------------------------------------------
@@ -329,6 +347,29 @@ describe('extractExecutionResult', () => {
 		expect(result.data!['Set Node']).toContain('<untrusted_data');
 		expect(result.data!['Set Node']).toContain('"id": 1');
 		expect(result.data!['Set Node']).toContain('"name": "Alice"');
+	});
+
+	it('groups the output data of a multi-output node per output', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [{ name: 'Filter', type: 'n8n-nodes-base.filter' }],
+				runData: {
+					Filter: [makeMultiOutputTaskData([[{ text: '$TSLA' }], [{ text: 'plain' }]])],
+				},
+			}),
+		);
+
+		const result = await extractExecutionResult('exec-1', true, filterNodeTypes());
+
+		const wrapped = result.data!.Filter as string;
+		expect(JSON.parse(wrapped.split('\n').slice(1, -1).join('\n'))).toEqual({
+			outputs: [
+				{ index: 0, name: 'Kept', items: [{ text: '$TSLA' }] },
+				{ index: 1, name: 'Discarded', items: [{ text: 'plain' }] },
+			],
+			totalItems: 2,
+		});
 	});
 
 	it('excludes node output data when includeOutputData is false', async () => {
@@ -714,6 +755,33 @@ describe('truncateResultData', () => {
 		const result = truncateResultData(data);
 
 		expect(result['Empty Node']).toEqual([]);
+	});
+
+	it('collapses the item arrays of each output for a multi-output node', () => {
+		const bigItems = Array.from({ length: 200 }, (_, i) => ({ id: i, data: 'x'.repeat(300) }));
+		const data: Record<string, unknown> = {
+			Filter: {
+				outputs: [
+					{ index: 0, name: 'Kept', items: bigItems },
+					{ index: 1, name: 'Discarded', items: [] },
+				],
+				totalItems: 200,
+			},
+		};
+
+		const result = truncateResultData(data);
+
+		expect(result.Filter).toEqual({
+			outputs: [
+				{
+					index: 0,
+					name: 'Kept',
+					items: { _itemCount: 200, _truncated: true, _firstItemPreview: bigItems[0] },
+				},
+				{ index: 1, name: 'Discarded', items: [] },
+			],
+			totalItems: 200,
+		});
 	});
 });
 
@@ -1147,7 +1215,7 @@ describe('extractNodeOutput', () => {
 
 		expect(result.nodeName).toBe('Set Node');
 		expect(result.totalItems).toBe(25);
-		expect(result.items).toHaveLength(10); // default maxItems
+		expect(result.outputs[0].items).toHaveLength(10); // default maxItems
 		expect(result.returned).toEqual({ from: 0, to: 10 });
 	});
 
@@ -1163,11 +1231,11 @@ describe('extractNodeOutput', () => {
 		const result = await extractNodeOutput('exec-1', 'Set Node', { startIndex: 10, maxItems: 5 });
 
 		expect(result.totalItems).toBe(25);
-		expect(result.items).toHaveLength(5);
+		expect(result.outputs[0].items).toHaveLength(5);
 		expect(result.returned).toEqual({ from: 10, to: 15 });
 		// Items are wrapped in untrusted-data boundary tags
-		expect(result.items[0]).toContain('<untrusted_data');
-		expect(result.items[0]).toContain('"id": 10');
+		expect(result.outputs[0].items[0]).toContain('<untrusted_data');
+		expect(result.outputs[0].items[0]).toContain('"id": 10');
 	});
 
 	it('caps maxItems at 50', async () => {
@@ -1181,7 +1249,7 @@ describe('extractNodeOutput', () => {
 
 		const result = await extractNodeOutput('exec-1', 'Set Node', { maxItems: 100 });
 
-		expect(result.items).toHaveLength(50);
+		expect(result.outputs[0].items).toHaveLength(50);
 		expect(result.returned).toEqual({ from: 0, to: 50 });
 	});
 
@@ -1197,9 +1265,9 @@ describe('extractNodeOutput', () => {
 		const result = await extractNodeOutput('exec-1', 'Big Node');
 
 		expect(result.totalItems).toBe(1);
-		expect(result.items).toHaveLength(1);
+		expect(result.outputs[0].items).toHaveLength(1);
 		// Items are wrapped in untrusted-data boundary tags after truncation
-		const wrapped = result.items[0] as string;
+		const wrapped = result.outputs[0].items[0] as string;
 		expect(wrapped).toContain('<untrusted_data');
 		expect(wrapped).toContain('_truncatedItem');
 		expect(wrapped).toContain('"originalLength"');
@@ -1237,8 +1305,72 @@ describe('extractNodeOutput', () => {
 		const result = await extractNodeOutput('exec-1', 'Node', { startIndex: 100 });
 
 		expect(result.totalItems).toBe(1);
-		expect(result.items).toHaveLength(0);
+		expect(result.outputs[0].items).toHaveLength(0);
 		expect(result.returned).toEqual({ from: 100, to: 100 });
+	});
+
+	it('reports each output of a multi-output node separately, with the node type labels', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [{ name: 'Filter', type: 'n8n-nodes-base.filter' }],
+				runData: {
+					Filter: [makeMultiOutputTaskData([[{ text: '$TSLA' }], [{ text: 'plain' }]])],
+				},
+			}),
+		);
+
+		const result = await extractNodeOutput('exec-1', 'Filter', undefined, filterNodeTypes());
+
+		expect(result.totalItems).toBe(2);
+		expect(result.returned).toEqual({ from: 0, to: 2 });
+		expect(result.outputs).toEqual([
+			expect.objectContaining({ index: 0, name: 'Kept', totalItems: 1 }),
+			expect.objectContaining({ index: 1, name: 'Discarded', totalItems: 1 }),
+		]);
+		expect(result.outputs[0].items[0]).toContain('"text": "$TSLA"');
+		expect(result.outputs[1].items[0]).toContain('"text": "plain"');
+	});
+
+	it('lists an output that received no items and omits names without node types', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				runData: { Filter: [makeMultiOutputTaskData([[], [{ id: 1 }, { id: 2 }]])] },
+			}),
+		);
+
+		const result = await extractNodeOutput('exec-1', 'Filter');
+
+		expect(result.totalItems).toBe(2);
+		expect(result.outputs[0]).toEqual({ index: 0, totalItems: 0, items: [] });
+		expect(result.outputs[1]).toMatchObject({ index: 1, totalItems: 2 });
+		expect(result.outputs[1].items).toHaveLength(2);
+		expect(result.outputs[1]).not.toHaveProperty('name');
+	});
+
+	it('paginates across outputs as one sequence', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				runData: {
+					Filter: [
+						makeMultiOutputTaskData([
+							[{ id: 0 }, { id: 1 }],
+							[{ id: 2 }, { id: 3 }],
+						]),
+					],
+				},
+			}),
+		);
+
+		const result = await extractNodeOutput('exec-1', 'Filter', { startIndex: 1, maxItems: 2 });
+
+		expect(result.returned).toEqual({ from: 1, to: 3 });
+		expect(result.outputs[0].items).toHaveLength(1);
+		expect(result.outputs[0].items[0]).toContain('"id": 1');
+		expect(result.outputs[1].items).toHaveLength(1);
+		expect(result.outputs[1].items[0]).toContain('"id": 2');
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -52,13 +52,14 @@ import type { PolicyCleared } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { generateWorkflowCode, parseWorkflowCode } from '@n8n/workflow-sdk';
 import { mock } from 'vitest-mock-extended';
-import { Expression } from 'n8n-workflow';
+import { Expression, NodeConnectionTypes } from 'n8n-workflow';
 import type {
 	ExecutionError,
 	IConnections,
 	IDataObject,
 	INode,
 	INodeParameters,
+	INodeTypeDescription,
 	IPinData,
 	IRunExecutionData,
 	ITaskData,
@@ -163,6 +164,7 @@ function makeExecution(
 		stoppedAt: overrides.stoppedAt ?? new Date('2026-01-01T00:01:00Z'),
 		workflowData: {
 			nodes: overrides.workflowNodes ?? [],
+			connections: {},
 		},
 		data: {
 			resultData: {
@@ -205,13 +207,20 @@ function makeMultiOutputTaskData(outputs: IDataObject[][]): ITaskData {
 	};
 }
 
-/** Node types that resolve every node to a two-output Filter (Kept / Discarded). */
-function filterNodeTypes(): NodeTypes {
+/** Node types that resolve every node to the given description. */
+function nodeTypesWith(description: Partial<INodeTypeDescription>): NodeTypes {
 	const nodeTypes = mock<NodeTypes>();
-	nodeTypes.getByNameAndVersion.mockReturnValue({
-		description: { outputNames: ['Kept', 'Discarded'] },
-	} as never);
+	nodeTypes.getByNameAndVersion.mockReturnValue({ description } as never);
 	return nodeTypes;
+}
+
+/** Node types that resolve every node to a Filter: one declared output, two output names. */
+function filterNodeTypes(): NodeTypes {
+	return nodeTypesWith({
+		properties: [],
+		outputs: [NodeConnectionTypes.Main],
+		outputNames: ['Kept', 'Discarded'],
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -367,6 +376,36 @@ describe('extractExecutionResult', () => {
 			outputs: [
 				{ index: 0, name: 'Kept', items: [{ text: '$TSLA' }] },
 				{ index: 1, name: 'Discarded', items: [{ text: 'plain' }] },
+			],
+			totalItems: 2,
+		});
+	});
+
+	it('labels the Success and Error outputs of a node that routes errors to an extra output', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [
+					{
+						name: 'HTTP Request',
+						type: 'n8n-nodes-base.httpRequest',
+						onError: 'continueErrorOutput',
+					},
+				],
+				runData: {
+					'HTTP Request': [makeMultiOutputTaskData([[{ id: 1 }], [{ error: 'timeout' }]])],
+				},
+			}),
+		);
+		const nodeTypes = nodeTypesWith({ properties: [], outputs: [NodeConnectionTypes.Main] });
+
+		const result = await extractExecutionResult('exec-1', true, nodeTypes);
+
+		const wrapped = result.data!['HTTP Request'] as string;
+		expect(JSON.parse(wrapped.split('\n').slice(1, -1).join('\n'))).toEqual({
+			outputs: [
+				{ index: 0, name: 'Success', items: [{ id: 1 }] },
+				{ index: 1, name: 'Error', items: [{ error: 'timeout' }] },
 			],
 			totalItems: 2,
 		});
@@ -1371,6 +1410,90 @@ describe('extractNodeOutput', () => {
 		expect(result.outputs[0].items[0]).toContain('"id": 1');
 		expect(result.outputs[1].items).toHaveLength(1);
 		expect(result.outputs[1].items[0]).toContain('"id": 2');
+	});
+
+	it('prefers the displayName of a declared output over outputNames', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [{ name: 'Router', type: 'test.router' }],
+				runData: { Router: [makeMultiOutputTaskData([[{ id: 1 }], [{ id: 2 }]])] },
+			}),
+		);
+		const nodeTypes = nodeTypesWith({
+			properties: [],
+			outputs: [
+				{ type: 'main', displayName: 'Premium' },
+				{ type: 'main', displayName: 'Fallback' },
+			],
+			outputNames: ['a', 'b'],
+		});
+
+		const result = await extractNodeOutput('exec-1', 'Router', undefined, nodeTypes);
+
+		expect(result.outputs.map((output) => output.name)).toEqual(['Premium', 'Fallback']);
+	});
+
+	it('resolves an outputs expression to its display names', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [{ name: 'Switch', type: 'n8n-nodes-base.switch' }],
+				runData: { Switch: [makeMultiOutputTaskData([[{ id: 1 }], [{ id: 2 }]])] },
+			}),
+		);
+		const nodeTypes = nodeTypesWith({
+			properties: [],
+			outputs: "={{ [{ type: 'main', displayName: 'A' }, { type: 'main', displayName: 'B' }] }}",
+		});
+
+		const result = await extractNodeOutput('exec-1', 'Switch', undefined, nodeTypes);
+
+		expect(result.outputs.map((output) => output.name)).toEqual(['A', 'B']);
+	});
+
+	it('labels the outputs Success and Error when the node routes errors to an extra output', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [
+					{
+						name: 'HTTP Request',
+						type: 'n8n-nodes-base.httpRequest',
+						onError: 'continueErrorOutput',
+					},
+				],
+				runData: {
+					'HTTP Request': [makeMultiOutputTaskData([[{ id: 1 }], [{ error: 'timeout' }]])],
+				},
+			}),
+		);
+		const nodeTypes = nodeTypesWith({ properties: [], outputs: [NodeConnectionTypes.Main] });
+
+		const result = await extractNodeOutput('exec-1', 'HTTP Request', undefined, nodeTypes);
+
+		expect(result.outputs.map((output) => output.name)).toEqual(['Success', 'Error']);
+	});
+
+	it('returns index-only outputs when the node type is unknown', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [{ name: 'Filter', type: 'n8n-nodes-community.missing' }],
+				runData: { Filter: [makeMultiOutputTaskData([[{ id: 1 }], [{ id: 2 }]])] },
+			}),
+		);
+		const nodeTypes = mock<NodeTypes>();
+		nodeTypes.getByNameAndVersion.mockImplementation(() => {
+			throw new Error('Unrecognized node type');
+		});
+
+		const result = await extractNodeOutput('exec-1', 'Filter', undefined, nodeTypes);
+
+		expect(result.outputs).toEqual([
+			{ index: 0, totalItems: 1, items: [expect.stringContaining('"id": 1')] },
+			{ index: 1, totalItems: 1, items: [expect.stringContaining('"id": 2')] },
+		]);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -144,6 +144,9 @@ function createMockExecutionRepository(
 	};
 }
 
+/** The subset of a workflow node the adapter helpers read. */
+type WorkflowNode = { name: string; type: string; onError?: string };
+
 /** Build a minimal execution object that satisfies the shape read by the adapter helpers. */
 function makeExecution(
 	overrides: {
@@ -153,7 +156,7 @@ function makeExecution(
 		runData?: Record<string, ITaskData[]>;
 		pinData?: IPinData;
 		error?: Partial<ExecutionError>;
-		workflowNodes?: Array<{ name: string; type: string; onError?: string }>;
+		workflowNodes?: WorkflowNode[];
 	} = {},
 ) {
 	const runData = overrides.runData ?? {};
@@ -199,31 +202,39 @@ function makeTaskData(
 	} as unknown as ITaskData;
 }
 
+const FILTER_NODE: WorkflowNode = { name: 'Filter', type: 'n8n-nodes-base.filter' };
+
 /**
- * Build a task data entry for a multi-output node, one item list per output.
- * `null` marks an output that never received data.
+ * Mock an execution where `node` ran once and emitted `outputs`, one item list
+ * per output. `null` marks an output that never received data.
  */
-function makeMultiOutputTaskData(outputs: Array<IDataObject[] | null>): ITaskData {
-	return {
-		...makeTaskData([]),
-		data: { main: outputs.map((items) => items?.map((json) => ({ json })) ?? null) },
-	};
+function mockMultiOutputRun(outputs: Array<IDataObject[] | null>, node = FILTER_NODE) {
+	const main = outputs.map((items) => items?.map((json) => ({ json })) ?? null);
+	createMockExecutionRepository(
+		makeExecution({
+			workflowNodes: [node],
+			runData: { [node.name]: [{ ...makeTaskData([]), data: { main } }] },
+		}),
+	);
 }
 
-/** Node types that resolve every node to the given description. */
+/** Node types that resolve every node to the given description. `new Workflow` needs `properties`. */
 function nodeTypesWith(description: Partial<INodeTypeDescription>): NodeTypes {
 	const nodeTypes = mock<NodeTypes>();
-	nodeTypes.getByNameAndVersion.mockReturnValue({ description } as never);
+	nodeTypes.getByNameAndVersion.mockReturnValue({
+		description: { properties: [], ...description },
+	} as never);
 	return nodeTypes;
 }
 
 /** Node types that resolve every node to a Filter: one declared output, two output names. */
 function filterNodeTypes(): NodeTypes {
-	return nodeTypesWith({
-		properties: [],
-		outputs: [NodeConnectionTypes.Main],
-		outputNames: ['Kept', 'Discarded'],
-	});
+	return nodeTypesWith({ outputs: [NodeConnectionTypes.Main], outputNames: ['Kept', 'Discarded'] });
+}
+
+/** Parse the JSON the adapter wrapped in untrusted-data boundary tags. */
+function unwrapJson(wrapped: unknown): unknown {
+	return JSON.parse(String(wrapped).split('\n').slice(1, -1).join('\n'));
 }
 
 // ---------------------------------------------------------------------------
@@ -362,20 +373,11 @@ describe('extractExecutionResult', () => {
 	});
 
 	it('groups the output data of a multi-output node per output', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				workflowNodes: [{ name: 'Filter', type: 'n8n-nodes-base.filter' }],
-				runData: {
-					Filter: [makeMultiOutputTaskData([[{ text: '$TSLA' }], [{ text: 'plain' }]])],
-				},
-			}),
-		);
+		mockMultiOutputRun([[{ text: '$TSLA' }], [{ text: 'plain' }]]);
 
 		const result = await extractExecutionResult('exec-1', true, filterNodeTypes());
 
-		const wrapped = result.data!.Filter as string;
-		expect(JSON.parse(wrapped.split('\n').slice(1, -1).join('\n'))).toEqual({
+		expect(unwrapJson(result.data!.Filter)).toEqual({
 			outputs: [
 				{ index: 0, name: 'Kept', items: [{ text: '$TSLA' }] },
 				{ index: 1, name: 'Discarded', items: [{ text: 'plain' }] },
@@ -384,48 +386,12 @@ describe('extractExecutionResult', () => {
 		});
 	});
 
-	it('labels the Success and Error outputs of a node that routes errors to an extra output', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				workflowNodes: [
-					{
-						name: 'HTTP Request',
-						type: 'n8n-nodes-base.httpRequest',
-						onError: 'continueErrorOutput',
-					},
-				],
-				runData: {
-					'HTTP Request': [makeMultiOutputTaskData([[{ id: 1 }], [{ error: 'timeout' }]])],
-				},
-			}),
-		);
-		const nodeTypes = nodeTypesWith({ properties: [], outputs: [NodeConnectionTypes.Main] });
-
-		const result = await extractExecutionResult('exec-1', true, nodeTypes);
-
-		const wrapped = result.data!['HTTP Request'] as string;
-		expect(JSON.parse(wrapped.split('\n').slice(1, -1).join('\n'))).toEqual({
-			outputs: [
-				{ index: 0, name: 'Success', items: [{ id: 1 }] },
-				{ index: 1, name: 'Error', items: [{ error: 'timeout' }] },
-			],
-			totalItems: 2,
-		});
-	});
-
 	it('reports a null output as empty', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				runData: { Filter: [makeMultiOutputTaskData([null, [{ id: 1 }]])] },
-			}),
-		);
+		mockMultiOutputRun([null, [{ id: 1 }]]);
 
 		const result = await extractExecutionResult('exec-1', true);
 
-		const wrapped = result.data!.Filter as string;
-		expect(JSON.parse(wrapped.split('\n').slice(1, -1).join('\n'))).toEqual({
+		expect(unwrapJson(result.data!.Filter)).toEqual({
 			outputs: [
 				{ index: 0, items: [] },
 				{ index: 1, items: [{ id: 1 }] },
@@ -1372,155 +1338,106 @@ describe('extractNodeOutput', () => {
 	});
 
 	it('reports each output of a multi-output node separately, with the node type labels', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				workflowNodes: [{ name: 'Filter', type: 'n8n-nodes-base.filter' }],
-				runData: {
-					Filter: [makeMultiOutputTaskData([[{ text: '$TSLA' }], [{ text: 'plain' }]])],
-				},
-			}),
-		);
+		mockMultiOutputRun([[{ text: '$TSLA' }], [{ text: 'plain' }]]);
 
 		const result = await extractNodeOutput('exec-1', 'Filter', undefined, filterNodeTypes());
 
 		expect(result.totalItems).toBe(2);
 		expect(result.returned).toEqual({ from: 0, to: 2 });
 		expect(result.outputs).toEqual([
-			expect.objectContaining({ index: 0, name: 'Kept', totalItems: 1 }),
-			expect.objectContaining({ index: 1, name: 'Discarded', totalItems: 1 }),
+			{
+				index: 0,
+				name: 'Kept',
+				totalItems: 1,
+				items: [expect.stringContaining('"text": "$TSLA"')],
+			},
+			{
+				index: 1,
+				name: 'Discarded',
+				totalItems: 1,
+				items: [expect.stringContaining('"text": "plain"')],
+			},
 		]);
-		expect(result.outputs[0].items[0]).toContain('"text": "$TSLA"');
-		expect(result.outputs[1].items[0]).toContain('"text": "plain"');
 	});
 
-	it('lists an output that received no items and omits names without node types', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				runData: { Filter: [makeMultiOutputTaskData([[], [{ id: 1 }, { id: 2 }]])] },
-			}),
-		);
+	it('lists empty and null outputs as empty, and omits names without node types', async () => {
+		mockMultiOutputRun([[], null, [{ id: 1 }, { id: 2 }]]);
 
 		const result = await extractNodeOutput('exec-1', 'Filter');
 
 		expect(result.totalItems).toBe(2);
-		expect(result.outputs[0]).toEqual({ index: 0, totalItems: 0, items: [] });
-		expect(result.outputs[1]).toMatchObject({ index: 1, totalItems: 2 });
-		expect(result.outputs[1].items).toHaveLength(2);
-		expect(result.outputs[1]).not.toHaveProperty('name');
-	});
-
-	it('lists a null output as empty', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				runData: { Filter: [makeMultiOutputTaskData([null, [{ id: 1 }]])] },
-			}),
-		);
-
-		const result = await extractNodeOutput('exec-1', 'Filter');
-
-		expect(result.totalItems).toBe(1);
-		expect(result.outputs[0]).toEqual({ index: 0, totalItems: 0, items: [] });
-		expect(result.outputs[1].items[0]).toContain('"id": 1');
+		expect(result.outputs).toEqual([
+			{ index: 0, totalItems: 0, items: [] },
+			{ index: 1, totalItems: 0, items: [] },
+			{
+				index: 2,
+				totalItems: 2,
+				items: [expect.stringContaining('"id": 1'), expect.stringContaining('"id": 2')],
+			},
+		]);
 	});
 
 	it('paginates across outputs as one sequence', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				runData: {
-					Filter: [
-						makeMultiOutputTaskData([
-							[{ id: 0 }, { id: 1 }],
-							[{ id: 2 }, { id: 3 }],
-						]),
-					],
-				},
-			}),
-		);
+		mockMultiOutputRun([
+			[{ id: 0 }, { id: 1 }],
+			[{ id: 2 }, { id: 3 }],
+		]);
 
 		const result = await extractNodeOutput('exec-1', 'Filter', { startIndex: 1, maxItems: 2 });
 
 		expect(result.returned).toEqual({ from: 1, to: 3 });
-		expect(result.outputs[0].items).toHaveLength(1);
-		expect(result.outputs[0].items[0]).toContain('"id": 1');
-		expect(result.outputs[1].items).toHaveLength(1);
-		expect(result.outputs[1].items[0]).toContain('"id": 2');
+		expect(result.outputs[0].items).toEqual([expect.stringContaining('"id": 1')]);
+		expect(result.outputs[1].items).toEqual([expect.stringContaining('"id": 2')]);
 	});
 
-	it('prefers the displayName of a declared output over outputNames', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				workflowNodes: [{ name: 'Router', type: 'test.router' }],
-				runData: { Router: [makeMultiOutputTaskData([[{ id: 1 }], [{ id: 2 }]])] },
-			}),
-		);
-		const nodeTypes = nodeTypesWith({
-			properties: [],
-			outputs: [
-				{ type: 'main', displayName: 'Premium' },
-				{ type: 'main', displayName: 'Fallback' },
-			],
-			outputNames: ['a', 'b'],
-		});
-
-		const result = await extractNodeOutput('exec-1', 'Router', undefined, nodeTypes);
-
-		expect(result.outputs.map((output) => output.name)).toEqual(['Premium', 'Fallback']);
-	});
-
-	it('resolves an outputs expression to its display names', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				workflowNodes: [{ name: 'Switch', type: 'n8n-nodes-base.switch' }],
-				runData: { Switch: [makeMultiOutputTaskData([[{ id: 1 }], [{ id: 2 }]])] },
-			}),
-		);
-		const nodeTypes = nodeTypesWith({
-			properties: [],
-			outputs: "={{ [{ type: 'main', displayName: 'A' }, { type: 'main', displayName: 'B' }] }}",
-		});
-
-		const result = await extractNodeOutput('exec-1', 'Switch', undefined, nodeTypes);
-
-		expect(result.outputs.map((output) => output.name)).toEqual(['A', 'B']);
-	});
-
-	it('labels the outputs Success and Error when the node routes errors to an extra output', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				workflowNodes: [
-					{
-						name: 'HTTP Request',
-						type: 'n8n-nodes-base.httpRequest',
-						onError: 'continueErrorOutput',
-					},
+	it.each<{
+		name: string;
+		node?: Partial<WorkflowNode>;
+		description: Partial<INodeTypeDescription>;
+		names: string[];
+	}>([
+		{
+			name: 'prefers the displayName of a declared output over outputNames',
+			description: {
+				outputs: [
+					{ type: NodeConnectionTypes.Main, displayName: 'Premium' },
+					{ type: NodeConnectionTypes.Main, displayName: 'Fallback' },
 				],
-				runData: {
-					'HTTP Request': [makeMultiOutputTaskData([[{ id: 1 }], [{ error: 'timeout' }]])],
-				},
-			}),
+				outputNames: ['a', 'b'],
+			},
+			names: ['Premium', 'Fallback'],
+		},
+		{
+			name: 'resolves an outputs expression to its display names',
+			description: {
+				outputs: "={{ [{ type: 'main', displayName: 'A' }, { type: 'main', displayName: 'B' }] }}",
+			},
+			names: ['A', 'B'],
+		},
+		{
+			name: 'labels the outputs Success and Error when the node routes errors to an extra output',
+			node: { onError: 'continueErrorOutput' },
+			description: { outputs: [NodeConnectionTypes.Main] },
+			names: ['Success', 'Error'],
+		},
+	])('$name', async ({ node, description, names }) => {
+		mockMultiOutputRun([[{ id: 1 }], [{ id: 2 }]], { ...FILTER_NODE, ...node });
+
+		const result = await extractNodeOutput(
+			'exec-1',
+			'Filter',
+			undefined,
+			nodeTypesWith(description),
 		);
-		const nodeTypes = nodeTypesWith({ properties: [], outputs: [NodeConnectionTypes.Main] });
 
-		const result = await extractNodeOutput('exec-1', 'HTTP Request', undefined, nodeTypes);
-
-		expect(result.outputs.map((output) => output.name)).toEqual(['Success', 'Error']);
+		expect(result.outputs.map((output) => output.name)).toEqual(names);
 	});
 
 	it('returns index-only outputs when the node type is unknown', async () => {
-		createMockExecutionRepository(
-			makeExecution({
-				status: 'success',
-				workflowNodes: [{ name: 'Filter', type: 'n8n-nodes-community.missing' }],
-				runData: { Filter: [makeMultiOutputTaskData([[{ id: 1 }], [{ id: 2 }]])] },
-			}),
-		);
+		mockMultiOutputRun([[{ id: 1 }], [{ id: 2 }]], {
+			name: 'Filter',
+			type: 'n8n-nodes-community.missing',
+		});
 		const nodeTypes = mock<NodeTypes>();
 		nodeTypes.getByNameAndVersion.mockImplementation(() => {
 			throw new Error('Unrecognized node type');

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -103,6 +103,7 @@ import {
 	type INodeProperties,
 	type INodeTypeDescription,
 	type IConnections,
+	type IWorkflowBase,
 	type IWorkflowSettings,
 	type IWorkflowExecutionDataProcess,
 	type DataTableRow,
@@ -4112,8 +4113,10 @@ export async function extractExecutionOutcome(
 	// parameter-values privacy setting.
 	const runData = execution.data?.resultData?.runData;
 	const executedNodeNames = Object.keys(runData ?? {});
-	if (includeOutputData) {
-		if (runData) {
+	if (includeOutputData && runData) {
+		const workflow = buildExecutionWorkflow(execution.workflowData, nodeTypes);
+		await workflow?.expression.acquireIsolate();
+		try {
 			for (const [nodeName, nodeRuns] of Object.entries(runData)) {
 				const lastRun = nodeRuns[nodeRuns.length - 1];
 				if (!lastRun?.data?.main) continue;
@@ -4124,12 +4127,9 @@ export async function extractExecutionOutcome(
 					resultData[nodeName] = truncateNodeOutput(branches[0]);
 					continue;
 				}
-				// Multi-output nodes (Filter, IF, Switch) route each output to a different
-				// downstream node, so their items are reported per output, never as one list.
-				const names = resolveOutputNames(
-					execution.workflowData?.nodes.find((node) => node.name === nodeName),
-					nodeTypes,
-				);
+				// Multi-output nodes (Filter, IF, Switch) keep each output separate, so
+				// their items are reported per output, never as one list.
+				const names = resolveOutputNames(workflow, nodeName);
 				resultData[nodeName] = {
 					outputs: branches.map((items, index) => ({
 						index,
@@ -4139,6 +4139,8 @@ export async function extractExecutionOutcome(
 					totalItems,
 				} satisfies BranchedNodeOutput;
 			}
+		} finally {
+			await workflow?.expression.releaseIsolate();
 		}
 	}
 
@@ -4253,24 +4255,48 @@ function capItem(item: unknown): unknown {
 }
 
 /**
- * Output labels as the canvas shows them: the node type's `outputNames`
- * (Filter: Kept/Discarded, IF: true/false) or each output's `displayName`, plus
- * "Error" when the node routes errors to an extra output. Empty when node types
- * are unavailable or the type is unknown, so outputs are then index-only.
+ * Transient Workflow over the execution's workflow so `getNodeOutputs` can
+ * resolve dynamic `outputs` expressions (Switch). Same pattern as the
+ * `getNodeInputs` call above. `undefined` when node types are missing or a
+ * node type is not installed; outputs are then index-only.
  */
-function resolveOutputNames(node: INode | undefined, nodeTypes?: NodeTypes): string[] {
-	if (!node || !nodeTypes) return [];
+function buildExecutionWorkflow(
+	workflowData: IWorkflowBase | undefined,
+	nodeTypes?: NodeTypes,
+): Workflow | undefined {
+	if (!workflowData || !nodeTypes) return undefined;
 	try {
-		const { description } = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
-		// ponytail: expression outputs (Switch) stay index-only; its default labels are the indices anyway.
-		const names =
-			description.outputNames ??
-			(Array.isArray(description.outputs)
-				? description.outputs.map((output) =>
-						typeof output === 'string' ? '' : (output.displayName ?? ''),
-					)
-				: []);
-		return names.length > 0 && node.onError === 'continueErrorOutput' ? [...names, 'Error'] : names;
+		// The constructor fills default parameters on the passed node objects.
+		// Nothing downstream reads raw parameters, so no copy is needed.
+		return new Workflow({
+			nodes: workflowData.nodes,
+			connections: workflowData.connections,
+			active: false,
+			nodeTypes,
+		});
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Output labels as the node's output pane shows them: the resolved output's
+ * `displayName` (Switch rules, Success / Error), else the node type's
+ * `outputNames[i]` (Filter: Kept / Discarded). An empty string means no label.
+ */
+function resolveOutputNames(workflow: Workflow | undefined, nodeName: string): string[] {
+	const node = workflow?.getNode(nodeName);
+	if (!workflow || !node) return [];
+	try {
+		const { description } = workflow.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+		const outputs = NodeHelpers.getNodeOutputs(workflow, node, description);
+		// Filter declares one output but names two, so count both sources.
+		const count = Math.max(outputs.length, description.outputNames?.length ?? 0);
+		return Array.from({ length: count }, (_, i) => {
+			const output = outputs[i];
+			const displayName = typeof output === 'object' ? output.displayName : undefined;
+			return displayName ?? description.outputNames?.[i] ?? '';
+		});
 	} catch {
 		return [];
 	}
@@ -4305,10 +4331,14 @@ export async function extractNodeOutput(
 
 	const startIndex = options?.startIndex ?? 0;
 	const maxItems = Math.min(options?.maxItems ?? 10, 50);
-	const names = resolveOutputNames(
-		execution.workflowData?.nodes.find((node) => node.name === nodeName),
-		nodeTypes,
-	);
+	const workflow = buildExecutionWorkflow(execution.workflowData, nodeTypes);
+	await workflow?.expression.acquireIsolate();
+	let names: string[];
+	try {
+		names = resolveOutputNames(workflow, nodeName);
+	} finally {
+		await workflow?.expression.releaseIsolate();
+	}
 
 	// One page over the items of all outputs (first output first), reported per
 	// output so a Filter's Kept and Discarded items never read as one list.

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -2076,6 +2076,7 @@ export class InstanceAiAdapterService {
 					const { result, telemetryError } = await extractExecutionOutcome(
 						executionId,
 						allowSendingParameterValues,
+						nodeTypes,
 					);
 					await pruneVerificationPins(result.executedNodeNames);
 					trackBuilderExecutedWorkflow(result.status, telemetryError);
@@ -2103,7 +2104,7 @@ export class InstanceAiAdapterService {
 				if (isRunning) {
 					return { executionId, status: 'running' } satisfies ExecutionResult;
 				}
-				return await extractExecutionResult(executionId, allowSendingParameterValues);
+				return await extractExecutionResult(executionId, allowSendingParameterValues, nodeTypes);
 			},
 
 			async getResult(executionId: string) {
@@ -2112,7 +2113,7 @@ export class InstanceAiAdapterService {
 				if (activeExecutions.has(executionId)) {
 					await activeExecutions.getPostExecutePromise(executionId);
 				}
-				return await extractExecutionResult(executionId, allowSendingParameterValues);
+				return await extractExecutionResult(executionId, allowSendingParameterValues, nodeTypes);
 			},
 
 			async stop(executionId: string) {
@@ -2150,13 +2151,13 @@ export class InstanceAiAdapterService {
 				if (!allowSendingParameterValues) {
 					return {
 						nodeName,
-						items: [],
+						outputs: [],
 						totalItems: 0,
 						returned: { from: 0, to: 0 },
 					} satisfies NodeOutputResult;
 				}
 
-				return await extractNodeOutput(executionId, nodeName, options);
+				return await extractNodeOutput(executionId, nodeName, options, nodeTypes);
 			},
 
 			getResolvedNodeParameters: async (
@@ -3951,25 +3952,50 @@ export function truncateResultData(resultData: Record<string, unknown>): Record<
 	if (serialized.length <= MAX_RESULT_CHARS) return resultData;
 
 	const truncated: Record<string, unknown> = {};
-	for (const [nodeName, items] of Object.entries(resultData)) {
-		if (!Array.isArray(items) || items.length === 0) {
-			truncated[nodeName] = items;
-			continue;
-		}
-
-		const itemStr = JSON.stringify(items[0]);
-		const preview =
-			itemStr.length > MAX_NODE_OUTPUT_CHARS
-				? `${itemStr.slice(0, MAX_NODE_OUTPUT_CHARS)}…`
-				: items[0];
-
-		truncated[nodeName] = {
-			_itemCount: items.length,
-			_truncated: true,
-			_firstItemPreview: preview,
-		};
+	for (const [nodeName, value] of Object.entries(resultData)) {
+		truncated[nodeName] = isBranchedNodeOutput(value)
+			? {
+					...value,
+					outputs: value.outputs.map((output) => ({
+						...output,
+						items: collapseItems(output.items),
+					})),
+				}
+			: collapseItems(value);
 	}
 	return truncated;
+}
+
+/** Replaces an item array with its count and a capped first-item preview. */
+function collapseItems(items: unknown): unknown {
+	if (!Array.isArray(items) || items.length === 0) return items;
+
+	const itemStr = JSON.stringify(items[0]);
+	const preview =
+		itemStr.length > MAX_NODE_OUTPUT_CHARS
+			? `${itemStr.slice(0, MAX_NODE_OUTPUT_CHARS)}…`
+			: items[0];
+
+	return {
+		_itemCount: items.length,
+		_truncated: true,
+		_firstItemPreview: preview,
+	};
+}
+
+/** `data[nodeName]` of a multi-output node: items grouped per output. */
+interface BranchedNodeOutput {
+	outputs: Array<{ index: number; name?: string; items: unknown }>;
+	totalItems: number;
+}
+
+function isBranchedNodeOutput(value: unknown): value is BranchedNodeOutput {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'outputs' in value &&
+		Array.isArray(value.outputs)
+	);
 }
 
 /**
@@ -4041,8 +4067,9 @@ function extractNodeErrors(
 export async function extractExecutionResult(
 	executionId: string,
 	includeOutputData = true,
+	nodeTypes?: NodeTypes,
 ): Promise<ExecutionResult> {
-	return (await extractExecutionOutcome(executionId, includeOutputData)).result;
+	return (await extractExecutionOutcome(executionId, includeOutputData, nodeTypes)).result;
 }
 
 /**
@@ -4056,6 +4083,7 @@ export async function extractExecutionResult(
 export async function extractExecutionOutcome(
 	executionId: string,
 	includeOutputData = true,
+	nodeTypes?: NodeTypes,
 ): Promise<{ result: ExecutionResult; telemetryError?: string }> {
 	const execution = await Container.get(ExecutionPersistence).findSingleExecution(executionId, {
 		includeData: true,
@@ -4088,15 +4116,28 @@ export async function extractExecutionOutcome(
 		if (runData) {
 			for (const [nodeName, nodeRuns] of Object.entries(runData)) {
 				const lastRun = nodeRuns[nodeRuns.length - 1];
-				if (lastRun?.data?.main) {
-					const outputItems = lastRun.data.main
-						.flat()
-						.filter((item): item is NonNullable<typeof item> => item !== null && item !== undefined)
-						.map((item) => item.json);
-					if (outputItems.length > 0) {
-						resultData[nodeName] = truncateNodeOutput(outputItems);
-					}
+				if (!lastRun?.data?.main) continue;
+				const branches = lastRun.data.main.map((items) => (items ?? []).map((item) => item.json));
+				const totalItems = branches.reduce((sum, items) => sum + items.length, 0);
+				if (totalItems === 0) continue;
+				if (branches.length === 1) {
+					resultData[nodeName] = truncateNodeOutput(branches[0]);
+					continue;
 				}
+				// Multi-output nodes (Filter, IF, Switch) route each output to a different
+				// downstream node, so their items are reported per output, never as one list.
+				const names = resolveOutputNames(
+					execution.workflowData?.nodes.find((node) => node.name === nodeName),
+					nodeTypes,
+				);
+				resultData[nodeName] = {
+					outputs: branches.map((items, index) => ({
+						index,
+						...(names[index] ? { name: names[index] } : {}),
+						items: truncateNodeOutput(items),
+					})),
+					totalItems,
+				} satisfies BranchedNodeOutput;
 			}
 		}
 	}
@@ -4203,6 +4244,38 @@ export function truncateNodeOutput(items: unknown[]): unknown[] | unknown {
 /** Maximum characters for a single item returned by get-node-output. */
 const MAX_ITEM_CHARS = 50_000;
 
+/** Caps one item so a single giant JSON blob cannot flood the context. */
+function capItem(item: unknown): unknown {
+	const str = JSON.stringify(item);
+	return str.length > MAX_ITEM_CHARS
+		? { _truncatedItem: true, preview: str.slice(0, MAX_ITEM_CHARS), originalLength: str.length }
+		: item;
+}
+
+/**
+ * Output labels as the canvas shows them: the node type's `outputNames`
+ * (Filter: Kept/Discarded, IF: true/false) or each output's `displayName`, plus
+ * "Error" when the node routes errors to an extra output. Empty when node types
+ * are unavailable or the type is unknown, so outputs are then index-only.
+ */
+function resolveOutputNames(node: INode | undefined, nodeTypes?: NodeTypes): string[] {
+	if (!node || !nodeTypes) return [];
+	try {
+		const { description } = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+		// ponytail: expression outputs (Switch) stay index-only; its default labels are the indices anyway.
+		const names =
+			description.outputNames ??
+			(Array.isArray(description.outputs)
+				? description.outputs.map((output) =>
+						typeof output === 'string' ? '' : (output.displayName ?? ''),
+					)
+				: []);
+		return names.length > 0 && node.onError === 'continueErrorOutput' ? [...names, 'Error'] : names;
+	} catch {
+		return [];
+	}
+}
+
 /**
  * Extract paginated raw output for a specific node from an execution.
  * Each item is capped at MAX_ITEM_CHARS to prevent a single giant JSON blob from flooding context.
@@ -4211,6 +4284,7 @@ export async function extractNodeOutput(
 	executionId: string,
 	nodeName: string,
 	options?: { startIndex?: number; maxItems?: number },
+	nodeTypes?: NodeTypes,
 ): Promise<NodeOutputResult> {
 	const execution = await Container.get(ExecutionPersistence).findSingleExecution(executionId, {
 		includeData: true,
@@ -4231,46 +4305,46 @@ export async function extractNodeOutput(
 
 	const startIndex = options?.startIndex ?? 0;
 	const maxItems = Math.min(options?.maxItems ?? 10, 50);
+	const names = resolveOutputNames(
+		execution.workflowData?.nodes.find((node) => node.name === nodeName),
+		nodeTypes,
+	);
 
-	// Walk the nested output arrays without materializing all items into memory.
-	// Only collect the slice we need — avoids OOM on nodes with huge result sets.
+	// One page over the items of all outputs (first output first), reported per
+	// output so a Filter's Kept and Discarded items never read as one list.
+	// Only the requested slice is materialized — avoids OOM on huge result sets.
 	let index = 0;
-	let totalItems = 0;
-	const collected: unknown[] = [];
-	for (const output of lastRun?.data?.main ?? []) {
-		for (const item of output ?? []) {
-			totalItems++;
-			if (index >= startIndex && collected.length < maxItems) {
+	let returnedCount = 0;
+	const outputs = (lastRun?.data?.main ?? []).map((output, outputIndex) => {
+		const items = output ?? [];
+		const firstInPage = Math.max(startIndex - index, 0);
+		const collected: unknown[] = [];
+		for (const item of items) {
+			if (index >= startIndex && returnedCount < maxItems) {
 				collected.push(item.json);
+				returnedCount++;
 			}
 			index++;
 		}
-	}
-
-	// Per-item char cap
-	const capped = collected.map((item) => {
-		const str = JSON.stringify(item);
-		if (str.length > MAX_ITEM_CHARS) {
-			return {
-				_truncatedItem: true,
-				preview: str.slice(0, MAX_ITEM_CHARS),
-				originalLength: str.length,
-			};
-		}
-		return item;
+		return {
+			index: outputIndex,
+			...(names[outputIndex] ? { name: names[outputIndex] } : {}),
+			totalItems: items.length,
+			items: collected.map((item, i) =>
+				wrapUntrustedData(
+					JSON.stringify(capItem(item), null, 2),
+					'execution-output',
+					`node:${nodeName}[${outputIndex}][${firstInPage + i}]`,
+				),
+			),
+		};
 	});
 
 	return {
 		nodeName,
-		items: capped.map((item, i) =>
-			wrapUntrustedData(
-				JSON.stringify(item, null, 2),
-				'execution-output',
-				`node:${nodeName}[${startIndex + i}]`,
-			),
-		),
-		totalItems,
-		returned: { from: startIndex, to: startIndex + capped.length },
+		outputs,
+		totalItems: index,
+		returned: { from: startIndex, to: startIndex + returnedCount },
 	};
 }
 
@@ -4390,7 +4464,7 @@ export async function extractExecutionDebugInfo(
 		};
 	}
 
-	const baseResult = await extractExecutionResult(executionId, includeOutputData);
+	const baseResult = await extractExecutionResult(executionId, includeOutputData, nodeTypes);
 
 	const runData = execution.data?.resultData?.runData;
 	const nodeTrace: ExecutionDebugInfo['nodeTrace'] = [];


### PR DESCRIPTION
## Summary

Nodes like Filter, IF and Switch have more than one output. The n8n Assistant tool that reads node output (`get-node-output`) merged all of them into one list. For a Filter that kept 1 of 2 items, the assistant saw 2 items and could not tell which one was kept. In some chats it told the user the Filter was broken.

Now the tool reports each output on its own, with the label the editor shows (for a Filter: Kept and Discarded). The same applies to the run summary the assistant reads after a workflow runs. Nodes with one output look the same as before.

Checked with eval case #725, which reproduces this bug: in 3 of 3 runs the assistant read the Kept and Discarded lists and told the user which item was dropped. One check in that case still fails because its text was written for the old merged list. The case needs an update.

## How to test

1. Run the unit tests:
   ```bash
   cd packages/cli && pnpm test src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
   cd packages/@n8n/instance-ai && pnpm test src/tools/__tests__/executions.tool.test.ts src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
   ```
2. In the n8n Assistant, run a workflow with a Filter that keeps 1 of 2 items. Ask which item the Filter dropped. The assistant names it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1393

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



