### PR TITLE
ci: Grant contents read to the bundle PR retarget job (no-changelog)

### DIFF
--- a/.github/workflows/sec-sync-bundle-branches.yml
+++ b/.github/workflows/sec-sync-bundle-branches.yml
@@ -100,6 +100,7 @@ jobs:
     needs: [sync]
     if: ${{ !cancelled() && needs.sync.result != 'skipped' }}
     permissions:
+      contents: read # read the bundle branch ref
       pull-requests: write
     uses: ./.github/workflows/sec-sync-retarget-prs.yml
 


### PR DESCRIPTION
## Summary

`Security: Sync Bundle Branches` failed to load with:

> The nested job 'retarget' is requesting 'contents: read', but is only allowed 'contents: none'.

A caller job's `permissions:` block is the whole grant — anything it omits is `none`. The `retarget` job listed only `pull-requests: write`, while the reusable workflow's own job declares `contents: read` (it reads the bundle branch ref before moving any PR). Added `contents: read` to the caller. It is the only caller of that workflow.

## How to test

Dispatch `Security: Sync Bundle Branches` in `n8n-io/n8n-private`. The run now starts instead of failing at workflow load.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

