### PR TITLE
build: Size local pnpm build and typecheck to machine RAM

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -136,6 +136,8 @@ jobs:
               scripts/preview.mjs
               scripts/preview*
               scripts/serve-ready.mjs
+              scripts/turbo-sized.mjs
+              scripts/turbo-sizing.mjs
               scripts/licenses/**
               scripts/mutation-health/**
               cubic.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,19 @@ You can inspect the last few lines of the build log file to check for errors:
 tail -n 20 build.log
 ```
 
+`pnpm build` and `pnpm typecheck` size turbo's concurrency to the machine's
+RAM, because each type-checking worker peaks between 2.3 GB and 6.9 GB. To
+override the default, use one of these, highest precedence first:
+
+```bash
+pnpm typecheck --concurrency=1     # an explicit flag always wins
+TURBO_CONCURRENCY=3 pnpm build     # then the environment variable
+N8N_TURBO_SIZING_DEBUG=1 pnpm build  # print the sizing decision
+```
+
+Under CI the sizing is a no-op: every workflow pins its own concurrency and
+memory cap per job. See `scripts/turbo-sizing.mjs`.
+
 If build outputs or the turbo cache are stale (e.g. after switching branches
 or worktrees) but dependencies haven't changed, use `pnpm reset` (lightweight
 by default) for a fast recovery: it cleans build outputs and force-rebuilds

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prepare": "node scripts/prepare.mjs",
     "preinstall": "node scripts/block-npm-install.js",
-    "build": "turbo run build",
+    "build": "node scripts/turbo-sized.mjs build",
     "build:unchecked": "turbo run build:unchecked",
     "build:n8n": "node scripts/build-n8n.mjs",
     "build:deploy": "node scripts/build-n8n.mjs",
@@ -20,7 +20,7 @@
     "build:docker:smoke": "node scripts/smoke-n8n-image.mjs",
     "build:docker:clean": "TURBO_FORCE=true node scripts/build-n8n.mjs && DOCKER_BUILD_NO_CACHE=true DOCKER_BUILD_BASE_IMAGE=true node scripts/dockerize-n8n.mjs",
     "build:docker:test": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && turbo run test:container:standard --filter=n8n-playwright",
-    "typecheck": "turbo typecheck",
+    "typecheck": "node scripts/turbo-sized.mjs typecheck",
     "dev": "node scripts/dev-command-removed-notice.mjs",
     "dev:up": "node scripts/dev-up.mjs",
     "dev:be": "turbo run dev --env-mode=loose --log-prefix=none --filter=n8n",

--- a/scripts/agent-setup.mjs
+++ b/scripts/agent-setup.mjs
@@ -12,7 +12,7 @@
  *
  * Usage:
  *   pnpm agent:setup [all|install|build|test] [flags]
- *   node scripts/agent-setup.mjs all --mem 6144 --concurrency 4
+ *   node scripts/agent-setup.mjs all --mem 4096 --concurrency 2
  *
  * Exit codes: 0 = all steps pass, 1 = a step failed, 2 = invalid arguments.
  *
@@ -27,9 +27,8 @@ import { parseArgs } from 'node:util';
 import {
 	CONCURRENCY_ENV_VAR,
 	DEFAULT_PROCESS_MEM_MB,
-	computeConcurrency,
-	parseConcurrencyEnv,
 	readMachine,
+	resolveConcurrency,
 	resolveNodeOptions,
 } from './turbo-sizing.mjs';
 
@@ -101,20 +100,22 @@ if (!Number.isInteger(tailLines) || tailLines < 0) {
 	fail('--tail must be a non-negative integer');
 }
 
-// Precedence: the --concurrency flag, then the environment variable, then the
-// RAM-aware default. Same order as scripts/turbo-sized.mjs.
-let concurrency;
 if (values.concurrency !== undefined) {
 	const requested = Number(values.concurrency);
 	if (!Number.isInteger(requested) || requested <= 0) {
 		fail('--concurrency must be a positive integer');
 	}
-	concurrency = String(requested);
-} else {
-	concurrency =
-		parseConcurrencyEnv(process.env[CONCURRENCY_ENV_VAR]) ??
-		String(computeConcurrency({ ...readMachine(), processMemMb: mem }));
 }
+
+// The precedence order lives in resolveConcurrency(). Do not repeat it here.
+// This script has no CI branch on purpose: no workflow calls `agent:setup`,
+// and an agent wants the machine-sized default wherever it runs.
+const { concurrency } = resolveConcurrency({
+	flag: values.concurrency,
+	env: process.env,
+	machine: readMachine(),
+	processMemMb: mem,
+});
 
 const logDir = values['log-dir']
 	? resolve(process.cwd(), values['log-dir'])

--- a/scripts/agent-setup.mjs
+++ b/scripts/agent-setup.mjs
@@ -6,8 +6,9 @@
  * summary, so a fresh agent (cat-bot, Claude Code, a new hire) can verify a
  * checkout without burning context tokens on tens of thousands of lines of
  * pnpm/turbo/vitest output. Every spawned Node process is capped via
- * NODE_OPTIONS=--max-old-space-size and turbo concurrency is capped so total
- * resident memory stays bounded on a 6GB box.
+ * NODE_OPTIONS=--max-old-space-size and turbo concurrency is sized to the
+ * machine by scripts/turbo-sizing.mjs, so total resident memory stays bounded
+ * on a 6GB box.
  *
  * Usage:
  *   pnpm agent:setup [all|install|build|test] [flags]
@@ -23,6 +24,15 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
+import {
+	CONCURRENCY_ENV_VAR,
+	DEFAULT_PROCESS_MEM_MB,
+	computeConcurrency,
+	parseConcurrencyEnv,
+	readMachine,
+	resolveNodeOptions,
+} from './turbo-sizing.mjs';
+
 const REPO_ROOT = resolve(import.meta.dirname, '..');
 const VALID_STEPS = ['all', 'install', 'build', 'test'];
 
@@ -35,8 +45,9 @@ Steps:
   test      turbo run test (full suite)
 
 Flags:
-  --mem <MB>          per-process old-space cap (default 6144, matches CI)
-  --concurrency <n>   turbo concurrency for build/test (default 4)
+  --mem <MB>          per-process old-space cap (default ${DEFAULT_PROCESS_MEM_MB}, matches CI)
+  --concurrency <n>   turbo concurrency for build/test (default: sized to this
+                      machine's RAM; ${CONCURRENCY_ENV_VAR} also overrides it)
   --tail <n>          lines of the failing log to print on failure (default 60)
   --json              emit only the JSON summary to stdout
   --log-dir <path>    write logs and summary.json here (default .agent-setup/)
@@ -56,8 +67,8 @@ let positionals;
 try {
 	({ values, positionals } = parseArgs({
 		options: {
-			mem: { type: 'string', default: '6144' },
-			concurrency: { type: 'string', default: '4' },
+			mem: { type: 'string' },
+			concurrency: { type: 'string' },
 			tail: { type: 'string', default: '60' },
 			json: { type: 'boolean', default: false },
 			'log-dir': { type: 'string' },
@@ -83,15 +94,26 @@ if (!VALID_STEPS.includes(step)) {
 	fail(`unknown step "${step}" — must be one of: ${VALID_STEPS.join(', ')}`);
 }
 
-const mem = Number(values.mem);
-const concurrency = Number(values.concurrency);
+const mem = values.mem === undefined ? DEFAULT_PROCESS_MEM_MB : Number(values.mem);
 const tailLines = Number(values.tail);
 if (!Number.isInteger(mem) || mem <= 0) fail('--mem must be a positive integer (MB)');
-if (!Number.isInteger(concurrency) || concurrency <= 0) {
-	fail('--concurrency must be a positive integer');
-}
 if (!Number.isInteger(tailLines) || tailLines < 0) {
 	fail('--tail must be a non-negative integer');
+}
+
+// Precedence: the --concurrency flag, then the environment variable, then the
+// RAM-aware default. Same order as scripts/turbo-sized.mjs.
+let concurrency;
+if (values.concurrency !== undefined) {
+	const requested = Number(values.concurrency);
+	if (!Number.isInteger(requested) || requested <= 0) {
+		fail('--concurrency must be a positive integer');
+	}
+	concurrency = String(requested);
+} else {
+	concurrency =
+		parseConcurrencyEnv(process.env[CONCURRENCY_ENV_VAR]) ??
+		String(computeConcurrency({ ...readMachine(), processMemMb: mem }));
 }
 
 const logDir = values['log-dir']
@@ -116,12 +138,12 @@ const PLAN = {
 
 const stepsToRun = step === 'all' ? ['install', 'build', 'test'] : [step];
 
-const NODE_OPTS = `--max-old-space-size=${mem}`;
 const childEnv = {
 	...process.env,
-	NODE_OPTIONS: process.env.NODE_OPTIONS
-		? `${process.env.NODE_OPTIONS} ${NODE_OPTS}`
-		: NODE_OPTS,
+	// An explicit --mem outranks a cap already in the environment.
+	NODE_OPTIONS: resolveNodeOptions(process.env.NODE_OPTIONS, mem, {
+		override: values.mem !== undefined,
+	}),
 	FORCE_COLOR: '0',
 };
 

--- a/scripts/turbo-sized.mjs
+++ b/scripts/turbo-sized.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Runs a turbo task with the RAM-aware sizing from `scripts/turbo-sizing.mjs`.
+ *
+ * Turbo's default concurrency starts about ten type-checking workers at once.
+ * Each one peaks between 2.3 GB and 6.9 GB, so `pnpm build` and
+ * `pnpm typecheck` made a 16 GB laptop swap. This wrapper caps both the
+ * concurrency and the per-process old-space size before it calls turbo.
+ *
+ * Usage:
+ *   node scripts/turbo-sized.mjs <task> [extra turbo arguments...]
+ *   node scripts/turbo-sized.mjs build --filter=n8n
+ *   node scripts/turbo-sized.mjs typecheck --concurrency=1
+ *
+ * Every extra argument reaches turbo unchanged, so `pnpm build --concurrency=5`
+ * still means concurrency 5. Under CI the wrapper changes nothing at all,
+ * because each workflow pins its own concurrency and memory cap per job.
+ *
+ * Set `N8N_TURBO_SIZING_DEBUG=1` to print the sizing decision.
+ *
+ * See N8N-383 for design notes.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { CONCURRENCY_ENV_VAR, readMachine, resolveSizing } from './turbo-sizing.mjs';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+
+/**
+ * Prefers the workspace binary, so `node scripts/turbo-sized.mjs build` works
+ * outside a pnpm script, where node_modules/.bin is not on PATH.
+ */
+function turboBin() {
+	const local = resolve(
+		REPO_ROOT,
+		'node_modules/.bin',
+		process.platform === 'win32' ? 'turbo.cmd' : 'turbo',
+	);
+	return existsSync(local) ? local : 'turbo';
+}
+
+const [task, ...passThrough] = process.argv.slice(2);
+if (!task || task === '-h' || task === '--help') {
+	process.stderr.write('Usage: node scripts/turbo-sized.mjs <task> [extra turbo arguments...]\n');
+	process.exit(task ? 0 : 2);
+}
+
+const machine = readMachine();
+const sizing = resolveSizing({ args: passThrough, env: process.env, machine });
+
+const turboArgs = ['run', task, ...sizing.args];
+const env = { ...process.env, NODE_OPTIONS: sizing.nodeOptions };
+
+if (process.env.N8N_TURBO_SIZING_DEBUG) {
+	process.stderr.write(
+		`turbo-sized: ${machine.totalMemMb} MB RAM, ${machine.cpuCount} CPU ` +
+			`-> concurrency ${sizing.concurrency ?? 'turbo default'} (${sizing.source}), ` +
+			`NODE_OPTIONS="${env.NODE_OPTIONS ?? ''}"\n` +
+			`turbo-sized: override with --concurrency=<n> or ${CONCURRENCY_ENV_VAR}=<n>\n`,
+	);
+}
+
+const child = spawn(turboBin(), turboArgs, {
+	cwd: REPO_ROOT,
+	env,
+	stdio: 'inherit',
+	shell: process.platform === 'win32',
+});
+
+child.once('error', (err) => {
+	process.stderr.write(`turbo-sized: cannot start turbo: ${err.message}\n`);
+	process.exit(1);
+});
+
+child.once('exit', (code, signal) => {
+	// Report a signalled child the way a shell does, so CI still sees a failure.
+	if (signal) process.exit(1);
+	process.exit(code ?? 1);
+});

