### PR TITLE
fix(core): Correct the custom data truncation threshold and log it as a warning

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts
@@ -196,6 +196,30 @@ describe('Execution Metadata functions', () => {
 			expect(logger.error).not.toHaveBeenCalled();
 			expect(metadata).toEqual({ test1: value });
 		});
+
+		test('should warn, not error, and truncate a value over the limit', () => {
+			const { metadata, executionData } = createExecutionDataWithMetadata();
+
+			const value = 'a'.repeat(513);
+
+			setWorkflowExecutionMetadata(executionData, 'test1', value);
+
+			expect(logger.warn).toHaveBeenCalledTimes(1);
+			expect(logger.error).not.toHaveBeenCalled();
+			expect(metadata).toEqual({ test1: value.slice(0, 512) });
+		});
+
+		test('should warn, not error, and truncate a key over the limit', () => {
+			const { metadata, executionData } = createExecutionDataWithMetadata();
+
+			const key = 'a'.repeat(51);
+
+			setWorkflowExecutionMetadata(executionData, key, 'value1');
+
+			expect(logger.warn).toHaveBeenCalledTimes(1);
+			expect(logger.error).not.toHaveBeenCalled();
+			expect(metadata).toEqual({ [key.slice(0, 50)]: 'value1' });
+		});
 	});
 
 	// GHC-8254: AI Agent node with Chinese name fails with "Custom date key can only contain characters A-Za-z0-9_"

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts
@@ -1,4 +1,6 @@
-import { createRunExecutionData, type IRunExecutionData } from 'n8n-workflow';
+import type { Logger } from 'n8n-workflow';
+import { createRunExecutionData, type IRunExecutionData, LoggerProxy } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
 
 import { InvalidExecutionMetadataError } from '@/errors/invalid-execution-metadata.error';
 
@@ -171,6 +173,28 @@ describe('Execution Metadata functions', () => {
 
 		expect(metadata).toEqual({
 			test1: longValue.slice(0, 512),
+		});
+	});
+
+	describe('logging on truncation', () => {
+		const logger = mock<Logger>();
+
+		beforeEach(() => {
+			logger.warn.mockClear();
+			logger.error.mockClear();
+			LoggerProxy.init(logger);
+		});
+
+		test('should not log and should store the value in full when it is under the limit', () => {
+			const { metadata, executionData } = createExecutionDataWithMetadata();
+
+			const value = 'a'.repeat(300);
+
+			setWorkflowExecutionMetadata(executionData, 'test1', value);
+
+			expect(logger.warn).not.toHaveBeenCalled();
+			expect(logger.error).not.toHaveBeenCalled();
+			expect(metadata).toEqual({ test1: value });
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/execution-metadata.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/execution-metadata.ts
@@ -35,10 +35,10 @@ export function setWorkflowExecutionMetadata(
 	}
 	const val = String(value);
 	if (key.length > 50) {
-		Logger.error('Custom data key over 50 characters long. Truncating to 50 characters.');
+		Logger.warn('Custom data key over 50 characters long. Truncating to 50 characters.');
 	}
 	if (val.length > 512) {
-		Logger.error('Custom data value over 512 characters long. Truncating to 512 characters.');
+		Logger.warn('Custom data value over 512 characters long. Truncating to 512 characters.');
 	}
 	executionData.resultData.metadata[key.slice(0, 50)] = val.slice(0, 512);
 }

--- a/packages/core/src/execution-engine/node-execution-context/utils/execution-metadata.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/execution-metadata.ts
@@ -37,7 +37,7 @@ export function setWorkflowExecutionMetadata(
 	if (key.length > 50) {
 		Logger.error('Custom data key over 50 characters long. Truncating to 50 characters.');
 	}
-	if (val.length > 255) {
+	if (val.length > 512) {
 		Logger.error('Custom data value over 512 characters long. Truncating to 512 characters.');
 	}
 	executionData.resultData.metadata[key.slice(0, 50)] = val.slice(0, 512);


### PR DESCRIPTION
## Summary

`setWorkflowExecutionMetadata` truncates custom execution data values at
512 characters, but it logged an error when a value was over 255
characters, not 512. A value of 256–512 characters logged an error that
said the value was truncated, when it was stored in full. This PR fixes
the threshold.

It also changes the log level for both truncation messages (key and
value) from `error` to `warn`. Truncation is not a failure: the
execution continues and the shortened value is stored. The editor
already shows the user a warning about this before execution runs, so
the server log is a backup signal, not the main one. This matters in
practice because an AI Agent node auto-saves its reply as execution data
by default, and most replies are over 255 characters, so the old
threshold bug fired an `error` on almost every run.

Two commits, so either half can be reviewed or reverted on its own:

1. `fix(core): Log custom data truncation only when the value exceeds the limit`
2. `fix(core): Log custom data truncation at warn level`

## How to test

Run the new tests in
`packages/core/src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts`:

```
cd packages/core
pnpm test src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts
```

Two of the added tests fail against current `master` (before this PR):

- A 300-character value: `master` calls `logger.error`; this PR calls
  neither `logger.warn` nor `logger.error`, and stores the value in full.
- A 513-character value: `master` calls `logger.error`; this PR calls
  `logger.warn` once and never `logger.error`, and truncates to 512
  characters.

Manual repro: add an **Execution Data** node, save a key with a
300-character value, and run the workflow. On `master`, the server log
shows an `error` line saying the value was truncated, even though it
wasn't.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #38438

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take
  responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or
  `Backport to v1` (if the PR is an urgent fix that needs to be
  backported)

---

AI disclosure: Claude Code drafted this fix, the regression tests, the
issue, and this description; I reviewed and understand every line
before opening this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

