### PR TITLE
Jgalmeida/relax multi input output

### DIFF
--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -120,11 +120,11 @@ describe('NODE_GROUPS_REFERENCE', () => {
 		expect(NODE_GROUPS_REFERENCE).not.toContain('rejected on save');
 	});
 
-	it('states the single entry/exit boundary rule that grouping enforces', () => {
-		// reason: 'invalid-subgraph' — grouping rejects a group with more than one
-		// incoming or outgoing main connection (single entry/exit *boundary*).
-		expect(NODE_GROUPS_REFERENCE).toMatch(/single entry and exit/i);
-		expect(NODE_GROUPS_REFERENCE).toMatch(/incoming and one outgoing main connection/i);
+	it('states that grouping imposes no structural constraints', () => {
+		// A group is a visual frame: boundary connections may attach at any
+		// member, and members need not connect to one another.
+		expect(NODE_GROUPS_REFERENCE).toMatch(/no structural constraints/i);
+		expect(NODE_GROUPS_REFERENCE).toMatch(/attaching at any member/i);
 	});
 
 	it('does not claim the extraction-only per-node single-main-port rule', () => {
@@ -143,9 +143,10 @@ describe('NODE_GROUPS_REFERENCE', () => {
 			expect(NODE_GROUPS_REFERENCE).toMatch(/trigger nodes? (cannot|can't|may not|must not)/i);
 		});
 
-		it('states the single-connected-subgraph rule', () => {
-			// reason: 'invalid-subgraph' — one connected chunk, not two islands.
-			expect(NODE_GROUPS_REFERENCE).toMatch(/single connected|one connected/i);
+		it('states that members need not connect to one another', () => {
+			// reason: 'invalid-subgraph' no longer fires for grouping — a group is
+			// a visual frame and imposes no structural constraints.
+			expect(NODE_GROUPS_REFERENCE).toMatch(/need not connect to one another/i);
 		});
 
 		it('states the AI-Agent-and-sub-nodes-together rule in plain terms', () => {

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -745,19 +745,18 @@ describe('validateWorkflowNodeGroups', () => {
 				).not.toThrow();
 			});
 
-			it('still rejects disconnected connectable nodes when a sticky is present', () => {
+			it('accepts unconnected connectable nodes when a sticky is present', () => {
+				// Groups no longer require connected members.
 				expect(() =>
 					validateWorkflowNodeGroups(
 						{
 							nodes: [makeNode('n1'), makeNode('n2'), makeStickyNode('s1')],
 							connections: {},
-							nodeGroups: [{ id: 'g1', name: 'Disconnected', nodeIds: ['n1', 'n2', 's1'] }],
+							nodeGroups: [{ id: 'g1', name: 'Unconnected', nodeIds: ['n1', 'n2', 's1'] }],
 						},
 						getNodeType,
 					),
-				).toThrow(
-					'Node group "Disconnected" must form a single connected subgraph with a single entry and exit.',
-				);
+				).not.toThrow();
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useInvalidNodeGroupCleanup.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useInvalidNodeGroupCleanup.test.ts
@@ -91,16 +91,16 @@ describe('useInvalidNodeGroupCleanup', () => {
 		expect(trackSpy).not.toHaveBeenCalled();
 	});
 
-	it('removes a group whose members do not form a connected subgraph', () => {
+	it('removes a group that references a node missing from the workflow', () => {
 		const store = setupDocumentStore({
 			nodes: [
 				createTestNode({ id: 'node-a', name: 'Node A' }),
 				createTestNode({ id: 'node-b', name: 'Node B' }),
-				createTestNode({ id: 'node-c', name: 'Node C' }),
 			],
 			connections: createConnection('Node A', 'Node B'),
-			// Node C is not connected to the rest of the group
-			nodeGroups: [{ id: 'group-1', name: 'Group 1', nodeIds: ['node-a', 'node-b', 'node-c'] }],
+			nodeGroups: [
+				{ id: 'group-1', name: 'Group 1', nodeIds: ['node-a', 'node-b', 'does-not-exist'] },
+			],
 		});
 
 		const { removeInvalidNodeGroups } = useInvalidNodeGroupCleanup();
@@ -123,7 +123,7 @@ describe('useInvalidNodeGroupCleanup', () => {
 				workflow_id: WORKFLOW_ID,
 				group_id: 'group-1',
 				group_title: 'Group 1',
-				node_ids: ['node-a', 'node-b', 'node-c'],
+				node_ids: ['node-a', 'node-b', 'does-not-exist'],
 				node_count: 3,
 				source: 'invalid-on-save',
 			}),
@@ -177,8 +177,8 @@ describe('useInvalidNodeGroupCleanup', () => {
 			connections: createConnection('Node A', 'Node B'),
 			nodeGroups: [
 				{ id: 'group-1', name: 'Group 1', nodeIds: ['node-a', 'node-b'] },
-				// Members are not connected to each other
-				{ id: 'group-2', name: 'Group 2', nodeIds: ['node-c', 'node-d'] },
+				// References a missing node
+				{ id: 'group-2', name: 'Group 2', nodeIds: ['node-c', 'node-d', 'also-missing'] },
 				// References a missing node
 				{ id: 'group-3', name: 'Group 3', nodeIds: ['node-e', 'does-not-exist'] },
 			],
@@ -211,7 +211,11 @@ describe('useInvalidNodeGroupCleanup', () => {
 				createTestNode({ id: 'node-b', name: 'Node B' }),
 			],
 			nodeGroups: [
-				{ id: 'group-1', name: '<img src=x onerror=alert(1)>', nodeIds: ['node-a', 'node-b'] },
+				{
+					id: 'group-1',
+					name: '<img src=x onerror=alert(1)>',
+					nodeIds: ['node-a', 'node-b', 'does-not-exist'],
+				},
 			],
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useSelectionValidation.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSelectionValidation.test.ts
@@ -206,9 +206,9 @@ describe('useSelectionValidation', () => {
 		}
 	});
 
-	it('returns invalid-subgraph when the selection skips an intermediate node', () => {
-		// A → B → C; selecting only A and C leaves B (on the path) outside the
-		// selection, so the subgraph parser rejects the selection.
+	it('accepts a selection that skips an intermediate node', () => {
+		// A → B → C; selecting only A and C leaves B outside the group, which a
+		// visual frame allows.
 		const graph = makeLinearGraph();
 		setupGraph(graph, {
 			'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
@@ -217,10 +217,10 @@ describe('useSelectionValidation', () => {
 		const { isSelectionGroupable } = useSelectionValidation();
 		const result = isSelectionGroupable(['a', 'c']);
 
-		expect(result.valid).toBe(false);
+		expect(result.valid).toBe(true);
 	});
 
-	it('returns invalid-subgraph when selected nodes are disconnected', () => {
+	it('accepts selected nodes that are not connected to each other', () => {
 		const a = makeNode({ id: 'a', name: 'A' });
 		const b = makeNode({ id: 'b', name: 'B' });
 		setupGraph(
@@ -231,10 +231,7 @@ describe('useSelectionValidation', () => {
 		const { isSelectionGroupable } = useSelectionValidation();
 		const result = isSelectionGroupable(['a', 'b']);
 
-		expect(result.valid).toBe(false);
-		if (!result.valid) {
-			expect(result.reason).toBe('invalid-subgraph');
-		}
+		expect(result.valid).toBe(true);
 	});
 
 	it('validates against candidate connections when provided', () => {
@@ -243,9 +240,11 @@ describe('useSelectionValidation', () => {
 			'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
 		});
 
+		// Adds an ai_languageModel edge crossing the {A, B} boundary, which groups
+		// still reject — so the candidate must change the result.
 		const candidateConnections: IConnections = {
 			...graph.connections,
-			C: { main: [[{ node: 'B', type: 'main', index: 0 }]] },
+			Model: { ai_languageModel: [[{ node: 'B', type: 'ai_languageModel', index: 0 }]] },
 		};
 
 		const { isSelectionGroupable } = useSelectionValidation();
@@ -255,7 +254,7 @@ describe('useSelectionValidation', () => {
 
 		expect(result.valid).toBe(false);
 		if (!result.valid) {
-			expect(result.reason).toBe('invalid-subgraph');
+			expect(result.reason).toBe('non-main-boundary');
 		}
 	});
 
@@ -361,15 +360,24 @@ describe('useSelectionValidation', () => {
 		});
 
 		it('returns null when the resolved selection is not groupable', () => {
-			// A → B → C; selecting only A and C is an invalid subgraph
+			// A trigger cannot be grouped, so the selection stays ungroupable.
 			const graph = makeLinearGraph();
+			graph.nodes.trigger = makeNode({
+				id: 'trigger',
+				name: 'Trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+			});
 			setupGraph(graph, {
 				'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
+				'n8n-nodes-base.manualTrigger': makeNodeType({
+					name: 'n8n-nodes-base.manualTrigger',
+					group: ['trigger'],
+				}),
 			});
 
 			const { resolveGroupableNodeIds } = useSelectionValidation();
 
-			expect(resolveGroupableNodeIds(['a', 'c'])).toBeNull();
+			expect(resolveGroupableNodeIds(['trigger', 'a'])).toBeNull();
 		});
 
 		it('includes stickies when the selection also has a connectable node', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.test.ts
@@ -146,7 +146,8 @@ describe('useCanvasNodeGroupOperationGuards', () => {
 			expect(showToastSpy).not.toHaveBeenCalled();
 		});
 
-		it('still blocks removing the connection that keeps the group connected', () => {
+		it('allows removing the connection between group members', () => {
+			// Members need not stay connected, so the group survives the removal.
 			const { connectionsBySourceNode } = setupStickyGroup();
 			const guards = useCanvasNodeGroupOperationGuards();
 
@@ -156,8 +157,8 @@ describe('useCanvasNodeGroupOperationGuards', () => {
 				connectionsBySourceNode,
 			});
 
-			expect(allowed).toBe(false);
-			expect(showToastSpy).toHaveBeenCalledTimes(1);
+			expect(allowed).toBe(true);
+			expect(showToastSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -481,7 +481,11 @@ function validateNodeSelectionSubgraph<TNode extends INode>(
 	// members need not connect to each other. Extraction does not relax — a
 	// subworkflow has one trigger, one return, and one continuous path.
 	if (Array.isArray(selection) && relaxIo) {
-		selection = resolveBoundarySubgraphEndpoints(selectedNodeNames, adjacencyList);
+		// `start` / `end` name the single entry and exit that extraction wires into
+		// a subworkflow. A group has no single pair, and nothing reads these for a
+		// group: the collapsed canvas block remaps every boundary edge onto its own
+		// handles. So report none rather than picking an arbitrary member.
+		selection = { start: undefined, end: undefined };
 	}
 
 	if (Array.isArray(selection)) {
@@ -622,51 +626,4 @@ function findNonMainBoundaryConnection(
 	}
 
 	return null;
-}
-
-/**
- * Names the members where main connections enter and leave the group.
- *
- * Only extraction reads `start` / `end` (see `validateNodeSelectionForExtraction`
- * and `doExtractNodesIntoSubworkflow`). Grouping ignores them: the collapsed
- * canvas block remaps every boundary edge onto the group's own handles, so it
- * never needs to know which member an edge attached to. This exists so the
- * relaxed path still returns a well-formed `ExtractableSubgraphData`.
- *
- * A group may have many boundary edges attaching anywhere, so "the" entry and
- * exit are ambiguous. It reports a member that nothing inside the group feeds
- * (a true entry) and one that feeds nothing inside it (a true exit), falling
- * back to any boundary member when every edge attaches mid-chain.
- */
-function resolveBoundarySubgraphEndpoints(
-	nodeNames: Set<string>,
-	adjacencyList: IConnectionAdjacencyList,
-): ExtractableSubgraphData {
-	const entryCandidates: string[] = [];
-	const exitCandidates: string[] = [];
-	const hasInsideSource = new Set<string>();
-	const hasInsideTarget = new Set<string>();
-
-	for (const [sourceNodeName, connections] of adjacencyList.entries()) {
-		for (const connection of connections) {
-			if (connection.type !== NodeConnectionTypes.Main) continue;
-
-			const sourceInside = nodeNames.has(sourceNodeName);
-			const targetInside = nodeNames.has(connection.node);
-
-			if (sourceInside && targetInside) {
-				hasInsideSource.add(connection.node);
-				hasInsideTarget.add(sourceNodeName);
-			} else if (targetInside) {
-				entryCandidates.push(connection.node);
-			} else if (sourceInside) {
-				exitCandidates.push(sourceNodeName);
-			}
-		}
-	}
-
-	return {
-		start: entryCandidates.find((name) => !hasInsideSource.has(name)) ?? entryCandidates[0],
-		end: exitCandidates.find((name) => !hasInsideTarget.has(name)) ?? exitCandidates[0],
-	};
 }

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -83,12 +83,11 @@ export const NODE_GROUPING_RULES = {
 	},
 	invalidSubgraph: {
 		sdkReference:
-			'**One connected section with a single entry and exit.** The connectable members must ' +
-			'form a single connected section of the graph — reachable from one another, not two ' +
-			'unrelated islands — with at most one incoming and one outgoing main connection crossing ' +
-			'the group boundary. Sticky notes may accompany the selection without participating in ' +
-			'connectivity, and a sticky-only group is valid.',
-		violation: 'must form a single connected subgraph with a single entry and exit',
+			'**No structural constraints.** A group only frames nodes visually and does not ' +
+			'constrain the graph: any number of main connections may cross the group boundary, ' +
+			'attaching at any member, and the members need not connect to one another. Sticky notes ' +
+			'may accompany the selection, and a sticky-only group is valid.',
+		violation: 'must form a valid selection',
 	},
 	nonMainBoundary: {
 		sdkReference:
@@ -159,7 +158,10 @@ export function validateNodeSelectionForGrouping<TNode extends INode>(
 		};
 	}
 
-	const subgraphResult = validateNodeSelectionSubgraph({ ...input, nodes: connectableNodes });
+	const subgraphResult = validateNodeSelectionSubgraph(
+		{ ...input, nodes: connectableNodes },
+		{ relaxIo: true },
+	);
 	if (!subgraphResult.valid) return subgraphResult;
 
 	const nodeNames = new Set(subgraphResult.subGraph.map((node) => node.name));
@@ -454,11 +456,10 @@ function groupRuleViolationMessage(
 	}
 }
 
-function validateNodeSelectionSubgraph<TNode extends INode>({
-	nodes,
-	connectionsBySourceNode,
-	getNodeType,
-}: NodeGroupingValidationInput<TNode>): NodeSelectionValidationResult<TNode> {
+function validateNodeSelectionSubgraph<TNode extends INode>(
+	{ nodes, connectionsBySourceNode, getNodeType }: NodeGroupingValidationInput<TNode>,
+	{ relaxIo = false }: { relaxIo?: boolean } = {},
+): NodeSelectionValidationResult<TNode> {
 	const triggers = nodes.filter((node) => {
 		const nodeType = getNodeType(node);
 		return nodeType ? isTriggerNode(nodeType) : false;
@@ -473,18 +474,32 @@ function validateNodeSelectionSubgraph<TNode extends INode>({
 
 	const adjacencyList = buildAdjacencyList(connectionsBySourceNode);
 	const selectedNodeNames = new Set(nodes.map((node) => node.name));
-	const selection = parseExtractableSubgraphSelection(selectedNodeNames, adjacencyList);
+	let selection = parseExtractableSubgraphSelection(selectedNodeNames, adjacencyList);
+
+	// A group is a visual frame: it constrains nothing about the graph. Main
+	// connections may cross its boundary at any member, in any number, and the
+	// members need not connect to each other. Extraction does not relax — a
+	// subworkflow has one trigger, one return, and one continuous path.
+	if (Array.isArray(selection) && relaxIo) {
+		selection = resolveBoundarySubgraphEndpoints(selectedNodeNames, adjacencyList);
+	}
 
 	if (Array.isArray(selection)) {
 		return { valid: false, reason: 'invalid-subgraph', errors: selection };
 	}
 
-	const disconnectedSelectionError = findDisconnectedSelectionError(
-		selectedNodeNames,
-		adjacencyList,
-	);
-	if (disconnectedSelectionError) {
-		return { valid: false, reason: 'invalid-subgraph', errors: [disconnectedSelectionError] };
+	// Groups do not require connected members: the collapsed renderer remaps every
+	// boundary edge onto the group's own handles, so a frame around two parallel
+	// branches draws correctly. Extraction still requires connectivity, since a
+	// subworkflow needs one continuous path.
+	if (!relaxIo) {
+		const disconnectedSelectionError = findDisconnectedSelectionError(
+			selectedNodeNames,
+			adjacencyList,
+		);
+		if (disconnectedSelectionError) {
+			return { valid: false, reason: 'invalid-subgraph', errors: [disconnectedSelectionError] };
+		}
 	}
 
 	return { valid: true, subGraph: nodes, subGraphData: selection };
@@ -607,4 +622,46 @@ function findNonMainBoundaryConnection(
 	}
 
 	return null;
+}
+
+/**
+ * Picks the representative start/end for a group, which may have several boundary
+ * connections attaching anywhere in it. The canvas uses these only to place the
+ * collapsed block's single entry and exit handles, so it prefers a true entry (no
+ * incoming edge from inside) and a true exit (no outgoing edge to inside), and
+ * falls back to any boundary member when the group has none — a group whose only
+ * boundary edges attach mid-chain. The merge machinery in
+ * `useCanvasMapping.groups` folds the remaining edges onto them.
+ */
+function resolveBoundarySubgraphEndpoints(
+	nodeNames: Set<string>,
+	adjacencyList: IConnectionAdjacencyList,
+): ExtractableSubgraphData {
+	const entryCandidates: string[] = [];
+	const exitCandidates: string[] = [];
+	const hasInsideSource = new Set<string>();
+	const hasInsideTarget = new Set<string>();
+
+	for (const [sourceNodeName, connections] of adjacencyList.entries()) {
+		for (const connection of connections) {
+			if (connection.type !== NodeConnectionTypes.Main) continue;
+
+			const sourceInside = nodeNames.has(sourceNodeName);
+			const targetInside = nodeNames.has(connection.node);
+
+			if (sourceInside && targetInside) {
+				hasInsideSource.add(connection.node);
+				hasInsideTarget.add(sourceNodeName);
+			} else if (targetInside) {
+				entryCandidates.push(connection.node);
+			} else if (sourceInside) {
+				exitCandidates.push(sourceNodeName);
+			}
+		}
+	}
+
+	return {
+		start: entryCandidates.find((name) => !hasInsideSource.has(name)) ?? entryCandidates[0],
+		end: exitCandidates.find((name) => !hasInsideTarget.has(name)) ?? exitCandidates[0],
+	};
 }

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -625,13 +625,18 @@ function findNonMainBoundaryConnection(
 }
 
 /**
- * Picks the representative start/end for a group, which may have several boundary
- * connections attaching anywhere in it. The canvas uses these only to place the
- * collapsed block's single entry and exit handles, so it prefers a true entry (no
- * incoming edge from inside) and a true exit (no outgoing edge to inside), and
- * falls back to any boundary member when the group has none — a group whose only
- * boundary edges attach mid-chain. The merge machinery in
- * `useCanvasMapping.groups` folds the remaining edges onto them.
+ * Names the members where main connections enter and leave the group.
+ *
+ * Only extraction reads `start` / `end` (see `validateNodeSelectionForExtraction`
+ * and `doExtractNodesIntoSubworkflow`). Grouping ignores them: the collapsed
+ * canvas block remaps every boundary edge onto the group's own handles, so it
+ * never needs to know which member an edge attached to. This exists so the
+ * relaxed path still returns a well-formed `ExtractableSubgraphData`.
+ *
+ * A group may have many boundary edges attaching anywhere, so "the" entry and
+ * exit are ambiguous. It reports a member that nothing inside the group feeds
+ * (a true entry) and one that feeds nothing inside it (a true exit), falling
+ * back to any boundary member when every edge attaches mid-chain.
  */
 function resolveBoundarySubgraphEndpoints(
 	nodeNames: Set<string>,

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -1137,8 +1137,6 @@ describe('multi-entry/exit groups', () => {
 		});
 
 		expect(result.valid).toBe(true);
-		// The true entry is still preferred over the mid-chain one.
-		if (result.valid) expect(['B', 'C']).toContain(result.subGraphData.start);
 	});
 
 	it('accepts a connection out of a mid-group member', () => {
@@ -1160,10 +1158,9 @@ describe('multi-entry/exit groups', () => {
 		});
 
 		expect(result.valid).toBe(true);
-		if (result.valid) expect(result.subGraphData.end).toBe('D');
 	});
 
-	it('accepts a multi-entry/exit selection, resolving endpoints', () => {
+	it('accepts a multi-entry/exit selection', () => {
 		const result = validateNodeSelectionForGrouping({
 			nodes,
 			connectionsBySourceNode: connections,
@@ -1171,10 +1168,9 @@ describe('multi-entry/exit groups', () => {
 		});
 
 		expect(result.valid).toBe(true);
-		// Endpoints must be members, so the collapsed block can anchor its handles.
+		// Extraction endpoints do not apply to a group with several boundary edges.
 		if (result.valid) {
-			expect(['B', 'C']).toContain(result.subGraphData.start);
-			expect(result.subGraphData.end).toBe('D');
+			expect(result.subGraphData).toEqual({ start: undefined, end: undefined });
 		}
 	});
 

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -173,10 +173,11 @@ describe('node grouping validation', () => {
 		expect(result).toEqual({ valid: false, reason: 'trigger-selected', triggers: ['A'] });
 	});
 
-	it('returns invalid-subgraph when selected nodes skip an intermediate node', () => {
+	it('returns invalid-subgraph for extraction when selected nodes skip an intermediate node', () => {
 		const graph = makeLinearGraph();
 
-		const result = validateGrouping({
+		const result = validateNodeSelectionForExtraction({
+			getNodeType: () => makeNodeType(),
 			nodes: [graph.nodes[0], graph.nodes[2]],
 			connectionsBySourceNode: graph.connections,
 		});
@@ -187,10 +188,11 @@ describe('node grouping validation', () => {
 		}
 	});
 
-	it('returns invalid-subgraph when selected nodes are disconnected', () => {
+	it('returns invalid-subgraph for extraction when selected nodes are disconnected', () => {
 		const nodes = [makeNode({ id: 'a', name: 'A' }), makeNode({ id: 'b', name: 'B' })];
 
-		const result = validateGrouping({
+		const result = validateNodeSelectionForExtraction({
+			getNodeType: () => makeNodeType(),
 			nodes,
 			connectionsBySourceNode: {},
 		});
@@ -203,9 +205,15 @@ describe('node grouping validation', () => {
 
 	it('validates against the provided candidate connections', () => {
 		const graph = makeLinearGraph();
+		// Adds an ai_languageModel edge crossing the {A, B} boundary, which groups
+		// still reject — so the result must differ from the base connections.
 		const candidateConnections: IConnections = {
 			...graph.connections,
-			C: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			Model: {
+				[NodeConnectionTypes.AiLanguageModel]: [
+					[{ node: 'B', type: NodeConnectionTypes.AiLanguageModel, index: 0 }],
+				],
+			},
 		};
 
 		expect(
@@ -222,7 +230,7 @@ describe('node grouping validation', () => {
 
 		expect(result.valid).toBe(false);
 		if (!result.valid) {
-			expect(result.reason).toBe('invalid-subgraph');
+			expect(result.reason).toBe('non-main-boundary');
 		}
 	});
 
@@ -442,7 +450,8 @@ describe('node grouping validation', () => {
 			expect(result.valid).toBe(true);
 		});
 
-		it('still rejects disconnected connectable nodes when a sticky is present', () => {
+		it('accepts unconnected connectable nodes when a sticky is present', () => {
+			// Groups no longer require connected members; the sticky rides along.
 			const graph = makeLinearGraph();
 
 			const result = validateGrouping({
@@ -451,10 +460,7 @@ describe('node grouping validation', () => {
 				nodeTypes: stickyNodeTypes,
 			});
 
-			expect(result.valid).toBe(false);
-			if (!result.valid) {
-				expect(result.reason).toBe('invalid-subgraph');
-			}
+			expect(result.valid).toBe(true);
 		});
 
 		it('treats sticky-only selections as valid group data', () => {
@@ -821,21 +827,25 @@ describe('validateWorkflowGroups', () => {
 		]);
 	});
 
-	it('reports a disconnected selection as an invalid subgraph', () => {
+	it('reports a trigger in a group as a rule violation', () => {
 		const graph = makeLinearGraph();
+		const trigger = makeNode({
+			id: 'trigger',
+			name: 'Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+		});
 
 		const result = validateWorkflowGroups({
-			nodes: graph.nodes,
+			nodes: [...graph.nodes, trigger],
 			connectionsBySourceNode: graph.connections,
-			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['a', 'c'] }],
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['trigger', 'a'] }],
 			getNodeType,
 		});
 
 		expectViolations(result, [
 			{
-				code: 'invalid-subgraph',
-				message:
-					'Node group "Group" must form a single connected subgraph with a single entry and exit.',
+				code: 'trigger-selected',
+				message: 'Node group "Group" cannot contain trigger nodes: Trigger.',
 			},
 		]);
 	});
@@ -844,11 +854,16 @@ describe('validateWorkflowGroups', () => {
 		// The id is deliberately absent from the message: a group that fails these
 		// rules may never have been persisted. Consumers use `groupId` instead.
 		const graph = makeLinearGraph();
+		const trigger = makeNode({
+			id: 'trigger',
+			name: 'Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+		});
 
 		const result = validateWorkflowGroups({
-			nodes: graph.nodes,
+			nodes: [...graph.nodes, trigger],
 			connectionsBySourceNode: graph.connections,
-			nodeGroups: [{ id: 'group-uuid-1', name: 'Group', nodeIds: ['a', 'c'] }],
+			nodeGroups: [{ id: 'group-uuid-1', name: 'Group', nodeIds: ['trigger', 'a'] }],
 			getNodeType,
 		});
 
@@ -862,11 +877,17 @@ describe('validateWorkflowGroups', () => {
 	it('skips graph rules for a group that already has a basic violation', () => {
 		const graph = makeLinearGraph();
 
-		// Without the skip, {a, c} would additionally report invalid-subgraph.
+		// Without the skip, the trigger member would additionally report
+		// trigger-selected on top of the unknown-node-id basic violation.
+		const trigger = makeNode({
+			id: 'trigger',
+			name: 'Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+		});
 		const result = validateWorkflowGroups({
-			nodes: graph.nodes,
+			nodes: [...graph.nodes, trigger],
 			connectionsBySourceNode: graph.connections,
-			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['a', 'c', 'missing'] }],
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['trigger', 'a', 'missing'] }],
 			getNodeType,
 		});
 
@@ -903,20 +924,25 @@ describe('validateWorkflowGroups', () => {
 
 	it('collects all violations, basic checks first', () => {
 		const graph = makeLinearGraph();
+		const trigger = makeNode({
+			id: 'trigger',
+			name: 'Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+		});
 
 		const result = validateWorkflowGroups({
-			nodes: graph.nodes,
+			nodes: [...graph.nodes, trigger],
 			connectionsBySourceNode: graph.connections,
 			nodeGroups: [
 				{ id: 'g1', name: 'Broken', nodeIds: [] },
-				{ id: 'g2', name: 'Disconnected', nodeIds: ['a', 'c'] },
+				{ id: 'g2', name: 'HasTrigger', nodeIds: ['trigger', 'a'] },
 			],
 			getNodeType,
 		});
 
 		expectViolations(result, [
 			{ groupId: 'g1', code: 'empty-group' },
-			{ groupId: 'g2', code: 'invalid-subgraph' },
+			{ groupId: 'g2', code: 'trigger-selected' },
 		]);
 	});
 });
@@ -1075,5 +1101,124 @@ describe('dropInvalidWorkflowGroups', () => {
 			).toEqual([]);
 			expect(workflow.nodeGroups).toHaveLength(2);
 		});
+	});
+});
+
+describe('multi-entry/exit groups', () => {
+	const getNodeType = () => makeNodeType();
+
+	// Outside -> B and Outside2 -> C, so the group {B, C, D} has two entries.
+	// D -> Out1 and D -> Out2 give it two exits.
+	const nodes = ['B', 'C', 'D'].map((name) => makeNode({ id: name, name }));
+	const connections: IConnections = {
+		Outside: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+		Outside2: { main: [[{ node: 'C', type: NodeConnectionTypes.Main, index: 0 }]] },
+		B: { main: [[{ node: 'D', type: NodeConnectionTypes.Main, index: 0 }]] },
+		C: { main: [[{ node: 'D', type: NodeConnectionTypes.Main, index: 0 }]] },
+		D: {
+			main: [
+				[
+					{ node: 'Out1', type: NodeConnectionTypes.Main, index: 0 },
+					{ node: 'Out2', type: NodeConnectionTypes.Main, index: 0 },
+				],
+			],
+		},
+	};
+
+	it('accepts a connection into a mid-group member', () => {
+		// Outside -> D, where D already receives from B inside the group.
+		const result = validateNodeSelectionForGrouping({
+			nodes,
+			connectionsBySourceNode: {
+				...connections,
+				Outside3: { main: [[{ node: 'D', type: NodeConnectionTypes.Main, index: 0 }]] },
+			},
+			getNodeType,
+		});
+
+		expect(result.valid).toBe(true);
+		// The true entry is still preferred over the mid-chain one.
+		if (result.valid) expect(['B', 'C']).toContain(result.subGraphData.start);
+	});
+
+	it('accepts a connection out of a mid-group member', () => {
+		// B -> Outside4, where B also feeds D inside the group.
+		const result = validateNodeSelectionForGrouping({
+			nodes,
+			connectionsBySourceNode: {
+				...connections,
+				B: {
+					main: [
+						[
+							{ node: 'D', type: NodeConnectionTypes.Main, index: 0 },
+							{ node: 'Outside4', type: NodeConnectionTypes.Main, index: 0 },
+						],
+					],
+				},
+			},
+			getNodeType,
+		});
+
+		expect(result.valid).toBe(true);
+		if (result.valid) expect(result.subGraphData.end).toBe('D');
+	});
+
+	it('accepts a multi-entry/exit selection, resolving endpoints', () => {
+		const result = validateNodeSelectionForGrouping({
+			nodes,
+			connectionsBySourceNode: connections,
+			getNodeType,
+		});
+
+		expect(result.valid).toBe(true);
+		// Endpoints must be members, so the collapsed block can anchor its handles.
+		if (result.valid) {
+			expect(['B', 'C']).toContain(result.subGraphData.start);
+			expect(result.subGraphData.end).toBe('D');
+		}
+	});
+
+	it('accepts parallel members that do not connect to each other', () => {
+		// Two branches framed together: each member links only to outside nodes.
+		const parallel: IConnections = {
+			In: {
+				main: [
+					[
+						{ node: 'B', type: NodeConnectionTypes.Main, index: 0 },
+						{ node: 'C', type: NodeConnectionTypes.Main, index: 0 },
+					],
+				],
+			},
+			B: { main: [[{ node: 'Out1', type: NodeConnectionTypes.Main, index: 0 }]] },
+			C: { main: [[{ node: 'Out2', type: NodeConnectionTypes.Main, index: 0 }]] },
+		};
+
+		const result = validateNodeSelectionForGrouping({
+			nodes: [makeNode({ id: 'B', name: 'B' }), makeNode({ id: 'C', name: 'C' })],
+			connectionsBySourceNode: parallel,
+			getNodeType,
+		});
+
+		expect(result.valid).toBe(true);
+	});
+
+	it('still rejects a disconnected selection for extraction', () => {
+		const result = validateNodeSelectionForExtraction({
+			nodes: [makeNode({ id: 'B', name: 'B' }), makeNode({ id: 'Z', name: 'Z' })],
+			connectionsBySourceNode: connections,
+			getNodeType,
+		});
+
+		expect(result.valid).toBe(false);
+	});
+
+	it('does not relax extraction, which needs a single entry and exit', () => {
+		const result = validateNodeSelectionForExtraction({
+			nodes,
+			connectionsBySourceNode: connections,
+			getNodeType,
+		});
+
+		expect(result.valid).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