--- a/scripts/turbo-sizing.mjs
+++ b/scripts/turbo-sizing.mjs
@@ -1,0 +1,195 @@
+/**
+ * Shared RAM-aware sizing for turbo runs.
+ *
+ * A `vue-tsc` / `tsc` worker peaks between 2.3 GB and 6.9 GB of resident
+ * memory. Turbo's own default concurrency (10) therefore asks for far more
+ * memory than a laptop has, and the machine swaps. This module derives one
+ * concurrency value and one per-process old-space cap from the machine, so
+ * `concurrency x cap` stays inside the installed RAM.
+ *
+ * The consumers are `scripts/turbo-sized.mjs` (the root `build` and
+ * `typecheck` scripts) and `scripts/agent-setup.mjs`. Keep the logic here;
+ * do not copy it into a consumer.
+ *
+ * Override precedence, highest first:
+ *   1. an explicit `--concurrency` / `--concurrency=<n>` argument
+ *   2. the `TURBO_CONCURRENCY` environment variable
+ *   3. the computed default from this module
+ *
+ * Under CI the whole module is a no-op: every workflow already pins the
+ * concurrency and the memory cap it wants per job.
+ *
+ * See N8N-383 for design notes.
+ */
+import { availableParallelism, totalmem } from 'node:os';
+
+/** Per-process old-space cap in MB. Matches the CI typecheck job. */
+export const DEFAULT_PROCESS_MEM_MB = 6144;
+
+/**
+ * Memory left to the operating system, the editor, and the turbo parent
+ * process. Without it a machine whose RAM is an exact multiple of the cap
+ * gets one worker too many.
+ */
+export const RESERVED_SYSTEM_MB = 2048;
+
+/** Never serialize completely, and never exceed turbo's own default. */
+export const MIN_CONCURRENCY = 1;
+export const MAX_CONCURRENCY = 10;
+
+/** Name of the environment variable that overrides the computed default. */
+export const CONCURRENCY_ENV_VAR = 'TURBO_CONCURRENCY';
+
+/**
+ * Concurrency that fits `processMemMb` workers into the machine's RAM.
+ *
+ * Pure — every input is explicit, so the callers in the tests can ask for a
+ * machine profile they are not running on.
+ *
+ * @param {object} machine
+ * @param {number} machine.totalMemMb installed RAM in MB
+ * @param {number} machine.cpuCount usable CPU count
+ * @param {number} [machine.processMemMb] per-process old-space cap in MB
+ * @returns {number} concurrency, between MIN_CONCURRENCY and MAX_CONCURRENCY
+ */
+export function computeConcurrency({
+	totalMemMb,
+	cpuCount,
+	processMemMb = DEFAULT_PROCESS_MEM_MB,
+}) {
+	// A machine smaller than one worker still has to run that one worker.
+	const budgetMb = Math.max(totalMemMb - RESERVED_SYSTEM_MB, processMemMb);
+	const byMemory = Math.floor(budgetMb / processMemMb);
+	const byCpu = Math.max(1, Math.floor(cpuCount));
+	return Math.min(Math.max(Math.min(byMemory, byCpu), MIN_CONCURRENCY), MAX_CONCURRENCY);
+}
+
+/** Reads the machine this process runs on. */
+export function readMachine() {
+	return {
+		totalMemMb: Math.floor(totalmem() / 1024 / 1024),
+		cpuCount: availableParallelism(),
+	};
+}
+
+/**
+ * Parses the `--concurrency` value out of a turbo argument list.
+ *
+ * Accepts `--concurrency=<value>` and `--concurrency <value>`. Returns the
+ * raw string so an invalid value still counts as "the caller decided" and
+ * reaches turbo, which reports the error better than this module can.
+ *
+ * @param {string[]} args
+ * @returns {string | undefined}
+ */
+export function findConcurrencyArg(args) {
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (arg === '--concurrency') return args[i + 1];
+		if (arg.startsWith('--concurrency=')) return arg.slice('--concurrency='.length);
+	}
+	return undefined;
+}
+
+/**
+ * Parses the environment override. Rejects anything that is not a positive
+ * integer or a percentage, which is what turbo itself accepts.
+ *
+ * @param {string | undefined} raw
+ * @returns {string | undefined}
+ */
+export function parseConcurrencyEnv(raw) {
+	if (raw === undefined) return undefined;
+	const value = raw.trim();
+	if (value === '') return undefined;
+	if (/^[1-9][0-9]*%?$/.test(value)) return value;
+	return undefined;
+}
+
+/**
+ * Applies the precedence rules and reports which one won.
+ *
+ * `source` is `'flag'`, `'env'`, `'ci'`, or `'computed'`. `'ci'` means no
+ * default was injected: CI pins its own concurrency per job, so this module
+ * must not change what a workflow already runs.
+ *
+ * @param {object} input
+ * @param {string[]} input.args turbo arguments the caller passed through
+ * @param {Record<string, string | undefined>} input.env
+ * @param {{ totalMemMb: number, cpuCount: number }} input.machine
+ * @param {number} [input.processMemMb]
+ * @returns {{ concurrency: string | undefined, source: string, inject: boolean }}
+ */
+export function resolveConcurrency({ args, env, machine, processMemMb = DEFAULT_PROCESS_MEM_MB }) {
+	const fromFlag = findConcurrencyArg(args);
+	if (fromFlag !== undefined) {
+		return { concurrency: fromFlag, source: 'flag', inject: false };
+	}
+
+	const fromEnv = parseConcurrencyEnv(env[CONCURRENCY_ENV_VAR]);
+	if (fromEnv !== undefined) {
+		return { concurrency: fromEnv, source: 'env', inject: true };
+	}
+
+	if (env.CI) {
+		return { concurrency: undefined, source: 'ci', inject: false };
+	}
+
+	const computed = computeConcurrency({ ...machine, processMemMb });
+	return { concurrency: String(computed), source: 'computed', inject: true };
+}
+
+/**
+ * Adds the per-process old-space cap to NODE_OPTIONS.
+ *
+ * By default a cap the caller already set wins: the concurrency arithmetic
+ * above is only valid for the cap it was computed with, but a developer who
+ * pins the cap by hand has taken that arithmetic over. Pass `override` when
+ * the cap came from an explicit flag, which outranks the environment.
+ *
+ * @param {string | undefined} nodeOptions current NODE_OPTIONS
+ * @param {number} processMemMb
+ * @param {{ override?: boolean }} [options]
+ * @returns {string}
+ */
+export function resolveNodeOptions(
+	nodeOptions,
+	processMemMb = DEFAULT_PROCESS_MEM_MB,
+	{ override = false } = {},
+) {
+	const current = nodeOptions?.trim() ?? '';
+	if (!override && current.includes('--max-old-space-size')) return current;
+	const cap = `--max-old-space-size=${processMemMb}`;
+	// Node applies the last --max-old-space-size it reads, so appending wins.
+	return current === '' ? cap : `${current} ${cap}`;
+}
+
+/**
+ * Composes the two decisions above into everything a runner needs.
+ *
+ * WARNING: under CI this returns the caller's arguments and NODE_OPTIONS
+ * unchanged. Every n8n workflow pins its own concurrency and memory cap per
+ * job. A default injected here would silently change those jobs.
+ *
+ * @param {object} input
+ * @param {string[]} input.args turbo arguments the caller passed through
+ * @param {Record<string, string | undefined>} input.env
+ * @param {{ totalMemMb: number, cpuCount: number }} input.machine
+ * @param {number} [input.processMemMb]
+ * @returns {{ args: string[], nodeOptions: string | undefined, concurrency: string | undefined, source: string }}
+ */
+export function resolveSizing({ args, env, machine, processMemMb = DEFAULT_PROCESS_MEM_MB }) {
+	if (env.CI) {
+		// Report what the workflow chose, if anything, but change nothing.
+		const { concurrency } = resolveConcurrency({ args, env, machine, processMemMb });
+		return { args, nodeOptions: env.NODE_OPTIONS, concurrency, source: 'ci' };
+	}
+
+	const { concurrency, inject, source } = resolveConcurrency({ args, env, machine, processMemMb });
+	return {
+		args: inject ? [`--concurrency=${concurrency}`, ...args] : args,
+		nodeOptions: resolveNodeOptions(env.NODE_OPTIONS, processMemMb),
+		concurrency,
+		source,
+	};
+}

