### PR TITLE
feat(Slack Trigger Node): Add version 2 with a required signing-secret credential

### DIFF
--- a/packages/nodes-base/credentials/SlackApi.credentials.ts
+++ b/packages/nodes-base/credentials/SlackApi.credentials.ts
@@ -28,7 +28,7 @@ export class SlackApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 			description:
-				'The signature secret is used to verify the authenticity of requests sent by Slack.',
+				'Only used by Slack Trigger nodes of version 1 to verify requests sent by Slack. Newer Slack Trigger nodes use the separate "Slack Signing Secret" credential instead.',
 		},
 		{
 			displayName: 'Managed App ID',
@@ -50,7 +50,7 @@ export class SlackApi implements ICredentialType {
 		},
 		{
 			displayName:
-				'We strongly recommend setting up a <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">signing secret</a> to ensure the authenticity of requests.',
+				'If a Slack Trigger node of version 1 uses this credential, we strongly recommend setting up a <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">signing secret</a> to ensure the authenticity of requests.',
 			name: 'notice',
 			type: 'notice',
 			default: '',

--- a/packages/nodes-base/credentials/SlackSigningSecretApi.credentials.ts
+++ b/packages/nodes-base/credentials/SlackSigningSecretApi.credentials.ts
@@ -1,0 +1,30 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export class SlackSigningSecretApi implements ICredentialType {
+	name = 'slackSigningSecretApi';
+
+	displayName = 'Slack Signing Secret';
+
+	icon = 'file:../nodes/Slack/slack.svg' as const;
+
+	documentationUrl = 'slack';
+
+	// The secret only verifies incoming requests. It never leaves the instance in a request.
+	hideDomainRestrictionFields = true;
+
+	// Only the nodes that declare this credential (the Slack Trigger) can decrypt it.
+	restrictToSupportedNodes = true as const;
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Signing Secret',
+			name: 'signatureSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			required: true,
+			description:
+				'The signing secret of your Slack app. Find it under "Basic Information" in the Slack API dashboard. The Slack Trigger node uses it to verify that incoming requests come from Slack. <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">More info</a>.',
+		},
+	];
+}

