### PR TITLE
chore: ui changes to switch to preview tab when agent makes a change

### DIFF
--- a/packages/cli/src/modules/apps/__tests__/app-draft.service.test.ts
+++ b/packages/cli/src/modules/apps/__tests__/app-draft.service.test.ts
@@ -34,8 +34,8 @@ function createDraft(files: Record<string, string>) {
 		exists: vi.fn(async (file: string) =>
 			Object.keys(files).some((f) => `/home/user/workspace/apps/greeter/${f}` === file),
 		),
-		readFile: vi.fn(async (file: string) =>
-			files[file.replace('/home/user/workspace/apps/greeter/', '')],
+		readFile: vi.fn(
+			async (file: string) => files[file.replace('/home/user/workspace/apps/greeter/', '')],
 		),
 		writeFile: vi.fn().mockResolvedValue(undefined),
 	};
@@ -109,7 +109,12 @@ describe('AppDraftService', () => {
 				return { appId: 'app-1' } as never;
 			});
 
-			const result = await service.write('app-1', USER, async () => ({ 'src/main.ts': 'x' }), draft);
+			const result = await service.write(
+				'app-1',
+				USER,
+				async () => ({ 'src/main.ts': 'x' }),
+				draft,
+			);
 
 			expect(restoreAppMock).toHaveBeenCalledWith(
 				expect.objectContaining({ appWorkspace: expect.anything() }),
@@ -130,7 +135,12 @@ describe('AppDraftService', () => {
 			const { draft, filesystem } = createDraft({});
 			restoreAppMock.mockResolvedValue({ error: true, stage: 'restore', message: 'unpack failed' });
 
-			const result = await service.write('app-1', USER, async () => ({ 'src/main.ts': 'x' }), draft);
+			const result = await service.write(
+				'app-1',
+				USER,
+				async () => ({ 'src/main.ts': 'x' }),
+				draft,
+			);
 
 			expect(result).toEqual({ error: true, message: 'unpack failed' });
 			expect(filesystem.writeFile).not.toHaveBeenCalled();

--- a/packages/cli/src/modules/apps/app-draft.service.ts
+++ b/packages/cli/src/modules/apps/app-draft.service.ts
@@ -51,7 +51,10 @@ export class AppDraftService {
 		if (draft) await this.snapshotService.snapshotAfterRun(appId, user, draft);
 		const [newest] = await this.appsService.listVersions(appId);
 		if (!newest) return null;
-		return { versionId: newest.id, files: await this.appsService.listVersionFiles(appId, newest.id) };
+		return {
+			versionId: newest.id,
+			files: await this.appsService.listVersionFiles(appId, newest.id),
+		};
 	}
 
 	/** `draft`: the app's sandbox workspace; a sandbox that does not hold the app yet gets it restored first. */
@@ -93,7 +96,8 @@ export class AppDraftService {
 		const root = await getWorkspaceRoot(draft);
 		const workspace = createScopedWorkspace(draft, root);
 		const filesystem = workspace.filesystem;
-		if (!filesystem) return { error: true, message: 'The sandbox is not available on this instance.' };
+		if (!filesystem)
+			return { error: true, message: 'The sandbox is not available on this instance.' };
 
 		const appDir = `apps/${namespace}`;
 		if (!(await filesystem.exists(`${appDir}/package.json`))) {

--- a/packages/frontend/editor-ui/src/features/apps/AppDetailsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/apps/AppDetailsView.test.ts
@@ -982,6 +982,31 @@ describe('AppDetailsView', () => {
 		);
 	});
 
+	it('switches to Preview on a later build too, not just the first', async () => {
+		const { getByTestId, queryByTestId, rerender } = await renderApp(makeApp(), {
+			artifactMode: true,
+			artifactVersionId: 'v-1',
+		});
+
+		expect(getByTestId('app-builder-preview')).toBeInTheDocument();
+
+		await userEvent.click(getByTestId('app-builder-mode-build'));
+		expect(getByTestId('app-builder-build')).toBeInTheDocument();
+
+		await rerender({
+			projectId: 'proj-1',
+			appId: 'app-1',
+			artifactMode: true,
+			artifactVersionId: 'v-2',
+		});
+
+		expect(queryByTestId('app-builder-build')).not.toBeInTheDocument();
+		expect(getByTestId('instance-ai-app-preview-iframe')).toHaveAttribute(
+			'src',
+			'/apps/greeter/?v=v-2',
+		);
+	});
+
 	describe('live preview', () => {
 		const liveProps = {
 			projectId: 'proj-1',

--- a/packages/frontend/editor-ui/src/features/apps/AppDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/apps/AppDetailsView.vue
@@ -485,9 +485,16 @@ watch(buildTab, async (tab) => {
 
 // The turn's snapshot decides whether the draft has unpublished changes and
 // which pages the app has: routes are derived from the newest snapshot.
+//
+// A live-preview edit lands here without ever touching `versionId` (it
+// updates the draft, not the published version), so this is also where an
+// agent-driven change on that path surfaces its result — same as the
+// versionId watcher above, unconditionally, even if the user had switched
+// away from Preview.
 watch(
 	() => props.refreshKey,
 	async () => {
+		mode.value = 'preview';
 		try {
 			const [updated] = await Promise.all([
 				appsStore.getApp(props.projectId, props.appId),

--- a/packages/frontend/editor-ui/src/features/apps/AppDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/apps/AppDetailsView.vue
@@ -471,6 +471,13 @@ watch(showPreviewPane, (next, previous) => {
 	if (next && !previous) mode.value = 'preview';
 });
 
+// A later build is what the user was waiting for too, not just the first —
+// so an agent-driven change always surfaces the result instead of leaving
+// the user staring at Build, even if a preview was already showing.
+watch(versionId, (next, previous) => {
+	if (next && next !== previous) mode.value = 'preview';
+});
+
 // Fetched on demand: the list changes with every assistant turn and publish.
 watch(buildTab, async (tab) => {
 	if (tab === 'versions') await refreshVersions();

--- a/packages/frontend/editor-ui/src/features/apps/components/__tests__/AppCodeViewer.test.ts
+++ b/packages/frontend/editor-ui/src/features/apps/components/__tests__/AppCodeViewer.test.ts
@@ -76,7 +76,10 @@ describe('AppCodeViewer', () => {
 	});
 
 	it('lists the files in a tree and shows a placeholder before any file is selected', async () => {
-		appsStore.fetchAppDraftFiles.mockResolvedValue({ versionId: 'v-1', files: ['main.ts', 'index.html'] });
+		appsStore.fetchAppDraftFiles.mockResolvedValue({
+			versionId: 'v-1',
+			files: ['main.ts', 'index.html'],
+		});
 		const { getByText, queryByTestId } = renderViewer({
 			props: { projectId: 'proj-1', appId: 'app-1' },
 		});
@@ -209,7 +212,9 @@ describe('AppCodeViewer', () => {
 		await userEvent.click(getByTestId('app-code-save'));
 		await waitAllPromises();
 
-		expect(getByTestId('app-code-save-error')).toHaveTextContent("Could not find the file: 'main.ts'");
+		expect(getByTestId('app-code-save-error')).toHaveTextContent(
+			"Could not find the file: 'main.ts'",
+		);
 		expect(getByTestId('fcv-content')).toHaveTextContent('main.ts:export {};!');
 		expect(getByTestId('app-code-save')).not.toHaveAttribute('aria-disabled', 'true');
 	});


### PR DESCRIPTION
## Summary
This PR is a UI change that switches the user's view to the Preview tab when the agent makes a change in the AI assistant. 

## How to test
1. Use the AI assistant to build an app
2. Switch to the `Build` tab
3. Ask the AI agent to make a change
4. Confirm that you see that when a change is made the tab is automatically switched to`Preview`

## Related Linear tickets, Github issues, and Community forum posts
Hackweek - no Linear tickets 

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. 
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