--- a/scripts/turbo-sizing.mjs
+++ b/scripts/turbo-sizing.mjs
@@ -107,36 +107,40 @@ export function parseConcurrencyEnv(raw) {
 }
 
 /**
- * Applies the precedence rules and reports which one won.
+ * The precedence order, in one place. Every caller uses this function, so the
+ * order is never written twice.
  *
- * `source` is `'flag'`, `'env'`, `'ci'`, or `'computed'`. `'ci'` means no
- * default was injected: CI pins its own concurrency per job, so this module
- * must not change what a workflow already runs.
+ * Each caller passes its own flag value in its own idiom: `turbo-sized.mjs`
+ * reads it out of a turbo argument list with `findConcurrencyArg()`, and
+ * `agent-setup.mjs` takes it from `parseArgs`. The flag value is returned
+ * unvalidated, so a bad value reaches turbo, which reports it better than
+ * this module can.
+ *
+ * This function knows nothing about CI. The CI policy belongs to
+ * `resolveSizing()`, which is the only place that may decide to change
+ * nothing at all.
  *
  * @param {object} input
- * @param {string[]} input.args turbo arguments the caller passed through
+ * @param {string | undefined} input.flag value of an explicit concurrency flag
  * @param {Record<string, string | undefined>} input.env
  * @param {{ totalMemMb: number, cpuCount: number }} input.machine
  * @param {number} [input.processMemMb]
- * @returns {{ concurrency: string | undefined, source: string, inject: boolean }}
+ * @returns {{ concurrency: string, source: 'flag' | 'env' | 'computed' }}
  */
