### PR TITLE
feat(Confluence Node): Unhide the node and enable AI tool usage

### DIFF
--- a/packages/nodes-base/nodes/Confluence/actions/description.ts
+++ b/packages/nodes-base/nodes/Confluence/actions/description.ts
@@ -19,8 +19,7 @@ export const confluenceNodeDescription: INodeTypeDescription = {
 	defaults: {
 		name: 'Confluence',
 	},
-	// Hidden shell: operations land per-ticket; unhide + usableAsTool + docs at ENT-311
-	hidden: true,
+	usableAsTool: true,
 	inputs: [NodeConnectionTypes.Main],
 	outputs: [NodeConnectionTypes.Main],
 	credentials: [

--- a/packages/nodes-base/nodes/Confluence/test/Confluence.node.test.ts
+++ b/packages/nodes-base/nodes/Confluence/test/Confluence.node.test.ts
@@ -22,10 +22,10 @@ describe('Confluence Node', () => {
 		]);
 	});
 
-	it('should stay hidden and off the AI-tool surface while operations land', () => {
-		expect(node.description.hidden).toBe(true);
+	it('should be visible in the nodes panel and usable as an AI tool', () => {
+		expect(node.description.hidden).toBeUndefined();
 		expect(node.description.properties.length).toBeGreaterThan(0);
-		expect(node.description.usableAsTool).toBeUndefined();
+		expect(node.description.usableAsTool).toBe(true);
 	});
 
 	it('should expose the page resource with its operations', () => {


### PR DESCRIPTION
## Summary

This is the release gate for the Confluence node. The node was built behind the `hidden` flag, so the operations could land on master one ticket at a time without showing a half-finished node. All v1 operations are merged, so this PR makes the node public:

- Removes `hidden: true` from the node description. The node now appears in the nodes panel and in search.
- Sets `usableAsTool: true`. An AI Agent can now call the node as a tool.
- Updates the guard test, which asserted the hidden state, to assert the release state.

The codex metadata (`Confluence.node.json`) already carries the correct categories and documentation URLs, so it needs no change.

## How to test

1. Build the repo and start n8n.
2. Open a workflow and search the nodes panel for `Confluence`. The node must appear.
3. Add a Confluence Cloud OAuth2 credential and run **Page → Create**, then **Page → Get** on the new page. Both must succeed.
4. Add an **AI Agent** node. Connect Confluence as a tool. The node must appear in the tool list.
5. Ask the agent to create a page and then read it back. The agent must complete both steps.

Unit tests:

```bash
cd packages/nodes-base && pnpm test nodes/Confluence
```

No feature flag, license, or module env var gates this node.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-311
- Docs: n8n-io/n8n-docs#5197 (credentials) and n8n-io/n8n-docs#5307 (node page). Both must merge together with this PR.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.


🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