--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -22,7 +22,7 @@ export class SlackTrigger implements INodeType {
 		name: 'slackTrigger',
 		icon: 'file:slack.svg',
 		group: ['trigger'],
-		version: 1,
+		version: [1, 2],
 		subtitle: '={{$parameter["eventFilter"].join(", ")}}',
 		description: 'Handle Slack events via webhooks',
 		defaults: {
@@ -43,6 +43,15 @@ export class SlackTrigger implements INodeType {
 				name: 'slackApi',
 				required: true,
 			},
+			{
+				name: 'slackSigningSecretApi',
+				required: true,
+				displayOptions: {
+					show: {
+						'@version': [2],
+					},
+				},
+			},
 		],
 		properties: [
 			{
@@ -57,6 +66,23 @@ export class SlackTrigger implements INodeType {
 				name: 'notice',
 				type: 'notice',
 				default: '',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName:
+					'Set up a webhook in your Slack app to enable this node. <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#configure-a-webhook-in-slack" target="_blank">More info</a>. The node verifies every request with the <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/#verify-the-webhook" target="_blank">signing secret</a> of your Slack app and rejects requests that Slack did not sign.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						'@version': [2],
+					},
+				},
 			},
 			{
 				displayName: 'Trigger On',
@@ -342,7 +368,12 @@ export class SlackTrigger implements INodeType {
 		const watchWorkspace = this.getNodeParameter('watchWorkspace', false) as boolean;
 		let eventChannel: string = '';
 
-		const isSignatureValid = await verifySignature.call(this);
+		// Version 1 reads the optional secret from the Slack API credential and skips verification
+		// without it. Version 2 has a dedicated, required signing-secret credential and fails closed.
+		const isSignatureValid =
+			this.getNode().typeVersion >= 2
+				? await verifySignature.call(this, 'slackSigningSecretApi', { requireSecret: true })
+				: await verifySignature.call(this);
 		if (!isSignatureValid) {
 			const res = this.getResponseObject();
 			res.status(401).send('Unauthorized').end();

--- a/packages/nodes-base/nodes/Slack/SlackTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTriggerHelpers.ts
@@ -81,11 +81,31 @@ export async function downloadFile(this: IWebhookFunctions, url: string): Promis
 	return response;
 }
 
+export interface VerifySlackSignatureOptions {
+	/**
+	 * Fail verification when the credential has no signature secret. Defaults to `false`
+	 * because the secret is optional on the `slackApi` and `slackOAuth2Api` credentials.
+	 */
+	requireSecret?: boolean;
+}
+
 export async function verifySignature(
 	this: IWebhookFunctions,
 	credentialType = 'slackApi',
+	options: VerifySlackSignatureOptions = {},
 ): Promise<boolean> {
-	const credential = await this.getCredentials(credentialType);
+	let signatureSecret: unknown;
+	try {
+		signatureSecret = (await this.getCredentials(credentialType)).signatureSecret;
+	} catch (error) {
+		// The node has no credential of this type. Treat it like a missing secret.
+		signatureSecret = undefined;
+	}
+	const hasSecret = typeof signatureSecret === 'string' && signatureSecret !== '';
+	if (!hasSecret && options.requireSecret) {
+		return false;
+	}
+
 	const req = this.getRequestObject();
 
 	const timestamp = req.header('x-slack-request-timestamp');
@@ -93,11 +113,10 @@ export async function verifySignature(
 		return false;
 	}
 
-	const signatureSecret = credential.signatureSecret;
 	try {
 		const isValid = verifySignatureGeneric({
 			getExpectedSignature: () => {
-				if (!signatureSecret || typeof signatureSecret !== 'string' || !req.rawBody) {
+				if (!hasSecret || !req.rawBody) {
 					return null;
 				}
 
@@ -115,7 +134,7 @@ export async function verifySignature(
 				const computedSignature = `v0=${hmac.digest('hex')}`;
 				return computedSignature;
 			},
-			skipIfNoExpectedSignature: !signatureSecret || typeof signatureSecret !== 'string',
+			skipIfNoExpectedSignature: !hasSecret,
 			getActualSignature: () => {
 				const actualSignature = req.header('x-slack-signature');
 				return typeof actualSignature === 'string' ? actualSignature : null;

--- a/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
@@ -1,7 +1,8 @@
 import { mock } from 'vitest-mock-extended';
-import type { ILoadOptionsFunctions, IWebhookFunctions, INodeType } from 'n8n-workflow';
+import type { ILoadOptionsFunctions, IWebhookFunctions, INode, INodeType } from 'n8n-workflow';
 
 import { SlackTrigger } from '../SlackTrigger.node';
+import { verifySignature } from '../SlackTriggerHelpers';
 import * as GenericFunctions from '../V2/GenericFunctions';
 
 // Mock the helper functions
@@ -20,6 +21,8 @@ describe('SlackTrigger Node', () => {
 		vi.clearAllMocks();
 		slackTrigger = new SlackTrigger();
 		mockWebhookFunctions = mock<IWebhookFunctions>();
+		mockWebhookFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+		vi.mocked(verifySignature).mockResolvedValue(true);
 
 		// Mock helpers
 		mockWebhookFunctions.helpers = {
@@ -706,6 +709,60 @@ describe('SlackTrigger Node', () => {
 			expect(mockWebhookFunctions.getResponseObject().json).toHaveBeenCalledWith({
 				challenge: 'test_challenge_123',
 			});
+		});
+	});
+
+	describe('webhook method - signature verification', () => {
+		const eventRequest = {
+			body: {
+				type: 'event_callback',
+				event: { type: 'message', channel: 'C123', user: 'U456', text: 'Hello' },
+			},
+		};
+
+		beforeEach(() => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue(eventRequest as any);
+			mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'trigger':
+						return ['message'];
+					case 'watchWorkspace':
+						return true;
+					default:
+						return {};
+				}
+			});
+		});
+
+		it('should verify with the optional secret of the Slack API credential in version 1', async () => {
+			mockWebhookFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(verifySignature).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(verifySignature).mock.calls[0]).toEqual([]);
+			expect(result.workflowData).toBeDefined();
+		});
+
+		it('should verify with the required signing-secret credential in version 2', async () => {
+			mockWebhookFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(verifySignature).toHaveBeenCalledWith('slackSigningSecretApi', {
+				requireSecret: true,
+			});
+			expect(result.workflowData).toBeDefined();
+		});
+
+		it('should respond with 401 and not start the workflow when verification fails', async () => {
+			mockWebhookFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+			vi.mocked(verifySignature).mockResolvedValue(false);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(mockWebhookFunctions.getResponseObject().status).toHaveBeenCalledWith(401);
+			expect(result).toEqual({ noWebhookResponse: true });
 		});
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/SlackTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/SlackTriggerHelpers.test.ts
@@ -195,5 +195,69 @@ describe('SlackTriggerHelpers', () => {
 			expect(result).toBe(true);
 			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('slackApi');
 		});
+
+		describe('with requireSecret', () => {
+			it('should return false when the credential has no signature secret', async () => {
+				mockWebhookFunctions.getCredentials.mockResolvedValue({});
+
+				const result = await verifySignature.call(mockWebhookFunctions, 'slackSigningSecretApi', {
+					requireSecret: true,
+				});
+
+				expect(result).toBe(false);
+				expect(createHmac).not.toHaveBeenCalled();
+				expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('slackSigningSecretApi');
+			});
+
+			it('should return false when the signature secret is an empty string', async () => {
+				mockWebhookFunctions.getCredentials.mockResolvedValue({ signatureSecret: '' });
+
+				const result = await verifySignature.call(mockWebhookFunctions, 'slackSigningSecretApi', {
+					requireSecret: true,
+				});
+
+				expect(result).toBe(false);
+				expect(createHmac).not.toHaveBeenCalled();
+			});
+
+			it('should return false when the node has no credential of the given type', async () => {
+				mockWebhookFunctions.getCredentials.mockRejectedValue(new Error('No credentials'));
+
+				const result = await verifySignature.call(mockWebhookFunctions, 'slackSigningSecretApi', {
+					requireSecret: true,
+				});
+
+				expect(result).toBe(false);
+				expect(createHmac).not.toHaveBeenCalled();
+			});
+
+			it('should verify the signature when the credential has a signature secret', async () => {
+				mockWebhookFunctions.getCredentials.mockResolvedValue({
+					signatureSecret: testSignatureSecret,
+				});
+				(timingSafeEqual as Mock).mockReturnValue(true);
+
+				const result = await verifySignature.call(mockWebhookFunctions, 'slackSigningSecretApi', {
+					requireSecret: true,
+				});
+
+				expect(result).toBe(true);
+				expect(createHmac).toHaveBeenCalledWith('sha256', testSignatureSecret);
+				expect(timingSafeEqual).toHaveBeenCalled();
+			});
+
+			it('should return false when the signature is invalid', async () => {
+				mockWebhookFunctions.getCredentials.mockResolvedValue({
+					signatureSecret: testSignatureSecret,
+				});
+				(timingSafeEqual as Mock).mockReturnValue(false);
+
+				const result = await verifySignature.call(mockWebhookFunctions, 'slackSigningSecretApi', {
+					requireSecret: true,
+				});
+
+				expect(result).toBe(false);
+			});
+		});
 	});
 });

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -362,6 +362,7 @@
       "dist/credentials/SlackApi.credentials.js",
       "dist/credentials/SlackManagerOAuth2Api.credentials.js",
       "dist/credentials/SlackOAuth2Api.credentials.js",
+      "dist/credentials/SlackSigningSecretApi.credentials.js",
       "dist/credentials/Sms77Api.credentials.js",
       "dist/credentials/Smtp.credentials.js",
       "dist/credentials/Snowflake.credentials.js",


### PR DESCRIPTION
## Summary

Non-breaking follow-up to the closed #38405.

- New credential type `Slack Signing Secret` (`slackSigningSecretApi`). It holds only the signing secret of the Slack app. It hides the domain restriction fields and sets `restrictToSupportedNodes`, so only the Slack Trigger node can decrypt it.
- Slack Trigger version 2 requires this credential as a second credential and rejects every request without a valid Slack signature with `401`. New Slack Trigger nodes default to version 2.
- Slack Trigger version 1 is unchanged. It still reads the optional `Signature Secret` from the Slack API credential and skips verification when the secret is empty. Existing workflows keep working.
- The `Signature Secret` field of the Slack API credential stays optional. Its description and notice now say that only Slack Trigger version 1 uses it.

## How to test

1. Add a Slack Trigger node to a workflow. Confirm it is version 2 and asks for two credentials: `Slack API` and `Slack Signing Secret`.
2. Create a `Slack Signing Secret` credential with the value from "Basic Information" of your Slack app. Confirm the credential modal shows no "Allowed HTTP Request Domains" field.
3. Point the Slack app's event subscription to the webhook URL and trigger an event. Confirm the workflow runs.
4. Send a request to the webhook URL without a Slack signature (for example with curl). Confirm the response is `401 Unauthorized`.
5. Open a workflow with an existing Slack Trigger (version 1). Confirm it still shows one credential and still runs.
6. Try to use the `Slack Signing Secret` credential in an HTTP Request node. Confirm the node refuses it.
7. Run `pnpm test nodes/Slack` in `packages/nodes-base`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-296

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