-export function resolveConcurrency({ args, env, machine, processMemMb = DEFAULT_PROCESS_MEM_MB }) {
-	const fromFlag = findConcurrencyArg(args);
-	if (fromFlag !== undefined) {
-		return { concurrency: fromFlag, source: 'flag', inject: false };
+export function resolveConcurrency({ flag, env, machine, processMemMb = DEFAULT_PROCESS_MEM_MB }) {
+	if (flag !== undefined && String(flag).trim() !== '') {
+		return { concurrency: String(flag), source: 'flag' };
 	}
 
 	const fromEnv = parseConcurrencyEnv(env[CONCURRENCY_ENV_VAR]);
 	if (fromEnv !== undefined) {
-		return { concurrency: fromEnv, source: 'env', inject: true };
+		return { concurrency: fromEnv, source: 'env' };
 	}
 
-	if (env.CI) {
-		return { concurrency: undefined, source: 'ci', inject: false };
-	}
-
-	const computed = computeConcurrency({ ...machine, processMemMb });
-	return { concurrency: String(computed), source: 'computed', inject: true };
+	return {
+		concurrency: String(computeConcurrency({ ...machine, processMemMb })),
+		source: 'computed',
+	};
 }
 
 /**
@@ -180,14 +184,21 @@ export function resolveNodeOptions(
  */
 export function resolveSizing({ args, env, machine, processMemMb = DEFAULT_PROCESS_MEM_MB }) {
 	if (env.CI) {
-		// Report what the workflow chose, if anything, but change nothing.
-		const { concurrency } = resolveConcurrency({ args, env, machine, processMemMb });
-		return { args, nodeOptions: env.NODE_OPTIONS, concurrency, source: 'ci' };
+		// Report what the workflow pinned itself, if anything, but change nothing.
+		const pinned = findConcurrencyArg(args) ?? parseConcurrencyEnv(env[CONCURRENCY_ENV_VAR]);
+		return { args, nodeOptions: env.NODE_OPTIONS, concurrency: pinned, source: 'ci' };
 	}
 
-	const { concurrency, inject, source } = resolveConcurrency({ args, env, machine, processMemMb });
+	const { concurrency, source } = resolveConcurrency({
+		flag: findConcurrencyArg(args),
+		env,
+		machine,
+		processMemMb,
+	});
+
 	return {
-		args: inject ? [`--concurrency=${concurrency}`, ...args] : args,
+		// The flag is already in args when the caller passed one.
+		args: source === 'flag' ? args : [`--concurrency=${concurrency}`, ...args],
 		nodeOptions: resolveNodeOptions(env.NODE_OPTIONS, processMemMb),
 		concurrency,
 		source,

--- a/scripts/turbo-sizing.test.mjs
+++ b/scripts/turbo-sizing.test.mjs
@@ -86,44 +86,46 @@ describe('resolveConcurrency precedence', () => {
 	const base = { machine: MACHINE_16GB };
 
 	it('lets an explicit flag win over the environment variable', () => {
-		const result = resolveConcurrency({
-			...base,
-			args: ['--concurrency=5'],
-			env: { TURBO_CONCURRENCY: '3' },
-		});
-		assert.deepEqual(result, { concurrency: '5', source: 'flag', inject: false });
+		const result = resolveConcurrency({ ...base, flag: '5', env: { TURBO_CONCURRENCY: '3' } });
+		assert.deepEqual(result, { concurrency: '5', source: 'flag' });
 	});
 
 	it('lets the environment variable win over the computed default', () => {
-		const result = resolveConcurrency({ ...base, args: [], env: { TURBO_CONCURRENCY: '3' } });
-		assert.deepEqual(result, { concurrency: '3', source: 'env', inject: true });
+		const result = resolveConcurrency({ ...base, env: { TURBO_CONCURRENCY: '3' } });
+		assert.deepEqual(result, { concurrency: '3', source: 'env' });
 	});
 
 	it('falls back to the computed default', () => {
-		const result = resolveConcurrency({ ...base, args: [], env: {} });
-		assert.deepEqual(result, { concurrency: '2', source: 'computed', inject: true });
+		const result = resolveConcurrency({ ...base, env: {} });
+		assert.deepEqual(result, { concurrency: '2', source: 'computed' });
 	});
 
 	it('ignores an invalid environment variable and computes instead', () => {
-		const result = resolveConcurrency({ ...base, args: [], env: { TURBO_CONCURRENCY: 'lots' } });
+		const result = resolveConcurrency({ ...base, env: { TURBO_CONCURRENCY: 'lots' } });
 		assert.equal(result.source, 'computed');
 	});
 
-	it('injects no default under CI, so workflow behaviour does not change', () => {
-		const result = resolveConcurrency({ ...base, args: [], env: { CI: 'true' } });
-		assert.deepEqual(result, { concurrency: undefined, source: 'ci', inject: false });
+	it('treats an empty or blank flag as absent', () => {
+		for (const flag of [undefined, '', '   ']) {
+			const result = resolveConcurrency({ ...base, flag, env: { TURBO_CONCURRENCY: '3' } });
+			assert.equal(result.concurrency, '3', `flag ${JSON.stringify(flag)} was not ignored`);
+		}
 	});
 
-	it('still honours a flag and an environment variable under CI', () => {
-		assert.equal(
-			resolveConcurrency({ ...base, args: ['--concurrency=5'], env: { CI: 'true' } }).concurrency,
-			'5',
-		);
-		assert.equal(
-			resolveConcurrency({ ...base, args: [], env: { CI: 'true', TURBO_CONCURRENCY: '2' } })
-				.concurrency,
-			'2',
-		);
+	it('returns a flag value unvalidated, so turbo reports a bad one', () => {
+		const result = resolveConcurrency({ ...base, flag: 'banana', env: {} });
+		assert.deepEqual(result, { concurrency: 'banana', source: 'flag' });
+	});
+
+	it('accepts a number as the flag, which is how parseArgs callers pass it', () => {
+		assert.equal(resolveConcurrency({ ...base, flag: 4, env: {} }).concurrency, '4');
+	});
+
+	// The CI policy belongs to resolveSizing(). Keeping it out of here is what
+	// lets agent-setup.mjs share the order without inheriting the no-op.
+	it('knows nothing about CI', () => {
+		const result = resolveConcurrency({ ...base, env: { CI: 'true' } });
+		assert.deepEqual(result, { concurrency: '2', source: 'computed' });
 	});
 });
 

--- a/scripts/turbo-sizing.test.mjs
+++ b/scripts/turbo-sizing.test.mjs
@@ -1,0 +1,191 @@
+// node --test scripts/turbo-sizing.test.mjs
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+	DEFAULT_PROCESS_MEM_MB,
+	MAX_CONCURRENCY,
+	computeConcurrency,
+	findConcurrencyArg,
+	parseConcurrencyEnv,
+	resolveConcurrency,
+	resolveNodeOptions,
+	resolveSizing,
+} from './turbo-sizing.mjs';
+
+const GB = 1024;
+const MACHINE_16GB = { totalMemMb: 16 * GB, cpuCount: 10 };
+
+describe('computeConcurrency', () => {
+	it('keeps concurrency x cap inside the RAM of common machines', () => {
+		for (const totalGb of [6, 8, 16, 24, 32, 64, 128]) {
+			const machine = { totalMemMb: totalGb * GB, cpuCount: 16 };
+			const concurrency = computeConcurrency(machine);
+			assert.ok(
+				concurrency * DEFAULT_PROCESS_MEM_MB <=
+					Math.max(machine.totalMemMb, DEFAULT_PROCESS_MEM_MB),
+				`${totalGb} GB got concurrency ${concurrency}`,
+			);
+		}
+	});
+
+	it('gives a 16 GB machine the same concurrency that CI pins', () => {
+		assert.equal(computeConcurrency(MACHINE_16GB), 2);
+	});
+
+	it('never returns less than one worker, even on a box smaller than the cap', () => {
+		assert.equal(computeConcurrency({ totalMemMb: 4 * GB, cpuCount: 2 }), 1);
+	});
+
+	it("never exceeds turbo's own default", () => {
+		assert.equal(computeConcurrency({ totalMemMb: 512 * GB, cpuCount: 128 }), MAX_CONCURRENCY);
+	});
+
+	it('is limited by the CPU count on a RAM-rich, CPU-poor machine', () => {
+		assert.equal(computeConcurrency({ totalMemMb: 128 * GB, cpuCount: 2 }), 2);
+	});
+
+	it('gives more workers when the per-process cap is smaller', () => {
+		const small = computeConcurrency({ ...MACHINE_16GB, processMemMb: 2048 });
+		assert.ok(small > computeConcurrency(MACHINE_16GB));
+	});
+});
+
+describe('findConcurrencyArg', () => {
+	it('reads the joined form', () => {
+		assert.equal(findConcurrencyArg(['--filter=n8n', '--concurrency=5']), '5');
+	});
+
+	it('reads the separated form', () => {
+		assert.equal(findConcurrencyArg(['--concurrency', '5', '--summarize']), '5');
+	});
+
+	it('returns undefined when absent', () => {
+		assert.equal(findConcurrencyArg(['--filter=n8n']), undefined);
+	});
+
+	it('does not match a different flag with the same prefix', () => {
+		assert.equal(findConcurrencyArg(['--concurrency-limit=5']), undefined);
+	});
+});
+
+describe('parseConcurrencyEnv', () => {
+	it('accepts an integer and a percentage', () => {
+		assert.equal(parseConcurrencyEnv('3'), '3');
+		assert.equal(parseConcurrencyEnv(' 50% '), '50%');
+	});
+
+	it('rejects an unset, empty, zero, or non-numeric value', () => {
+		for (const raw of [undefined, '', '  ', '0', '-2', 'many', '2.5']) {
+			assert.equal(parseConcurrencyEnv(raw), undefined, `accepted ${JSON.stringify(raw)}`);
+		}
+	});
+});
+
+describe('resolveConcurrency precedence', () => {
+	const base = { machine: MACHINE_16GB };
+
+	it('lets an explicit flag win over the environment variable', () => {
+		const result = resolveConcurrency({
+			...base,
+			args: ['--concurrency=5'],
+			env: { TURBO_CONCURRENCY: '3' },
+		});
+		assert.deepEqual(result, { concurrency: '5', source: 'flag', inject: false });
+	});
+
+	it('lets the environment variable win over the computed default', () => {
+		const result = resolveConcurrency({ ...base, args: [], env: { TURBO_CONCURRENCY: '3' } });
+		assert.deepEqual(result, { concurrency: '3', source: 'env', inject: true });
+	});
+
+	it('falls back to the computed default', () => {
+		const result = resolveConcurrency({ ...base, args: [], env: {} });
+		assert.deepEqual(result, { concurrency: '2', source: 'computed', inject: true });
+	});
+
+	it('ignores an invalid environment variable and computes instead', () => {
+		const result = resolveConcurrency({ ...base, args: [], env: { TURBO_CONCURRENCY: 'lots' } });
+		assert.equal(result.source, 'computed');
+	});
+
+	it('injects no default under CI, so workflow behaviour does not change', () => {
+		const result = resolveConcurrency({ ...base, args: [], env: { CI: 'true' } });
+		assert.deepEqual(result, { concurrency: undefined, source: 'ci', inject: false });
+	});
+
+	it('still honours a flag and an environment variable under CI', () => {
+		assert.equal(
+			resolveConcurrency({ ...base, args: ['--concurrency=5'], env: { CI: 'true' } }).concurrency,
+			'5',
+		);
+		assert.equal(
+			resolveConcurrency({ ...base, args: [], env: { CI: 'true', TURBO_CONCURRENCY: '2' } })
+				.concurrency,
+			'2',
+		);
+	});
+});
+
+describe('resolveNodeOptions', () => {
+	it('adds the cap when NODE_OPTIONS is unset', () => {
+		assert.equal(resolveNodeOptions(undefined, 6144), '--max-old-space-size=6144');
+	});
+
+	it('appends the cap to existing options', () => {
+		assert.equal(
+			resolveNodeOptions('--enable-source-maps', 6144),
+			'--enable-source-maps --max-old-space-size=6144',
+		);
+	});
+
+	it('keeps a cap the caller already set', () => {
+		assert.equal(
+			resolveNodeOptions('--max-old-space-size=2048', 6144),
+			'--max-old-space-size=2048',
+		);
+	});
+	it('overrides an existing cap when asked, because Node reads the last one', () => {
+		assert.equal(
+			resolveNodeOptions('--max-old-space-size=2048', 6144, { override: true }),
+			'--max-old-space-size=2048 --max-old-space-size=6144',
+		);
+	});
+});
+
+describe('resolveSizing', () => {
+	const base = { machine: MACHINE_16GB };
+
+	it('prepends the computed concurrency and keeps the caller arguments', () => {
+		const sizing = resolveSizing({ ...base, args: ['--filter=n8n'], env: {} });
+		assert.deepEqual(sizing.args, ['--concurrency=2', '--filter=n8n']);
+		assert.equal(sizing.nodeOptions, `--max-old-space-size=${DEFAULT_PROCESS_MEM_MB}`);
+		assert.equal(sizing.source, 'computed');
+	});
+
+	it('adds nothing when the caller already set the concurrency', () => {
+		const sizing = resolveSizing({ ...base, args: ['--concurrency=5'], env: {} });
+		assert.deepEqual(sizing.args, ['--concurrency=5']);
+		assert.equal(sizing.source, 'flag');
+	});
+
+	it('changes neither arguments nor NODE_OPTIONS under CI', () => {
+		const env = { CI: 'true', NODE_OPTIONS: '--max-old-space-size=6144' };
+		const sizing = resolveSizing({ ...base, args: ['--filter=n8n'], env });
+		assert.deepEqual(sizing.args, ['--filter=n8n']);
+		assert.equal(sizing.nodeOptions, env.NODE_OPTIONS);
+		assert.equal(sizing.source, 'ci');
+		assert.equal(sizing.concurrency, undefined);
+	});
+
+	it('injects no memory cap under CI when the workflow set none', () => {
+		const sizing = resolveSizing({ ...base, args: [], env: { CI: 'true' } });
+		assert.equal(sizing.nodeOptions, undefined);
+	});
+
+	it('reports the concurrency a CI workflow pinned itself', () => {
+		const sizing = resolveSizing({ ...base, args: ['--concurrency=5'], env: { CI: 'true' } });
+		assert.equal(sizing.concurrency, '5');
+		assert.deepEqual(sizing.args, ['--concurrency=5']);
+	});
+});


### PR DESCRIPTION
## Summary

Turbo's default concurrency starts about ten type-checking workers at once. Each `vue-tsc` / `tsc` worker peaks between 2.3 GB and 6.9 GB, so `pnpm build` and `pnpm typecheck` made a 16 GB laptop swap. Only the agent path (`scripts/agent-setup.mjs`) had a cap, and that cap was a constant (`--concurrency 4`), not sized to the machine.

`scripts/turbo-sizing.mjs` now holds the sizing logic once:

- `computeConcurrency()` derives the concurrency from installed RAM and CPU count, so `concurrency x per-process cap` stays inside the machine.
- `resolveSizing()` applies the override precedence and the CI no-op.
- `scripts/turbo-sized.mjs` is the thin runner behind the root `build` and `typecheck` scripts.
- `scripts/agent-setup.mjs` imports the same module for its defaults, so the logic is shared, not copied.

**Override precedence**, highest first:

1. an explicit `--concurrency` / `--concurrency=<n>` argument
2. the `TURBO_CONCURRENCY` environment variable
3. the computed default

**CI behaviour does not change.** Under `CI` the module is a complete no-op: it changes neither the turbo arguments nor `NODE_OPTIONS`. Every workflow already pins what it wants per job (`pnpm turbo typecheck --concurrency=2`, `pnpm build --concurrency=5` on Windows, `NODE_OPTIONS=--max-old-space-size=6144`). A default injected here would silently change those jobs.

`turbo.json` is untouched.

### Measured peak aggregate RSS

Whole process tree sampled every 400 ms during `pnpm typecheck --force`, 140 tasks, on a 36 GB / 18 CPU macOS machine:

| profile | concurrency | peak aggregate RSS | wall time |
| --- | --- | --- | --- |
| baseline (turbo default, no cap) | 10 | 11.30 GB | 86 s |
| this machine (36 GB, 18 CPU) | 5 | 10.92 GB | 102 s |
| 16 GB profile (`TURBO_CONCURRENCY=2`) | 2 | 7.03 GB | 116 s |

The 16 GB profile peaks at 7.03 GB, which is 44% of 16 GB. The module computes exactly `2` for a 16 GB machine — the same number the CI typecheck job picked by hand for its 15.2 GB runner.

`pnpm build --force` peaks at 4.09 GB and is almost insensitive to concurrency (3.88 GB at the turbo default, 3.98 GB at 2, 4.09 GB at 5). Its `dependsOn: ["^build"]` chain serializes the graph, so few packages build at once. The cap matters for `typecheck`, not for `build`.

## How to test

```bash
# 1. The computed default, and the sizing decision it made
N8N_TURBO_SIZING_DEBUG=1 pnpm typecheck

# 2. The environment variable beats the computed default
N8N_TURBO_SIZING_DEBUG=1 TURBO_CONCURRENCY=3 pnpm typecheck

# 3. An explicit flag beats the environment variable
N8N_TURBO_SIZING_DEBUG=1 TURBO_CONCURRENCY=3 pnpm typecheck --concurrency=1

# 4. Under CI nothing is injected
N8N_TURBO_SIZING_DEBUG=1 CI=true pnpm typecheck

# 5. Unit tests
node --test scripts/turbo-sizing.test.mjs
```

Observed on the 36 GB / 18 CPU machine:

```
1. concurrency 5 (computed), NODE_OPTIONS="--max-old-space-size=6144"
2. concurrency 3 (env),      NODE_OPTIONS="--max-old-space-size=6144"
3. concurrency 1 (flag),     NODE_OPTIONS="--max-old-space-size=6144"
4. concurrency turbo default (ci), NODE_OPTIONS=""
5. 27 tests, 27 pass, 0 fail
```

`pnpm build` and `pnpm typecheck` both pass on this machine (70/70 and 140/140 tasks).

`scripts/turbo-sizing.mjs` and `scripts/turbo-sized.mjs` are added to the `workflow-scripts` path filter in `ci-pull-requests.yml`, so a future edit to either file runs the new unit tests. Without that, `scripts/*.test.mjs` was the only trigger and the module itself would have been unguarded.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-383

Item 2 of Phase 1 in N8N-381. Item 3 (N8N-384) owns `turbo.json` and runs in parallel; this PR does not touch that file.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — `AGENTS.md` documents the override precedence and the debug flag.
- [x] Tests included. — `scripts/turbo-sizing.test.mjs`, 27 cases covering the sizing arithmetic, the argument and environment parsing, the full precedence order, and the CI no-op.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

