### PR TITLE
fix(core): Fix workflow publishing silently failing in multi-main mode

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
@@ -560,6 +560,109 @@ describe('WorkflowProductionChecklist', () => {
 
 			expect(mockN8nSuggestedActionsProps.open).toBe(false);
 		});
+
+		// ADO-4969: with the publication service, activeVersionId is set as soon as
+		// the publish request returns, but trigger registration can still fail. The
+		// checklist must only auto-open once the lifecycle confirms the publication.
+		describe('with the publication service enabled', () => {
+			function renderWithPublicationService() {
+				const pinia = createTestingPinia();
+				settingsStore = useSettingsStore(pinia);
+				vi.spyOn(settingsStore, 'isWorkflowPublicationServiceEnabled', 'get').mockReturnValue(true);
+
+				workflowsCache.getWorkflowSettings = vi.fn().mockResolvedValue({
+					suggestedActions: {},
+					firstActivatedAt: undefined,
+				});
+
+				workflowDocumentStoreRef.value?.setActiveState({
+					activeVersionId: null,
+					activeVersion: null,
+				});
+				workflowDocumentStoreRef.value?.setPublicationStatus({ status: 'idle' });
+
+				return renderComponent({ pinia });
+			}
+
+			function publishOptimistically() {
+				// What publishWorkflow does when the publish request returns, before
+				// the real outcome is known.
+				workflowDocumentStoreRef.value?.setActiveState({
+					activeVersionId: 'v1',
+					activeVersion: null,
+				});
+				workflowDocumentStoreRef.value?.setPublicationStatus({ status: 'publishing' });
+			}
+
+			it('should not open popover or record first activation while still publishing', async () => {
+				renderWithPublicationService();
+				await flushPromises();
+
+				publishOptimistically();
+				await flushPromises();
+
+				expect(mockN8nSuggestedActionsProps.open).toBe(false);
+				expect(workflowsCache.updateFirstActivatedAt).not.toHaveBeenCalled();
+			});
+
+			it('should not open popover or record first activation when the publication fails', async () => {
+				renderWithPublicationService();
+				await flushPromises();
+
+				publishOptimistically();
+				await flushPromises();
+
+				workflowDocumentStoreRef.value?.setPublicationStatus({
+					status: 'failed',
+					failures: [{ nodeId: 'n1', nodeName: 'Github Trigger', errorMessage: 'boom' }],
+				});
+				await flushPromises();
+
+				expect(mockN8nSuggestedActionsProps.open).toBe(false);
+				expect(workflowsCache.updateFirstActivatedAt).not.toHaveBeenCalled();
+			});
+
+			it('should open popover once the publication is confirmed', async () => {
+				renderWithPublicationService();
+				await flushPromises();
+
+				publishOptimistically();
+				await flushPromises();
+				expect(mockN8nSuggestedActionsProps.open).toBe(false);
+
+				workflowDocumentStoreRef.value?.setPublicationStatus({ status: 'published' });
+
+				await vi.waitFor(() => {
+					expect(workflowsCache.updateFirstActivatedAt).toHaveBeenCalledWith(mockWorkflow.id);
+				});
+				await vi.waitFor(() => {
+					expect(mockN8nSuggestedActionsProps.open).toBe(true);
+				});
+			});
+
+			it('should open popover on the first publication that succeeds after a failed one', async () => {
+				renderWithPublicationService();
+				await flushPromises();
+
+				publishOptimistically();
+				workflowDocumentStoreRef.value?.setPublicationStatus({
+					status: 'failed',
+					failures: [],
+				});
+				await flushPromises();
+				expect(mockN8nSuggestedActionsProps.open).toBe(false);
+
+				// User retries and this time registration succeeds
+				workflowDocumentStoreRef.value?.setPublicationStatus({ status: 'publishing' });
+				await flushPromises();
+				workflowDocumentStoreRef.value?.setPublicationStatus({ status: 'published' });
+
+				await vi.waitFor(() => {
+					expect(mockN8nSuggestedActionsProps.open).toBe(true);
+				});
+				expect(workflowsCache.updateFirstActivatedAt).toHaveBeenCalledWith(mockWorkflow.id);
+			});
+		});
 	});
 
 	describe('Completion states', () => {

--- a/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.vue
@@ -245,34 +245,49 @@ function handlePopoverOpenChange(open: boolean) {
 	}
 }
 
-// Watch for workflow activation
-watch(
-	() => !!workflowDocumentStore?.value?.activeVersionId,
-	async (isActive, wasActive) => {
-		if (isActive && !wasActive) {
-			// Check if this is the first activation
-			if (!cachedSettings.value?.firstActivatedAt) {
-				if (isAnyModalOpen.value) {
-					// Defer opening until any open modal closes so the popover
-					// doesn't paint over it.
-					const stop = watch(isAnyModalOpen, (isOpen) => {
-						if (!isOpen) {
-							stop();
-							openSuggestedActions();
-						}
-					});
-				} else {
-					setTimeout(() => {
-						openSuggestedActions();
-					}, 0); // Ensure UI is ready and availableActions.length > 0
-				}
-			}
+// With the publication service, activeVersionId flips optimistically when the
+// publish request returns; whether the triggers actually registered arrives
+// later as a lifecycle push. Only count the workflow as activated once the
+// lifecycle confirms it, so a failed publish never auto-opens the checklist
+// (ADO-4969). Without the service, activation is synchronous and
+// activeVersionId is already authoritative (the lifecycle stays 'idle' there).
+const isConfirmedActive = computed(() => {
+	if (!workflowDocumentStore?.value?.activeVersionId) {
+		return false;
+	}
 
-			// Update firstActivatedAt after opening popover
-			await workflowsCache.updateFirstActivatedAt(workflowDocumentStore?.value?.workflowId ?? '');
+	if (settingsStore.isWorkflowPublicationServiceEnabled) {
+		return workflowDocumentStore.value.publicationStatus === 'published';
+	}
+
+	return true;
+});
+
+// Watch for workflow activation
+watch(isConfirmedActive, async (isActive, wasActive) => {
+	if (isActive && !wasActive) {
+		// Check if this is the first activation
+		if (!cachedSettings.value?.firstActivatedAt) {
+			if (isAnyModalOpen.value) {
+				// Defer opening until any open modal closes so the popover
+				// doesn't paint over it.
+				const stop = watch(isAnyModalOpen, (isOpen) => {
+					if (!isOpen) {
+						stop();
+						openSuggestedActions();
+					}
+				});
+			} else {
+				setTimeout(() => {
+					openSuggestedActions();
+				}, 0); // Ensure UI is ready and availableActions.length > 0
+			}
 		}
-	},
-);
+
+		// Update firstActivatedAt after opening popover
+		await workflowsCache.updateFirstActivatedAt(workflowDocumentStore?.value?.workflowId ?? '');
+	}
+});
 
 onMounted(async () => {
 	await loadWorkflowSettings();

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
@@ -160,6 +160,27 @@ describe('workflowActivated', () => {
 			expect(mockConsumePendingActivationModal).toHaveBeenCalledWith('wf-other', 'v1');
 			expect(mockUIStore.openModal).not.toHaveBeenCalled();
 		});
+
+		it('opens the modal before the workspace refresh, so navigating away mid-refresh cannot misplace it', async () => {
+			mockConsumePendingActivationModal.mockReturnValue(true);
+
+			// Push beats the publish response: the stored active version is stale,
+			// so the handler refreshes the workspace (awaits).
+			let resolveFetch!: (workflow: { id: string; checksum: string }) => void;
+			mockWorkflowsListStore.fetchWorkflow.mockReturnValue(
+				new Promise((resolve) => {
+					resolveFetch = resolve;
+				}),
+			);
+
+			const handlerDone = workflowActivated(makeEvent('wf-123', 'v1'), options);
+
+			// The modal is already open while the refresh is still in flight.
+			expect(mockUIStore.openModal).toHaveBeenCalledWith(WORKFLOW_ACTIVE_MODAL_KEY);
+
+			resolveFetch({ id: 'wf-123', checksum: 'abc' });
+			await handlerDone;
+		});
 	});
 
 	// Regression: INS-859 — "Workflow was changed by someone else" on dragging a node.

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
@@ -7,6 +7,7 @@ import {
 	createWorkflowDocumentId,
 	useWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
+import { WORKFLOW_ACTIVE_MODAL_KEY } from '@/app/constants';
 import type { PushHandlerOptions } from './types';
 
 const {
@@ -15,6 +16,7 @@ const {
 	mockBannersStore,
 	mockUIStore,
 	mockSettingsStore,
+	mockConsumePendingActivationModal,
 } = vi.hoisted(() => ({
 	mockWorkflowsListStore: {
 		fetchWorkflow: vi.fn(),
@@ -27,10 +29,12 @@ const {
 	},
 	mockUIStore: {
 		stateIsDirty: false,
+		openModal: vi.fn(),
 	},
 	mockSettingsStore: {
 		isWorkflowPublicationServiceEnabled: true,
 	},
+	mockConsumePendingActivationModal: vi.fn(),
 }));
 
 vi.mock('@/app/stores/workflowsList.store', () => ({
@@ -53,6 +57,10 @@ vi.mock('@n8n/stores/settings.store', () => ({
 	useSettingsStore: () => mockSettingsStore,
 }));
 
+vi.mock('@/app/composables/workflowPublicationConfirmation', () => ({
+	consumePendingActivationModal: mockConsumePendingActivationModal,
+}));
+
 describe('workflowActivated', () => {
 	const documentId = createWorkflowDocumentId('wf-123');
 	let options: PushHandlerOptions;
@@ -70,6 +78,7 @@ describe('workflowActivated', () => {
 		vi.clearAllMocks();
 		mockUIStore.stateIsDirty = false;
 		mockSettingsStore.isWorkflowPublicationServiceEnabled = true;
+		mockConsumePendingActivationModal.mockReturnValue(false);
 		options = { router: mock<Router>(), documentId };
 		workflowDocumentStore = useWorkflowDocumentStore(documentId);
 	});
@@ -118,6 +127,39 @@ describe('workflowActivated', () => {
 
 		expect(workflowDocumentStore.publicationStatus).toBe('idle');
 		expect(mockBannersStore.removeBannerFromStack).not.toHaveBeenCalled();
+	});
+
+	// ADO-4969: the publish flow defers the one-time success modal until this
+	// confirming push, so a failure push arriving instead can never contradict
+	// an already-shown success dialog.
+	describe('deferred activation success modal (ADO-4969)', () => {
+		it('opens the success modal when this tab published the confirmed version', async () => {
+			mockWorkflowsListStore.fetchWorkflow.mockResolvedValue({ id: 'wf-123', checksum: 'abc' });
+			mockConsumePendingActivationModal.mockReturnValue(true);
+
+			await workflowActivated(makeEvent('wf-123', 'v1'), options);
+
+			expect(mockConsumePendingActivationModal).toHaveBeenCalledWith('wf-123', 'v1');
+			expect(mockUIStore.openModal).toHaveBeenCalledWith(WORKFLOW_ACTIVE_MODAL_KEY);
+		});
+
+		it('does not open the modal when no publish is pending in this tab', async () => {
+			mockWorkflowsListStore.fetchWorkflow.mockResolvedValue({ id: 'wf-123', checksum: 'abc' });
+			mockConsumePendingActivationModal.mockReturnValue(false);
+
+			await workflowActivated(makeEvent('wf-123', 'v1'), options);
+
+			expect(mockUIStore.openModal).not.toHaveBeenCalled();
+		});
+
+		it('resolves the intent but keeps the modal closed when viewing another workflow', async () => {
+			mockConsumePendingActivationModal.mockReturnValue(true);
+
+			await workflowActivated(makeEvent('wf-other', 'v1'), options);
+
+			expect(mockConsumePendingActivationModal).toHaveBeenCalledWith('wf-other', 'v1');
+			expect(mockUIStore.openModal).not.toHaveBeenCalled();
+		});
 	});
 
 	// Regression: INS-859 — "Workflow was changed by someone else" on dragging a node.

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -5,6 +5,8 @@ import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+import { consumePendingActivationModal } from '@/app/composables/workflowPublicationConfirmation';
+import { WORKFLOW_ACTIVE_MODAL_KEY } from '@/app/constants';
 import type { PushHandlerOptions } from './types';
 
 export async function workflowActivated(
@@ -18,6 +20,9 @@ export async function workflowActivated(
 	const uiStore = useUIStore();
 
 	const { workflowId, activeVersionId } = data;
+
+	// Publication confirmed - resolve the intent in this tab
+	const showActivationModal = consumePendingActivationModal(workflowId, activeVersionId);
 
 	const workflowIsBeingViewed = workflowDocumentStore.workflowId === workflowId;
 	const activeVersionChanged = workflowDocumentStore.activeVersionId !== activeVersionId;
@@ -42,5 +47,10 @@ export async function workflowActivated(
 			workflowDocumentStore.setPublicationStatus({ status: 'published', failures: [] });
 		}
 		bannersStore.removeBannerFromStack('WORKFLOW_AUTO_DEACTIVATED');
+
+		// First publish initiated in this tab: how the one-time success modal (ADO-4969).
+		if (showActivationModal) {
+			uiStore.openModal(WORKFLOW_ACTIVE_MODAL_KEY);
+		}
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -25,6 +25,15 @@ export async function workflowActivated(
 	const showActivationModal = consumePendingActivationModal(workflowId, activeVersionId);
 
 	const workflowIsBeingViewed = workflowDocumentStore.workflowId === workflowId;
+
+	// First publish initiated in this tab: show the one-time success modal (ADO-4969).
+	// Open it before the refresh below: the awaits can yield long enough for
+	// navigation to change what is on screen, and the modal does not depend on
+	// the fetched data.
+	if (workflowIsBeingViewed && showActivationModal) {
+		uiStore.openModal(WORKFLOW_ACTIVE_MODAL_KEY);
+	}
+
 	const activeVersionChanged = workflowDocumentStore.activeVersionId !== activeVersionId;
 	if (workflowIsBeingViewed && activeVersionChanged) {
 		const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
@@ -47,10 +56,5 @@ export async function workflowActivated(
 			workflowDocumentStore.setPublicationStatus({ status: 'published', failures: [] });
 		}
 		bannersStore.removeBannerFromStack('WORKFLOW_AUTO_DEACTIVATED');
-
-		// First publish initiated in this tab: how the one-time success modal (ADO-4969).
-		if (showActivationModal) {
-			uiStore.openModal(WORKFLOW_ACTIVE_MODAL_KEY);
-		}
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.test.ts
@@ -9,14 +9,23 @@ import {
 } from '@/app/stores/workflowDocument.store';
 import type { PushHandlerOptions } from './types';
 
-const { mockSettingsStore, mockUiStore, mockInitializeWorkspace, mockFetchWorkflow } = vi.hoisted(
-	() => ({
-		mockSettingsStore: { isWorkflowPublicationServiceEnabled: true },
-		mockUiStore: { stateIsDirty: true },
-		mockInitializeWorkspace: vi.fn(),
-		mockFetchWorkflow: vi.fn().mockResolvedValue({ checksum: 'abc' }),
-	}),
-);
+const {
+	mockSettingsStore,
+	mockUiStore,
+	mockInitializeWorkspace,
+	mockFetchWorkflow,
+	mockClearPendingActivationModal,
+} = vi.hoisted(() => ({
+	mockSettingsStore: { isWorkflowPublicationServiceEnabled: true },
+	mockUiStore: { stateIsDirty: true },
+	mockInitializeWorkspace: vi.fn(),
+	mockFetchWorkflow: vi.fn().mockResolvedValue({ checksum: 'abc' }),
+	mockClearPendingActivationModal: vi.fn(),
+}));
+
+vi.mock('@/app/composables/workflowPublicationConfirmation', () => ({
+	clearPendingActivationModal: mockClearPendingActivationModal,
+}));
 
 vi.mock('@n8n/stores/settings.store', () => ({
 	useSettingsStore: () => mockSettingsStore,
@@ -62,6 +71,20 @@ describe('workflowDeactivated', () => {
 
 		expect(workflowDocumentStore.publicationStatus).toBe('idle');
 		expect(workflowDocumentStore.publicationFailures).toEqual([]);
+	});
+
+	// ADO-4969: an unpublish that lands while a publish confirmation is pending
+	// invalidates the deferred success modal.
+	it('clears a pending activation success modal intent', async () => {
+		await workflowDeactivated(makeEvent(), options);
+
+		expect(mockClearPendingActivationModal).toHaveBeenCalledWith('wf-123');
+	});
+
+	it('clears the pending intent even when viewing another workflow', async () => {
+		await workflowDeactivated(makeEvent('wf-other'), options);
+
+		expect(mockClearPendingActivationModal).toHaveBeenCalledWith('wf-other');
 	});
 
 	it('clears the status on the non-dirty (re-init) path too', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -4,6 +4,7 @@ import { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+import { clearPendingActivationModal } from '@/app/composables/workflowPublicationConfirmation';
 import type { PushHandlerOptions } from './types';
 
 export async function workflowDeactivated(
@@ -14,6 +15,10 @@ export async function workflowDeactivated(
 	const workflowsListStore = useWorkflowsListStore();
 	const workflowDocumentStore = useWorkflowDocumentStore(documentId);
 	const uiStore = useUIStore();
+
+	// The workflow got unpublished while a publish confirmation was pending:
+	// the success modal no longer applies.
+	clearPendingActivationModal(data.workflowId);
 
 	if (workflowDocumentStore.workflowId === data.workflowId) {
 		// The workflow is no longer published; clear any lingering publication

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.test.ts
@@ -10,7 +10,13 @@ import {
 import type { PushHandlerOptions } from './types';
 import type { INodeUi } from '@/Interface';
 
-const { mockToast, mockI18n, mockSettingsStore, mockWorkflowsStore } = vi.hoisted(() => ({
+const {
+	mockToast,
+	mockI18n,
+	mockSettingsStore,
+	mockWorkflowsStore,
+	mockClearPendingActivationModal,
+} = vi.hoisted(() => ({
 	mockToast: {
 		showError: vi.fn(),
 	},
@@ -23,6 +29,7 @@ const { mockToast, mockI18n, mockSettingsStore, mockWorkflowsStore } = vi.hoiste
 	mockWorkflowsStore: {
 		setWorkflowInactive: vi.fn(),
 	},
+	mockClearPendingActivationModal: vi.fn(),
 }));
 
 vi.mock('@n8n/composables/useToast', () => ({
@@ -43,6 +50,10 @@ vi.mock('@n8n/stores/settings.store', () => ({
 
 vi.mock('@/app/stores/workflows.store', () => ({
 	useWorkflowsStore: () => mockWorkflowsStore,
+}));
+
+vi.mock('@/app/composables/workflowPublicationConfirmation', () => ({
+	clearPendingActivationModal: mockClearPendingActivationModal,
 }));
 
 describe('workflowFailedToActivate', () => {
@@ -144,6 +155,28 @@ describe('workflowFailedToActivate', () => {
 				expect.any(String),
 				expect.objectContaining({ description: undefined }),
 			);
+		});
+
+		// ADO-4969: the toast said "could not be activated" while the rest of the
+		// publish flow speaks of publishing.
+		it('titles the toast with "published" wording', async () => {
+			await workflowFailedToActivate(makeEvent(), options);
+
+			expect(mockI18n.baseText).toHaveBeenCalledWith('workflowActivator.showError.title', {
+				interpolate: { newStateName: 'published' },
+			});
+		});
+
+		it('clears a pending activation success modal intent (ADO-4969)', async () => {
+			await workflowFailedToActivate(makeEvent(), options);
+
+			expect(mockClearPendingActivationModal).toHaveBeenCalledWith('wf-123');
+		});
+
+		it('clears the pending intent even when viewing another workflow', async () => {
+			await workflowFailedToActivate(makeEvent({ workflowId: 'wf-other' }), options);
+
+			expect(mockClearPendingActivationModal).toHaveBeenCalledWith('wf-other');
 		});
 
 		it('does not set publicationStatus when the event is for a different workflow', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.ts
@@ -5,12 +5,17 @@ import { useI18n } from '@n8n/i18n';
 import { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
+import { clearPendingActivationModal } from '@/app/composables/workflowPublicationConfirmation';
 import type { PushHandlerOptions } from './types';
 
 export async function workflowFailedToActivate(
 	{ data }: WorkflowFailedToActivate,
 	{ documentId }: PushHandlerOptions,
 ) {
+	// The publication failed: make sure the success modal deferred by the
+	// publish flow never shows, even when this tab moved to another workflow.
+	clearPendingActivationModal(data.workflowId);
+
 	const workflowDocumentStore = useWorkflowDocumentStore(documentId);
 
 	if (workflowDocumentStore.workflowId !== data.workflowId) {
@@ -45,7 +50,7 @@ export async function workflowFailedToActivate(
 	const i18n = useI18n();
 	const { errorMessage } = useActivationError(() => data.nodeId);
 	const title = i18n.baseText('workflowActivator.showError.title', {
-		interpolate: { newStateName: 'activated' },
+		interpolate: { newStateName: 'published' },
 	});
 	toast.showError(new Error(data.errorMessage), title, {
 		message: errorMessage.value,

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.test.ts
@@ -17,6 +17,7 @@ const {
 	mockToast,
 	mockI18n,
 	mockSettingsStore,
+	mockClearPendingActivationModal,
 } = vi.hoisted(() => ({
 	mockWorkflowsListStore: {
 		fetchWorkflow: vi.fn(),
@@ -39,6 +40,11 @@ const {
 	mockSettingsStore: {
 		isWorkflowPublicationServiceEnabled: true,
 	},
+	mockClearPendingActivationModal: vi.fn(),
+}));
+
+vi.mock('@/app/composables/workflowPublicationConfirmation', () => ({
+	clearPendingActivationModal: mockClearPendingActivationModal,
 }));
 
 vi.mock('@/app/stores/workflowsList.store', () => ({
@@ -111,6 +117,22 @@ describe('workflowPartiallyActivated', () => {
 			{ nodeId: 'node-1', nodeName: 'Webhook', errorMessage: 'Path conflict' },
 			{ nodeId: 'node-2', nodeName: 'Schedule', errorMessage: 'Registration failed' },
 		]);
+	});
+
+	// ADO-4969: a partial publication gets its own warning toast; the success
+	// modal deferred by the publish flow must never show next to it.
+	it('clears a pending activation success modal intent', async () => {
+		mockWorkflowsListStore.fetchWorkflow.mockResolvedValue({ id: 'wf-123', checksum: 'abc' });
+
+		await workflowPartiallyActivated(makeEvent(), options);
+
+		expect(mockClearPendingActivationModal).toHaveBeenCalledWith('wf-123');
+	});
+
+	it('clears the pending intent even when viewing another workflow', async () => {
+		await workflowPartiallyActivated(makeEvent({ workflowId: 'wf-other' }), options);
+
+		expect(mockClearPendingActivationModal).toHaveBeenCalledWith('wf-other');
 	});
 
 	it('does NOT set publicationStatus when flag is off', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.ts
@@ -7,6 +7,7 @@ import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+import { clearPendingActivationModal } from '@/app/composables/workflowPublicationConfirmation';
 import type { PushHandlerOptions } from './types';
 
 export async function workflowPartiallyActivated(
@@ -20,6 +21,9 @@ export async function workflowPartiallyActivated(
 	const uiStore = useUIStore();
 
 	const { workflowId, activeVersionId } = data;
+
+	// A partial publication gets its own warning toast; no need to show modal
+	clearPendingActivationModal(workflowId);
 
 	if (workflowDocumentStore.workflowId !== workflowId) {
 		return;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useWorkflowActivate } from './useWorkflowActivate';
+import { WORKFLOW_ACTIVE_MODAL_KEY } from '@/app/constants';
 
 // --- hoisted mocks ---
 // vi.hoisted callbacks run before any imports, so only plain JS is usable there.
@@ -55,26 +56,43 @@ vi.mock('@/app/stores/workflows.store', () => ({
 	}),
 }));
 
+const mockGetWorkflowById = vi.hoisted(() =>
+	vi.fn().mockReturnValue({ activeVersion: null as unknown }),
+);
+
 vi.mock('@/app/stores/workflowsList.store', () => ({
 	useWorkflowsListStore: vi.fn().mockReturnValue({
-		getWorkflowById: vi.fn().mockReturnValue({ activeVersion: null }),
+		getWorkflowById: mockGetWorkflowById,
 		fetchWorkflow: vi.fn(),
 	}),
 }));
 
 // useSettingsStore is called at publish time (not at composable init), so we
 // control the return value per-test via the mockSettingsImpl variable below.
-const mockSettingsImpl = vi.hoisted(() => ({ isWorkflowPublicationServiceEnabled: false }));
+const mockSettingsImpl = vi.hoisted(() => ({
+	isWorkflowPublicationServiceEnabled: false,
+	isMultiMain: false,
+}));
 
 vi.mock('@n8n/stores/settings.store', () => ({
 	useSettingsStore: vi.fn(() => mockSettingsImpl),
 }));
 
+const mockOpenModal = vi.hoisted(() => vi.fn());
+
 vi.mock('@/app/stores/ui.store', () => ({
 	useUIStore: vi.fn().mockReturnValue({
-		openModal: vi.fn(),
+		openModal: mockOpenModal,
 		openModalWithData: vi.fn(),
 	}),
+}));
+
+const mockRegisterPendingActivationModal = vi.hoisted(() => vi.fn());
+const mockClearPendingActivationModal = vi.hoisted(() => vi.fn());
+
+vi.mock('@/app/composables/workflowPublicationConfirmation', () => ({
+	registerPendingActivationModal: mockRegisterPendingActivationModal,
+	clearPendingActivationModal: mockClearPendingActivationModal,
 }));
 
 vi.mock('@/features/collaboration/collaboration/collaboration.store', () => ({
@@ -95,8 +113,11 @@ vi.mock('@n8n/composables/useToast', () => ({
 	useToast: vi.fn().mockReturnValue({ showError: vi.fn(), showMessage: vi.fn() }),
 }));
 
+// Models the "Don't show again" flag of the activation success modal.
+const mockActivationStorageFlag = vi.hoisted(() => ({ value: undefined as string | undefined }));
+
 vi.mock('@n8n/composables/useStorage', () => ({
-	useStorage: vi.fn().mockReturnValue({ value: undefined }),
+	useStorage: vi.fn().mockReturnValue(mockActivationStorageFlag),
 }));
 
 vi.mock('@/app/composables/useActivationError', () => ({
@@ -136,6 +157,9 @@ describe('useWorkflowActivate', () => {
 		setActivePinia(createPinia());
 		vi.clearAllMocks();
 		mockSettingsImpl.isWorkflowPublicationServiceEnabled = false;
+		mockSettingsImpl.isMultiMain = false;
+		mockActivationStorageFlag.value = undefined;
+		mockGetWorkflowById.mockReturnValue({ activeVersion: null });
 		mockDocumentStore.hydrated = false;
 		mockDocumentStore.checksum = undefined;
 		otherDocumentStore.hydrated = false;
@@ -253,6 +277,94 @@ describe('useWorkflowActivate', () => {
 			expect(mockSetActiveState).not.toHaveBeenCalled();
 			expect(mockSetVersionData).not.toHaveBeenCalled();
 			expect(mockSetChecksum).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('publishWorkflow() — activation success modal (ADO-4969)', () => {
+		it('defers the modal to the confirming push when the publication service is ON', async () => {
+			mockSettingsImpl.isWorkflowPublicationServiceEnabled = true;
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
+
+			const { publishWorkflow } = useWorkflowActivate();
+			const result = await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(result).toEqual({ success: true });
+			expect(mockRegisterPendingActivationModal).toHaveBeenCalledWith(WORKFLOW_ID, VERSION_ID);
+			expect(mockOpenModal).not.toHaveBeenCalled();
+		});
+
+		it('registers the intent before the publish request, so an early push is not missed', async () => {
+			mockSettingsImpl.isWorkflowPublicationServiceEnabled = true;
+			const callOrder: string[] = [];
+			mockRegisterPendingActivationModal.mockImplementationOnce(() => {
+				callOrder.push('register');
+			});
+			mockPublishWorkflow.mockImplementationOnce(async () => {
+				callOrder.push('request');
+				return makePublishedWorkflowResponse();
+			});
+
+			const { publishWorkflow } = useWorkflowActivate();
+			await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(callOrder).toEqual(['register', 'request']);
+		});
+
+		it('defers the modal in multi-main setups even when the publication service is OFF', async () => {
+			mockSettingsImpl.isMultiMain = true;
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
+
+			const { publishWorkflow } = useWorkflowActivate();
+			await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(mockRegisterPendingActivationModal).toHaveBeenCalledWith(WORKFLOW_ID, VERSION_ID);
+			expect(mockOpenModal).not.toHaveBeenCalled();
+		});
+
+		it('opens the modal right away on legacy single-main, where no push will come', async () => {
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
+
+			const { publishWorkflow } = useWorkflowActivate();
+			await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(mockOpenModal).toHaveBeenCalledWith(WORKFLOW_ACTIVE_MODAL_KEY);
+			expect(mockRegisterPendingActivationModal).not.toHaveBeenCalled();
+		});
+
+		it('does nothing modal-related when the workflow already had a published version', async () => {
+			mockSettingsImpl.isWorkflowPublicationServiceEnabled = true;
+			mockGetWorkflowById.mockReturnValue({ activeVersion: { versionId: 'v-0' } });
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
+
+			const { publishWorkflow } = useWorkflowActivate();
+			await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(mockRegisterPendingActivationModal).not.toHaveBeenCalled();
+			expect(mockOpenModal).not.toHaveBeenCalled();
+		});
+
+		it('does nothing modal-related when the user opted out via "Don\'t show again"', async () => {
+			mockSettingsImpl.isWorkflowPublicationServiceEnabled = true;
+			mockActivationStorageFlag.value = 'true';
+			mockPublishWorkflow.mockResolvedValueOnce(makePublishedWorkflowResponse());
+
+			const { publishWorkflow } = useWorkflowActivate();
+			await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(mockRegisterPendingActivationModal).not.toHaveBeenCalled();
+			expect(mockOpenModal).not.toHaveBeenCalled();
+		});
+
+		it('clears the pending intent when the publish request fails', async () => {
+			mockSettingsImpl.isWorkflowPublicationServiceEnabled = true;
+			mockPublishWorkflow.mockRejectedValueOnce(new Error('network error'));
+
+			const { publishWorkflow } = useWorkflowActivate();
+			const result = await publishWorkflow(WORKFLOW_ID, VERSION_ID);
+
+			expect(result).toEqual({ success: false, errorHandled: true });
+			expect(mockClearPendingActivationModal).toHaveBeenCalledWith(WORKFLOW_ID);
+			expect(mockOpenModal).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -23,6 +23,10 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import {
+	registerPendingActivationModal,
+	clearPendingActivationModal,
+} from '@/app/composables/workflowPublicationConfirmation';
 
 export function useWorkflowActivate() {
 	const updatingWorkflowActivation = ref(false);
@@ -107,6 +111,22 @@ export function useWorkflowActivate() {
 
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 
+		// With the publication service (and in multi-main setups on the legacy
+		// path), trigger registration completes asynchronously after the publish
+		// request: the real outcome arrives as a workflowActivated /
+		// workflowFailedToActivate push. Showing the success modal on the API
+		// response would contradict a failure push that arrives moments later
+		// (ADO-4969), so defer it until the confirming push.
+		const settingsStore = useSettingsStore();
+		const activationIsConfirmedByPush =
+			settingsStore.isWorkflowPublicationServiceEnabled || settingsStore.isMultiMain;
+		const shouldShowActivationModal =
+			!hadPublishedVersion && useStorage(LOCAL_STORAGE_ACTIVATION_FLAG).value !== 'true';
+
+		if (activationIsConfirmedByPush && shouldShowActivationModal) {
+			registerPendingActivationModal(workflowId, versionId);
+		}
+
 		try {
 			// A hydrated document is open in an editor, routed or embedded (assistant artifact).
 			// The route id is empty on the assistant page and the publish modal is global, so
@@ -132,7 +152,7 @@ export function useWorkflowActivate() {
 				activeVersion: updatedWorkflow.activeVersion,
 			});
 
-			if (useSettingsStore().isWorkflowPublicationServiceEnabled) {
+			if (settingsStore.isWorkflowPublicationServiceEnabled) {
 				workflowDocumentStore.setPublicationStatus({ status: 'publishing' });
 			}
 
@@ -152,11 +172,13 @@ export function useWorkflowActivate() {
 				versionId: updatedWorkflow.activeVersion.versionId,
 			});
 
-			if (!hadPublishedVersion && useStorage(LOCAL_STORAGE_ACTIVATION_FLAG).value !== 'true') {
+			if (shouldShowActivationModal && !activationIsConfirmedByPush) {
 				uiStore.openModal(WORKFLOW_ACTIVE_MODAL_KEY);
 			}
 			return { success: true };
 		} catch (error) {
+			clearPendingActivationModal(workflowId);
+
 			if (isWebhookConflictError(error)) {
 				await handleWebhookConflictError(error);
 				return { success: false, errorHandled: true };

--- a/packages/frontend/editor-ui/src/app/composables/workflowPublicationConfirmation.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/workflowPublicationConfirmation.test.ts
@@ -1,0 +1,96 @@
+import {
+	registerPendingActivationModal,
+	consumePendingActivationModal,
+	clearPendingActivationModal,
+	PENDING_ACTIVATION_MODAL_TIMEOUT,
+} from './workflowPublicationConfirmation';
+
+describe('workflowPublicationConfirmation', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		// The registry is module-level: drop the ids used below so no intent
+		// leaks into the next test.
+		clearPendingActivationModal('wf-1');
+		clearPendingActivationModal('wf-2');
+		vi.useRealTimers();
+	});
+
+	describe('consumePendingActivationModal', () => {
+		it('consumes a registered intent when the version matches', () => {
+			registerPendingActivationModal('wf-1', 'v-1');
+
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(true);
+		});
+
+		it('consumes an intent only once', () => {
+			registerPendingActivationModal('wf-1', 'v-1');
+
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(true);
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(false);
+		});
+
+		it('does not consume when no intent was registered', () => {
+			expect(consumePendingActivationModal('wf-unknown', 'v-1')).toBe(false);
+		});
+
+		it('keeps the intent in place when the version does not match', () => {
+			registerPendingActivationModal('wf-1', 'v-2');
+
+			// A confirmation for an older version must not consume the intent of
+			// the newer publish still in flight.
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(false);
+			expect(consumePendingActivationModal('wf-1', 'v-2')).toBe(true);
+		});
+
+		it('tracks intents independently per workflow', () => {
+			registerPendingActivationModal('wf-1', 'v-1');
+			registerPendingActivationModal('wf-2', 'v-2');
+
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(true);
+			expect(consumePendingActivationModal('wf-2', 'v-2')).toBe(true);
+		});
+	});
+
+	describe('registerPendingActivationModal', () => {
+		it('overwrites a previous intent for the same workflow', () => {
+			registerPendingActivationModal('wf-1', 'v-1');
+			registerPendingActivationModal('wf-1', 'v-2');
+
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(false);
+			expect(consumePendingActivationModal('wf-1', 'v-2')).toBe(true);
+		});
+
+		it('expires the intent after the timeout', () => {
+			registerPendingActivationModal('wf-1', 'v-1');
+
+			vi.advanceTimersByTime(PENDING_ACTIVATION_MODAL_TIMEOUT);
+
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(false);
+		});
+
+		it('does not expire the intent before the timeout', () => {
+			registerPendingActivationModal('wf-1', 'v-1');
+
+			vi.advanceTimersByTime(PENDING_ACTIVATION_MODAL_TIMEOUT - 1);
+
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(true);
+		});
+	});
+
+	describe('clearPendingActivationModal', () => {
+		it('drops the intent so it can no longer be consumed', () => {
+			registerPendingActivationModal('wf-1', 'v-1');
+
+			clearPendingActivationModal('wf-1');
+
+			expect(consumePendingActivationModal('wf-1', 'v-1')).toBe(false);
+		});
+
+		it('does not throw when no intent exists', () => {
+			expect(() => clearPendingActivationModal('wf-unknown')).not.toThrow();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/workflowPublicationConfirmation.ts
+++ b/packages/frontend/editor-ui/src/app/composables/workflowPublicationConfirmation.ts
@@ -1,0 +1,74 @@
+/**
+ * Tracks the intent to show the one-time "Workflow published" success modal
+ * once a publication is confirmed.
+ *
+ * The publish API responds before triggers are actually registered (the
+ * registration runs asynchronously, on the leader in multi-main setups).
+ * Opening the success modal right after the API response can contradict a
+ * `workflowFailedToActivate` push that arrives moments later. Instead, the
+ * publish flow registers an intent here, and the `workflowActivated` push
+ * handler consumes it once the publication really succeeded.
+ *
+ * The registry is module-level on purpose: the publish flow and the push
+ * handlers run in unrelated component lifecycles, and the intent must only
+ * exist in the browser tab that initiated the publish.
+ */
+
+/** How long a pending intent stays valid before it is silently dropped. */
+export const PENDING_ACTIVATION_MODAL_TIMEOUT = 60_000;
+
+interface PendingActivationModal {
+	activeVersionId: string;
+	timeoutId: ReturnType<typeof setTimeout>;
+}
+
+const pendingActivationModals = new Map<string, PendingActivationModal>();
+
+/**
+ * Registers the intent to show the activation success modal for a workflow
+ * once its publication is confirmed. Re-registering overwrites any previous
+ * intent for the same workflow. The intent expires after
+ * {@link PENDING_ACTIVATION_MODAL_TIMEOUT} so a slow or lost confirmation
+ * cannot pop a stale modal much later.
+ */
+export function registerPendingActivationModal(workflowId: string, activeVersionId: string): void {
+	clearPendingActivationModal(workflowId);
+
+	const timeoutId = setTimeout(() => {
+		pendingActivationModals.delete(workflowId);
+	}, PENDING_ACTIVATION_MODAL_TIMEOUT);
+
+	pendingActivationModals.set(workflowId, { activeVersionId, timeoutId });
+}
+
+/**
+ * Consumes the pending intent for a workflow when the confirmed version
+ * matches the one that was published. Returns whether the caller should show
+ * the success modal. A version mismatch keeps the intent in place: it belongs
+ * to a newer publish whose confirmation is still on its way.
+ */
+export function consumePendingActivationModal(
+	workflowId: string,
+	activeVersionId: string,
+): boolean {
+	const pending = pendingActivationModals.get(workflowId);
+	if (pending?.activeVersionId !== activeVersionId) {
+		return false;
+	}
+
+	clearTimeout(pending.timeoutId);
+	pendingActivationModals.delete(workflowId);
+	return true;
+}
+
+/**
+ * Drops the pending intent for a workflow, e.g. because the publication
+ * failed, was partial, or the workflow got unpublished in the meantime.
+ */
+export function clearPendingActivationModal(workflowId: string): void {
+	const pending = pendingActivationModals.get(workflowId);
+	if (pending) {
+		clearTimeout(pending.timeoutId);
+		pendingActivationModals.delete(workflowId);
+	}
+}

--- a/packages/testing/playwright/pages/WorkflowActivationModal.ts
+++ b/packages/testing/playwright/pages/WorkflowActivationModal.ts
@@ -24,4 +24,12 @@ export class WorkflowActivationModal extends BasePage {
 
 		await this.getGotItButton().click();
 	}
+
+	/**
+	 * Closes the modal without persisting the "Don't show again" preference,
+	 * so the modal opens again on a later publish in the same context.
+	 */
+	async dismiss(): Promise<void> {
+		await this.getGotItButton().click();
+	}
 }

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -154,7 +154,8 @@ test.describe(
 			const workflowId = await createWorkflowWithSingleNode(api);
 			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();
-			await n8n.page.keyboard.press('Escape');
+			// The success modal opens once the publication is confirmed via push
+			await n8n.workflowActivationModal.close();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 			await expect(n8n.canvas.getArchivedTag()).not.toBeAttached();
@@ -218,7 +219,8 @@ test.describe(
 			await n8n.start.fromBlankCanvas();
 			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
 			await n8n.canvas.publishWorkflow();
-			await n8n.page.keyboard.press('Escape');
+			// The success modal opens once the publication is confirmed via push
+			await n8n.workflowActivationModal.close();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 
@@ -236,7 +238,8 @@ test.describe(
 			const workflowId = await createWorkflowWithSingleNode(api);
 			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();
-			await n8n.page.keyboard.press('Escape');
+			// The success modal opens once the publication is confirmed via push
+			await n8n.workflowActivationModal.close();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 
@@ -261,7 +264,8 @@ test.describe(
 			await expect(n8n.canvas.getArchivedTag()).not.toBeAttached();
 
 			await n8n.canvas.publishWorkflow();
-			await n8n.page.keyboard.press('Escape');
+			// The success modal opens once the publication is confirmed via push
+			await n8n.workflowActivationModal.close();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 			await expect(n8n.canvas.getOpenPublishModalButton()).toBeVisible();

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -155,7 +155,7 @@ test.describe(
 			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();
 			// The success modal opens once the publication is confirmed via push
-			await n8n.workflowActivationModal.close();
+			await n8n.workflowActivationModal.dismiss();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 			await expect(n8n.canvas.getArchivedTag()).not.toBeAttached();
@@ -220,7 +220,7 @@ test.describe(
 			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
 			await n8n.canvas.publishWorkflow();
 			// The success modal opens once the publication is confirmed via push
-			await n8n.workflowActivationModal.close();
+			await n8n.workflowActivationModal.dismiss();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 
@@ -239,7 +239,7 @@ test.describe(
 			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();
 			// The success modal opens once the publication is confirmed via push
-			await n8n.workflowActivationModal.close();
+			await n8n.workflowActivationModal.dismiss();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 
@@ -265,7 +265,7 @@ test.describe(
 
 			await n8n.canvas.publishWorkflow();
 			// The success modal opens once the publication is confirmed via push
-			await n8n.workflowActivationModal.close();
+			await n8n.workflowActivationModal.dismiss();
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 			await expect(n8n.canvas.getOpenPublishModalButton()).toBeVisible();

--- a/packages/testing/playwright/tests/e2e/workflows/list/workflows.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/list/workflows.spec.ts
@@ -154,7 +154,7 @@ test.describe(
 			// Publish the workflow and close the success modal, which opens once the
 			// publication is confirmed via push — it must not linger over the list view
 			await n8n.canvas.publishWorkflow();
-			await n8n.workflowActivationModal.close();
+			await n8n.workflowActivationModal.dismiss();
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 
 			// Go back to workflows list

--- a/packages/testing/playwright/tests/e2e/workflows/list/workflows.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/list/workflows.spec.ts
@@ -151,8 +151,10 @@ test.describe(
 			await n8n.canvas.nodeCreator.selectItem('Webhook');
 			await n8n.page.keyboard.press('Escape');
 
-			// Publish the workflow
+			// Publish the workflow and close the success modal, which opens once the
+			// publication is confirmed via push — it must not linger over the list view
 			await n8n.canvas.publishWorkflow();
+			await n8n.workflowActivationModal.close();
 			await expect(n8n.canvas.getPublishedIndicator()).toBeVisible();
 
 			// Go back to workflows list


### PR DESCRIPTION
## Summary
When publishing workflows in multi-main mode, the front-end would show success before actually waiting for any async action (like registering webhooks) to finish.

This PR defers the optimistic success UI until the backend confirms the publication:

- **New per-tab intent registry** (`workflowPublicationConfirmation.ts`): `publishWorkflow` registers the intent to show the success modal *before* the publish request (the confirming push can arrive before the response). The `workflowActivated` push handler consumes it (version-matched, only in the initiating tab, only while the workflow is viewed) and opens the modal. `workflowFailedToActivate`, `workflowPartiallyActivated`, `workflowDeactivated`, and a failed publish request clear it. Intents expire after 60s.
- **Legacy single-main** (publication service off, not multi-main) keeps the immediate modal: activation runs synchronously in the request and no confirming push is sent.
- **Consistent wording**: the failure toast now says "Workflow could not be **published**" (was "activated").
- **Production checklist**: with the publication service on, the checklist auto-opens only when the lifecycle reaches `published`, instead of on the optimistic `activeVersionId` flip. A failed publish no longer opens it and no longer consumes the one-time `firstActivatedAt`, so the checklist still appears on the first publish that succeeds. This also restores the intended ordering: success modal first, checklist after it is closed.

No backend changes: the publication service already broadcasts the activation outcome (`PublicationStatusReporter`) and relays it across mains.

## How to test

Can be tested locally by running n8n in multi-main mode:

```bash
pnpm --filter n8n-containers stack:clean:all   # reused containers would keep the old image
pnpm build:docker
pnpm --filter n8n-containers stack:multi-main --queue --mains 2 --workers 4
```

1. **Failure path**: create a workflow with a GitHub Trigger (any credential — webhook registration deterministically fails on localhost) and publish it (first publish). Expect: no "Workflow published" modal, the header button shows "Publishing…", then a single toast "Workflow could not be published" plus the red "Failed publish" indicator. No production checklist opens. Refreshing changes nothing.
2. **Success path**: create a workflow with a Schedule Trigger and publish it. Expect: "Publishing…", then the "Workflow published" modal once activation is confirmed, and the production checklist opens after the modal is closed.
3. **Retry**: publish the failed workflow from step 1 again. Expect a single failure toast, no modal. Fix it (or swap the trigger) and publish: the checklist opens on the first successful publish.
4. **Second tab** (optional): view the same workflow in another tab while publishing from the first. The modal only appears in the initiating tab.


## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4969


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

