### PR TITLE
feat(ai-builder): Wrap vecto store settings in advanced section

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7753,6 +7753,7 @@
 	"agents.builder.memory.episodicMemory.hint": "Stores source-backed memories from previous conversations.",
 	"agents.builder.memory.episodicMemory.credential.label": "OpenAI credential",
 	"agents.builder.memory.episodicMemory.credential.hint": "Used to create embeddings for episodic memory.",
+	"agents.builder.knowledge.advanced.title": "Advanced",
 	"agents.builder.files.title": "Knowledge base",
 	"agents.builder.files.titleTooltip": "Files uploaded to this agent. n8n stores them so the agent can search their contents and read them when answering.",
 	"agents.builder.files.description": "Add CSV, PDF, Markdown, or TXT files this agent can search and read. Upload up to {maxFiles} files at a time, {maxSizeMb} MB each. Knowledge base size is limited to {maxTotalGb} GB.",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
@@ -312,11 +312,23 @@ describe('AgentBuilderEditorColumn', () => {
 		expect(knowledgeWrapper.findComponent({ name: 'AgentFilesPanel' }).exists()).toBe(true);
 	});
 
-	it('renders the Knowledge tab with vector stores but without the files table when the knowledge base is disabled', async () => {
+	it('keeps vector stores under the collapsed Advanced disclosure on the Knowledge tab', async () => {
 		const wrapper = await mountColumn({ activeMainTab: 'knowledge', knowledgeBaseEnabled: false });
 
 		expect(wrapper.find('[data-testid="agent-knowledge-tab-content"]').exists()).toBe(true);
 		expect(wrapper.findComponent({ name: 'AgentFilesPanel' }).exists()).toBe(false);
+
+		const trigger = wrapper.find('[data-testid="agent-knowledge-advanced-trigger"]');
+
+		expect(trigger.exists()).toBe(true);
+		expect(trigger.attributes('aria-expanded')).toBe('false');
+		expect(wrapper.find('[data-testid="agent-knowledge-advanced-content"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-vector-stores-card"]').exists()).toBe(false);
+
+		await trigger.trigger('click');
+
+		expect(trigger.attributes('aria-expanded')).toBe('true');
+		expect(wrapper.find('[data-testid="agent-knowledge-advanced-content"]').exists()).toBe(true);
 		expect(wrapper.find('[data-testid="agent-vector-stores-card"]').exists()).toBe(true);
 	});
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { N8nCard, N8nTabs } from '@n8n/design-system';
+import { N8nCard, N8nIcon, N8nTabs, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import type { AgentConfigValidationIssue, AgentFileDto } from '@n8n/api-types';
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
@@ -191,15 +191,19 @@ const i18n = useI18n();
 						@upload-files="emit('upload-files', $event)"
 						@delete-file="emit('delete-file', $event)"
 					/>
-
-					<AgentVectorStoresPanel
-						:vector-stores="localConfig?.vectorStores ?? []"
-						:disabled="childrenDisabled"
-						data-testid="agent-vector-stores-card"
-						@connect="emit('add-vector-store')"
-						@edit="emit('edit-vector-store', $event)"
-						@remove="emit('remove-vector-store', $event)"
-					/>
+					<div>
+						<N8nText bold :class="$style.title" data-testid="agent-knowledge-tab-content-advanced">
+							{{ i18n.baseText('agents.builder.knowledge.advanced.title') }}
+						</N8nText>
+						<AgentVectorStoresPanel
+							:vector-stores="localConfig?.vectorStores ?? []"
+							:disabled="childrenDisabled"
+							data-testid="agent-vector-stores-card"
+							@connect="emit('add-vector-store')"
+							@edit="emit('edit-vector-store', $event)"
+							@remove="emit('remove-vector-store', $event)"
+						/>
+					</div>
 				</AgentBuilderTabPanel>
 
 				<AgentBuilderTabPanel
@@ -282,6 +286,14 @@ const i18n = useI18n();
 </template>
 
 <style lang="scss" module>
+.title {
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+	padding: 10px 0;
+	font-weight: 500;
+}
+
 .editorColumn {
 	display: flex;
 	flex-direction: column;

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { N8nCard, N8nTabs } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import type { AgentConfigValidationIssue, AgentFileDto } from '@n8n/api-types';
@@ -56,6 +56,7 @@ const props = defineProps<{
 }>();
 
 const childrenDisabled = computed(() => !props.canEditAgent);
+const isKnowledgeAdvancedExpanded = ref(false);
 
 const settingsStore = useSettingsStore();
 const isMcpAvailable = computed(
@@ -191,18 +192,46 @@ const i18n = useI18n();
 						@upload-files="emit('upload-files', $event)"
 						@delete-file="emit('delete-file', $event)"
 					/>
-					<div>
-						<N8nText bold :class="$style.title" data-testid="agent-knowledge-tab-content-advanced">
-							{{ i18n.baseText('agents.builder.knowledge.advanced.title') }}
-						</N8nText>
-						<AgentVectorStoresPanel
-							:vector-stores="localConfig?.vectorStores ?? []"
-							:disabled="childrenDisabled"
-							data-testid="agent-vector-stores-card"
-							@connect="emit('add-vector-store')"
-							@edit="emit('edit-vector-store', $event)"
-							@remove="emit('remove-vector-store', $event)"
-						/>
+					<div
+						:class="$style.advancedSection"
+						:data-state="isKnowledgeAdvancedExpanded ? 'open' : 'closed'"
+					>
+						<button
+							type="button"
+							:class="$style.advancedTrigger"
+							:aria-expanded="isKnowledgeAdvancedExpanded"
+							data-testid="agent-knowledge-advanced-trigger"
+							@click="isKnowledgeAdvancedExpanded = !isKnowledgeAdvancedExpanded"
+						>
+							<N8nText
+								tag="h3"
+								bold
+								:class="$style.title"
+								data-testid="agent-knowledge-tab-content-advanced"
+							>
+								{{ i18n.baseText('agents.builder.knowledge.advanced.title') }}
+							</N8nText>
+							<N8nIcon
+								icon="chevron-down"
+								size="small"
+								:class="$style.chevron"
+								data-testid="agent-knowledge-advanced-chevron"
+							/>
+						</button>
+						<div
+							v-if="isKnowledgeAdvancedExpanded"
+							:class="$style.advancedContent"
+							data-testid="agent-knowledge-advanced-content"
+						>
+							<AgentVectorStoresPanel
+								:vector-stores="localConfig?.vectorStores ?? []"
+								:disabled="childrenDisabled"
+								data-testid="agent-vector-stores-card"
+								@connect="emit('add-vector-store')"
+								@edit="emit('edit-vector-store', $event)"
+								@remove="emit('remove-vector-store', $event)"
+							/>
+						</div>
 					</div>
 				</AgentBuilderTabPanel>
 
@@ -286,12 +315,58 @@ const i18n = useI18n();
 </template>
 
 <style lang="scss" module>
+.advancedSection {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--sm);
+	width: 100%;
+}
+
+.advancedTrigger {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing--xs);
+	width: 100%;
+	padding: var(--spacing--xs) 0;
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+
+	&:focus-visible {
+		outline: 2px solid var(--color--primary);
+		outline-offset: 2px;
+		border-radius: var(--radius--sm);
+	}
+}
+
 .title {
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
-	padding: 10px 0;
-	font-weight: 500;
+	font-weight: var(--font-weight--medium);
+}
+
+.advancedTrigger h3 {
+	margin: 0;
+}
+
+.chevron {
+	flex-shrink: 0;
+	color: var(--text-color--subtler);
+	transform: rotate(0deg);
+	transition: transform var(--animation--duration) var(--animation--easing);
+}
+
+.advancedSection[data-state='open'] .chevron {
+	transform: rotate(180deg);
+}
+
+.advancedContent {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
 }
 
 .editorColumn {


### PR DESCRIPTION
## Summary

Vector stores sits under an "Advanced" disclosure, inside the Knowledge tab - not promoted to its own always-visible box, and not moved to Settings > Advanced either.

## How to test:
1. Create an agent on the agent builder
2. Click on the Knowledge tab and scroll down
3. See "Advanced" title over the vector stores configuration box.

Snap:
<img width="1209" height="874" alt="image" src="https://github.com/user-attachments/assets/39f0f6aa-0c64-4d97-bb7b-21c50cd37eb9" />

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AGENT-767/keep-vector-stores-under-advanced-inside-knowledge-not-promoted-not

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

