### PR TITLE
build: Narrow the typecheck task dependencies in turbo.json (no-changelog)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -49,8 +49,53 @@
 			"outputs": ["dist/**"],
 			"env": ["RELEASE"]
 		},
+		// A type check reads declarations, not bundles. Most packages still resolve a
+		// workspace import through the dependency's `types`/`exports` entry, which points
+		// into `dist`, so `^build` stays the default. The overrides below are the audited
+		// exceptions (N8N-384): a package gets a smaller edge only where every remaining
+		// `dist` read is listed. An edge with no proof stays `^build`.
 		"typecheck": {
 			"dependsOn": ["^build"]
+		},
+
+		// No import in these programs resolves to a workspace `dist`, so a type check here
+		// has nothing to wait for.
+		"@n8n/cli#typecheck": { "dependsOn": [] },
+		"@n8n/codemirror-lang#typecheck": { "dependsOn": [] },
+		"@n8n/constants#typecheck": { "dependsOn": [] },
+		"@n8n/crdt#typecheck": { "dependsOn": [] },
+		"@n8n/di#typecheck": { "dependsOn": [] },
+		"@n8n/errors#typecheck": { "dependsOn": [] },
+		"@n8n/eslint-plugin-design-system#typecheck": { "dependsOn": [] },
+		"@n8n/extension-sdk#typecheck": { "dependsOn": [] },
+		"@n8n/frontend-vite-config#typecheck": { "dependsOn": [] },
+		"@n8n/json-schema-to-zod#typecheck": { "dependsOn": [] },
+		"@n8n/mcp-browser#typecheck": { "dependsOn": [] },
+		"@n8n/n8n-benchmark#typecheck": { "dependsOn": [] },
+		"@n8n/permissions#typecheck": { "dependsOn": [] },
+		"@n8n/stylelint-config#typecheck": { "dependsOn": [] },
+		"@n8n/syslog-client#typecheck": { "dependsOn": [] },
+		"@n8n/test-impact#typecheck": { "dependsOn": [] },
+		"@n8n/tournament#typecheck": { "dependsOn": [] },
+		"@n8n/typeorm#typecheck": { "dependsOn": [] },
+		"@n8n/vitest-config#typecheck": { "dependsOn": [] },
+
+		// These read their siblings from `src` through tsconfig `paths`. Only the packages
+		// listed below are still resolved through `dist`.
+		"@n8n/design-system#typecheck": {
+			"dependsOn": ["n8n-workflow#build"]
+		},
+		"@n8n/frontend-module-insights#typecheck": {
+			"dependsOn": ["@n8n/permissions#build", "@n8n/vitest-config#build", "n8n-workflow#build"]
+		},
+		"@n8n/frontend-module-instance-registry#typecheck": {
+			"dependsOn": ["@n8n/permissions#build", "@n8n/vitest-config#build", "n8n-workflow#build"]
+		},
+		"@n8n/frontend-module-otel#typecheck": {
+			"dependsOn": ["@n8n/permissions#build", "@n8n/vitest-config#build", "n8n-workflow#build"]
+		},
+		"@n8n/storybook#typecheck": {
+			"dependsOn": ["@n8n/frontend-utils#build", "@n8n/i18n#build", "n8n-workflow#build"]
 		},
 		"format": {},
 		"format:check": {},


### PR DESCRIPTION
## Summary

`turbo.json` made every `typecheck` task wait for a full `dist` build of all of its
dependencies. A type check reads declarations, not bundles. An edge is only necessary
where an import really resolves into a dependency's `dist`.

This change audits all 78 packages that have a `typecheck` script and changes the edge
for 24 of them. `^build` stays the default, so a package that is not listed keeps its
current behaviour. An edge without proof stays.

| Decision | Packages | `dependsOn` |
| --- | --- | --- |
| Removed | 19 | `[]` |
| Narrowed | 5 | the proven `<pkg>#build` set |
| Kept | 54 | `^build` |

### Method

For every package, the program of its `typecheck` script (its tsconfig `include`, its
`files`, and every module reachable from them) was resolved import by import. A workspace
import counts as a `dist` read when no tsconfig `paths` entry covers it, because every
workspace package points its `types`/`exports` entry into `dist`.

Every changed edge is then verified on a cold tree: all `dist` directories deleted and
turbo cache reads disabled. That cold run — not the static resolution — is the oracle.
Where the two disagreed, the cold run won.

### Effect on the task graph

Build tasks that a `typecheck` must wait for, from `turbo run typecheck --filter=<pkg> --dry=json`:

| Filter | Before | After |
| --- | ---: | ---: |
| `@n8n/design-system` | 23 | 15 |
| `@n8n/storybook` | 27 | 17 |
| `@n8n/frontend-module-insights` | 29 | 16 |
| `@n8n/frontend-module-otel` | 29 | 16 |
| `@n8n/frontend-module-instance-registry` | 28 | 16 |
| `@n8n/permissions` and the 18 other removals | 0–2 each | 0 |
| full repo | 70 | 70 |

The full-repo number does not move. `packages/cli` and `n8n-nodes-base` read almost all of
their dependencies from `dist`, so a full `pnpm typecheck` still builds everything. The
gain is on the filtered runs that a developer or a path-filtered CI job actually starts.

### What did not change, and why

**`n8n-editor-ui` keeps `^build`.** It was the main target of the audit. Its `paths` use the
`"@n8n/x*": ["../@n8n/x/src*"]` form. The bare-name substitution of that form lands on a
directory, and this toolchain does not resolve it, so the import falls through to
`node_modules` and therefore to `dist`. A cold run without `^build` fails:

```
n8n-editor-ui:typecheck: src/features/shared/banners/banners.store.ts(4,24): error TS2307: Cannot find module '@n8n/stores' or its corresponding type declarations.
n8n-editor-ui:typecheck: ../../modules/insights/frontend/src/insights.api.ts(8,8): error TS2307: Cannot find module '@n8n/api-types' or its corresponding type declarations.
n8n-editor-ui:typecheck: ../../modules/otel/frontend/src/otel.module.ts(2,25): error TS2307: Cannot find module '@n8n/i18n' or its corresponding type declarations.
n8n-editor-ui:typecheck: ../../modules/insights/frontend/src/insights.api.ts(9,36): error TS2307: Cannot find module '@n8n/rest-api-client' or its corresponding type declarations.
```

Adding those four to the list removes only 6 of 37 build tasks, because `@n8n/design-system`
still enters through `@n8n/chat` and `@n8n/stores`. The lever that unlocks this package is
changing those `paths` entries to the exact-file form (`"@n8n/x": [".../src/index.ts"]` plus
`"@n8n/x/*"`), which is a source change and not part of this PR.

**`n8n` (`packages/cli`) keeps `^build`.** It reads 32 of its 40 workspace dependencies from
`dist`, and two specifiers (`n8n-nodes-base/credentials/Ftp.credentials`, `n8n-core/test/utils`)
could not be resolved statically. The problem is not moved to `packages/cli`: its edge is
untouched and its `dist` inputs are all still built by `^build`.

## Edge list

### Narrowed — `^build` replaced by the proven set (5)

| Package | `typecheck` `dependsOn` | Evidence |
| --- | --- | --- |
| `@n8n/design-system`<br><sub>packages/frontend/@n8n/design-system</sub> | `n8n-workflow#build` | `n8n-workflow` in `packages/frontend/@n8n/design-system/src/components/N8nCodeBlock/CodeBlock.stories.ts` → `./dist/esm/index.d.ts`<br>_no longer built for this type check (resolved from `src` through `paths`, or not in the program at all); green on a cold run: `@n8n/composables`, `@n8n/frontend-utils`, `@n8n/utils`, `@n8n/eslint-config`, `@n8n/playwright-janitor`, `@n8n/stylelint-config`, `@n8n/vitest-config`_ |
| `@n8n/frontend-module-insights`<br><sub>packages/modules/insights/frontend</sub> | `@n8n/permissions#build`<br>`@n8n/vitest-config#build`<br>`n8n-workflow#build` | `@n8n/vitest-config/frontend` in `packages/modules/insights/frontend/vite.config.ts` → `./dist/frontend.d.ts`<br>`n8n-workflow` in `packages/@n8n/api-types/src/schemas/agent-evals.schema.ts` → `./dist/esm/index.d.ts`<br>`@n8n/permissions` in `packages/@n8n/api-types/src/schemas/project.schema.ts` → `dist/index.d.ts`<br>_no longer built for this type check (resolved from `src` through `paths`, or not in the program at all); green on a cold run: `@n8n/api-types`, `@n8n/composables`, `@n8n/design-system`, `@n8n/frontend-constants`, `@n8n/i18n`, `@n8n/rest-api-client`, `@n8n/stores`, `@n8n/utils`, `@n8n/eslint-config`, `@n8n/playwright-janitor`, `@n8n/stylelint-config`_ |
| `@n8n/frontend-module-instance-registry`<br><sub>packages/modules/instance-registry/frontend</sub> | `@n8n/permissions#build`<br>`@n8n/vitest-config#build`<br>`n8n-workflow#build` | `@n8n/vitest-config/frontend` in `packages/modules/instance-registry/frontend/vite.config.ts` → `./dist/frontend.d.ts`<br>`n8n-workflow` in `packages/frontend/@n8n/stores/src/useRootStore.ts` → `./dist/esm/index.d.ts`<br>`@n8n/permissions` in `packages/@n8n/api-types/src/schemas/project.schema.ts` → `dist/index.d.ts`<br>_no longer built for this type check (resolved from `src` through `paths`, or not in the program at all); green on a cold run: `@n8n/api-types`, `@n8n/composables`, `@n8n/design-system`, `@n8n/i18n`, `@n8n/rest-api-client`, `@n8n/stores`, `@n8n/eslint-config`, `@n8n/playwright-janitor`_ |
| `@n8n/frontend-module-otel`<br><sub>packages/modules/otel/frontend</sub> | `@n8n/permissions#build`<br>`@n8n/vitest-config#build`<br>`n8n-workflow#build` | `@n8n/vitest-config/frontend` in `packages/modules/otel/frontend/vite.config.ts` → `./dist/frontend.d.ts`<br>`n8n-workflow` in `packages/@n8n/api-types/src/schemas/agent-evals.schema.ts` → `./dist/esm/index.d.ts`<br>`@n8n/permissions` in `packages/@n8n/api-types/src/schemas/project.schema.ts` → `dist/index.d.ts`<br>_no longer built for this type check (resolved from `src` through `paths`, or not in the program at all); green on a cold run: `@n8n/api-types`, `@n8n/composables`, `@n8n/design-system`, `@n8n/i18n`, `@n8n/rest-api-client`, `@n8n/stores`, `@n8n/eslint-config`, `@n8n/playwright-janitor`, `@n8n/stylelint-config`_ |
| `@n8n/storybook`<br><sub>packages/frontend/@n8n/storybook</sub> | `@n8n/frontend-utils#build`<br>`@n8n/i18n#build`<br>`n8n-workflow#build` | `n8n-workflow` in `packages/frontend/@n8n/i18n/src/index.ts` → `./dist/esm/index.d.ts`<br>`@n8n/frontend-utils/htmlUtils` in `packages/frontend/@n8n/design-system/src/composables/useMessage.ts` → `./dist/htmlUtils.d.mts`<br>`@n8n/i18n` — not predicted by static resolution; added because the cold run reported `Cannot find module '@n8n/i18n'`<br>_no longer built for this type check (resolved from `src` through `paths`, or not in the program at all); green on a cold run: `@n8n/chat`, `@n8n/composables`, `@n8n/design-system`, `@n8n/stores`, `@n8n/utils`, `@n8n/eslint-config`_ |

### Removed — no `^build` edge (19)

| Package | `typecheck` `dependsOn` | Evidence |
| --- | --- | --- |
| `@n8n/cli`<br><sub>packages/@n8n/cli</sub> | `[]` | 0 of the 93 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/codemirror-lang`<br><sub>packages/@n8n/codemirror-lang</sub> | `[]` | 0 of the 5 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/constants`<br><sub>packages/@n8n/constants</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (12 files in program) |
| `@n8n/crdt`<br><sub>packages/@n8n/crdt</sub> | `[]` | 0 of the 35 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/di`<br><sub>packages/@n8n/di</sub> | `[]` | 0 of the 6 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/errors`<br><sub>packages/@n8n/errors</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (4 files in program) |
| `@n8n/eslint-plugin-design-system`<br><sub>packages/frontend/@n8n/eslint-plugin-design-system</sub> | `[]` | 0 of the 5 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/extension-sdk`<br><sub>packages/@n8n/extension-sdk</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (6 files in program) |
| `@n8n/frontend-vite-config`<br><sub>packages/frontend/@n8n/frontend-vite-config</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (1 files in program) |
| `@n8n/json-schema-to-zod`<br><sub>packages/@n8n/json-schema-to-zod</sub> | `[]` | 0 of the 40 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/mcp-browser`<br><sub>packages/@n8n/mcp-browser</sub> | `[]` | 0 of the 65 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/n8n-benchmark`<br><sub>packages/@n8n/benchmark</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (20 files in program) |
| `@n8n/permissions`<br><sub>packages/@n8n/permissions</sub> | `[]` | 0 of the 35 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/stylelint-config`<br><sub>packages/@n8n/stylelint-config</sub> | `[]` | 0 of the 3 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/syslog-client`<br><sub>packages/@n8n/syslog-client</sub> | `[]` | 0 of the 14 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/test-impact`<br><sub>packages/testing/test-impact</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (19 files in program) |
| `@n8n/tournament`<br><sub>packages/@n8n/tournament</sub> | `[]` | 0 of the 10 files in the program import a workspace `dist`; green on a cold run with no build task in the graph. No longer built for this type check: `@n8n/vitest-config` |
| `@n8n/typeorm`<br><sub>packages/@n8n/typeorm</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (2551 files in program) |
| `@n8n/vitest-config`<br><sub>packages/@n8n/vitest-config</sub> | `[]` | no workspace dependency with a `build` task; `^build` is already a no-op (6 files in program) |

<details>
<summary>Kept — `^build` unchanged (54)</summary>

| Package | `typecheck` `dependsOn` | Evidence |
| --- | --- | --- |
| `@n8n/agents`<br><sub>packages/@n8n/agents</sub> | `^build` | `@n8n/utils/json/to-json-value` in `packages/@n8n/agents/src/types/utils/json.ts` → `./dist/json/to-json-value.d.mts` (+1 more workspace `dist` reads: `@n8n/ai-utilities`) |
| `@n8n/ai-node-sdk`<br><sub>packages/@n8n/ai-node-sdk</sub> | `^build` | `@n8n/ai-utilities` in `packages/@n8n/ai-node-sdk/src/index.ts` → `./dist/esm/index.d.ts` |
| `@n8n/ai-utilities`<br><sub>packages/@n8n/ai-utilities</sub> | `^build` | `@n8n/utils/is-record` in `packages/@n8n/ai-utilities/src/utils/text-editor.ts` → `./dist/is-record.d.mts` (+3 more workspace `dist` reads: `n8n-workflow`, `@n8n/backend-network`, `@n8n/api-types`) |
| `@n8n/ai-workflow-builder`<br><sub>packages/@n8n/ai-workflow-builder.ee</sub> | `^build` | `n8n-workflow` in `packages/@n8n/ai-workflow-builder.ee/scripts/workflow-to-mermaid.ts` → `./dist/esm/index.d.ts` (+7 more workspace `dist` reads: `@n8n/workflow-sdk`, `@n8n/api-types`, `@n8n/backend-common`, `@n8n/utils`, `@n8n/backend-network`, `@n8n/di`, `@n8n/ai-utilities`) |
| `@n8n/api-types`<br><sub>packages/@n8n/api-types</sub> | `^build` | `@n8n/permissions` in `packages/@n8n/api-types/src/schemas/user.schema.ts` → `dist/index.d.ts` (+1 more workspace `dist` reads: `n8n-workflow`) |
| `@n8n/backend-common`<br><sub>packages/@n8n/backend-common</sub> | `^build` | `n8n-workflow` in `packages/@n8n/backend-common/src/utils/path-util.ts` → `./dist/esm/index.d.ts` (+5 more workspace `dist` reads: `@n8n/utils`, `@n8n/constants`, `@n8n/config`, `@n8n/decorators`, `@n8n/di`) |
| `@n8n/backend-network`<br><sub>packages/@n8n/backend-network</sub> | `^build` | `@n8n/backend-common` in `packages/@n8n/backend-network/src/ssrf/ssrf-protection.service.ts` → `dist/index.d.ts` (+5 more workspace `dist` reads: `@n8n/config`, `@n8n/di`, `@n8n/utils`, `n8n-workflow`, `@n8n/constants`) |
| `@n8n/backend-test-utils`<br><sub>packages/@n8n/backend-test-utils</sub> | `^build` | `@n8n/backend-common` in `packages/@n8n/backend-test-utils/src/test-modules.ts` → `dist/index.d.ts` (+7 more workspace `dist` reads: `@n8n/di`, `@n8n/config`, `@n8n/db`, `@n8n/typeorm`, `n8n-workflow`, `@n8n/constants`, `@n8n/permissions`) |
| `@n8n/blob-storage`<br><sub>packages/@n8n/blob-storage</sub> | `^build` | `n8n-workflow` in `packages/@n8n/blob-storage/src/stream-utils.ts` → `./dist/esm/index.d.ts` (+5 more workspace `dist` reads: `@n8n/backend-network`, `@n8n/utils`, `@n8n/backend-common`, `@n8n/di`, `@n8n/config`) |
| `@n8n/chat`<br><sub>packages/frontend/@n8n/chat</sub> | `^build` | `@n8n/utils/string/truncate` in `packages/frontend/@n8n/design-system/src/directives/n8n-truncate.ts` → `./dist/string/truncate.d.mts` (+3 more workspace `dist` reads: `@n8n/frontend-utils`, `@n8n/composables`, `@n8n/vitest-config`) |
| `@n8n/chat-hub`<br><sub>packages/@n8n/chat-hub</sub> | `^build` | `@n8n/api-types` in `packages/@n8n/chat-hub/src/parser.ts` → `dist/index.d.ts` |
| `@n8n/client-oauth2`<br><sub>packages/@n8n/client-oauth2</sub> | `^build` | `@n8n/backend-network` in `packages/@n8n/client-oauth2/src/client-oauth2.ts` → `./dist/index.d.ts` (+1 more workspace `dist` reads: `@n8n/utils`) |
| `@n8n/code-health`<br><sub>packages/testing/code-health</sub> | `^build` | `@n8n/rules-engine/ast` in `packages/testing/code-health/src/utils/import-graph-scanner.ts` → `./dist/ast/index.d.ts` (+2 more workspace `dist` reads: `@n8n/config`, `@n8n/eslint-config`)<br>**proof incomplete** — unresolved specifier(s) `@n8n/eslint-config/node`; edge stays |
| `@n8n/codemirror-lang-sql`<br><sub>packages/@n8n/codemirror-lang-sql</sub> | `^build` | `@n8n/codemirror-lang` in `packages/@n8n/codemirror-lang-sql/src/sql.ts` → `./dist/index.d.ts` |
| `@n8n/composables`<br><sub>packages/frontend/@n8n/composables</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/composables/vite.config.ts` → `./dist/frontend.d.ts` (+6 more workspace `dist` reads: `@n8n/frontend-constants`, `@n8n/frontend-utils`, `@n8n/i18n`, `@n8n/api-types`, `@n8n/telemetry`, `n8n-workflow`) |
| `@n8n/computer-use`<br><sub>packages/@n8n/computer-use</sub> | `^build` | `@n8n/mcp-browser` in `packages/@n8n/computer-use/src/tools/types.ts` → `dist/index.d.ts` |
| `@n8n/config`<br><sub>packages/@n8n/config</sub> | `^build` | `@n8n/di` in `packages/@n8n/config/test/string-normalization.test.ts` → `dist/di.d.ts` (+1 more workspace `dist` reads: `@n8n/constants`) |
| `@n8n/db`<br><sub>packages/@n8n/db</sub> | `^build` | `@n8n/config` in `packages/@n8n/db/src/utils/transformers.ts` → `dist/index.d.ts` (+10 more workspace `dist` reads: `@n8n/di`, `@n8n/typeorm`, `n8n-workflow`, `@n8n/backend-common`, `@n8n/decorators`, `n8n-core`, `@n8n/permissions`, `@n8n/utils`, `@n8n/api-types`, `@n8n/constants`)<br>**proof incomplete** — unresolved specifier(s) `n8n-containers/postgres-versions.json`; edge stays |
| `@n8n/decorators`<br><sub>packages/@n8n/decorators</sub> | `^build` | `@n8n/constants` in `packages/@n8n/decorators/src/system-task/system-task.ts` → `dist/index.d.ts` (+4 more workspace `dist` reads: `@n8n/di`, `n8n-workflow`, `@n8n/api-types`, `@n8n/permissions`) |
| `@n8n/engine`<br><sub>packages/@n8n/engine</sub> | `^build` | `@n8n/constants` in `packages/@n8n/engine/src/server/routes/workflow-executions.ts` → `dist/index.d.ts` (+3 more workspace `dist` reads: `@n8n/typeorm`, `@n8n/config`, `@n8n/di`)<br>**proof incomplete** — unresolved specifier(s) `n8n-containers/postgres-versions.json`; edge stays |
| `@n8n/eslint-config`<br><sub>packages/@n8n/eslint-config</sub> | `^build` | `@n8n/backend-network/transport` in `packages/@n8n/eslint-config/src/rules/no-uncentralized-http.ts` → `./dist/transport.d.ts` (+8 more workspace `dist` reads: `@n8n/di`, `n8n-core`, `@n8n/decorators`, `n8n-workflow`, `@n8n/db`, `@n8n/agents`, `@n8n/typeorm`, `@n8n/eslint-plugin-design-system`) |
| `@n8n/eslint-plugin-community-nodes`<br><sub>packages/@n8n/eslint-plugin-community-nodes</sub> | `^build` | `n8n-workflow` in `packages/@n8n/eslint-plugin-community-nodes/src/utils/constants.ts` → `./dist/esm/index.d.ts` (+1 more workspace `dist` reads: `@n8n/ai-node-sdk`) |
| `@n8n/expression-runtime`<br><sub>packages/@n8n/expression-runtime</sub> | `^build` | `@n8n/tournament` in `packages/@n8n/expression-runtime/src/types/evaluator.ts` → `./dist/index.d.ts` (+1 more workspace `dist` reads: `@n8n/errors`) |
| `@n8n/frontend-constants`<br><sub>packages/frontend/@n8n/frontend-constants</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/frontend-constants/vite.config.ts` → `./dist/frontend.d.ts` |
| `@n8n/frontend-module-sdk`<br><sub>packages/frontend/@n8n/frontend-module-sdk</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/frontend-module-sdk/vite.config.ts` → `./dist/frontend.d.ts` (+3 more workspace `dist` reads: `@n8n/frontend-utils`, `@n8n/api-types`, `n8n-workflow`) |
| `@n8n/frontend-test-utils`<br><sub>packages/frontend/@n8n/frontend-test-utils</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/frontend-test-utils/vite.config.ts` → `./dist/frontend.d.ts` (+5 more workspace `dist` reads: `n8n-workflow`, `@n8n/utils`, `@n8n/frontend-utils`, `@n8n/composables`, `@n8n/permissions`) |
| `@n8n/frontend-utils`<br><sub>packages/frontend/@n8n/frontend-utils</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/frontend-utils/vite.config.ts` → `./dist/frontend.d.ts` |
| `@n8n/i18n`<br><sub>packages/frontend/@n8n/i18n</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/i18n/vite.config.ts` → `./dist/frontend.d.ts` (+1 more workspace `dist` reads: `n8n-workflow`) |
| `@n8n/imap`<br><sub>packages/@n8n/imap</sub> | `^build` | `@n8n/utils/sleep` in `packages/@n8n/imap/src/imap-simple.ts` → `./dist/sleep.d.mts` |
| `@n8n/instance-ai`<br><sub>packages/@n8n/instance-ai</sub> | `^build` | `@n8n/utils/is-record` in `packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts` → `./dist/is-record.d.mts` (+7 more workspace `dist` reads: `@n8n/agents`, `n8n-workflow`, `@n8n/api-types`, `@n8n/ai-utilities`, `@n8n/workflow-sdk`, `@n8n/mcp-browser`, `@n8n/backend-common`)<br>**proof incomplete** — unresolved specifier(s) `@n8n/workflow-sdk/package.json`; edge stays |
| `@n8n/local-gateway`<br><sub>packages/@n8n/local-gateway</sub> | `^build` | `@n8n/computer-use/logger` in `packages/@n8n/local-gateway/src/main/tray.ts` → `./dist/logger.js` |
| `@n8n/mcp-apps`<br><sub>packages/@n8n/mcp-apps</sub> | `^build` | `@n8n/utils/is-record` in `packages/@n8n/mcp-apps/src/server/register-mcp-app-tool.ts` → `./dist/is-record.d.mts` (+2 more workspace `dist` reads: `@n8n/frontend-utils`, `@n8n/composables`) |
| `@n8n/mcp-browser-extension`<br><sub>packages/@n8n/mcp-browser-extension</sub> | `^build` | `@n8n/design-system` in `packages/@n8n/mcp-browser-extension/src/ui/App.vue` → `./dist/index.d.ts` |
| `@n8n/n8n-extension-insights`<br><sub>packages/extensions/insights</sub> | `^build` | `@n8n/extension-sdk/frontend` in `packages/extensions/insights/src/frontend/index.ts` → `./dist/frontend/index.d.mts` |
| `@n8n/n8n-nodes-langchain`<br><sub>packages/@n8n/nodes-langchain</sub> | `^build` | `n8n-workflow` in `packages/@n8n/nodes-langchain/utils/tracing.ts` → `./dist/esm/index.d.ts` (+10 more workspace `dist` reads: `@n8n/json-schema-to-zod`, `@n8n/client-oauth2`, `@n8n/utils`, `n8n-core`, `@n8n/ai-utilities`, `@n8n/config`, `@n8n/di`, `@n8n/decorators`, `n8n-nodes-base`, `@n8n/typeorm`)<br>**proof incomplete** — unresolved specifier(s) `n8n-nodes-base/test/nodes/Helpers`, `@n8n/config/src`; edge stays |
| `@n8n/node-cli`<br><sub>packages/@n8n/node-cli</sub> | `^build` | `n8n-workflow` in `packages/@n8n/node-cli/src/template/templates/programmatic/example/template/nodes/Example/Example.node.ts` → `./dist/esm/index.d.ts` (+2 more workspace `dist` reads: `@n8n/ai-node-sdk`, `@n8n/eslint-plugin-community-nodes`) |
| `@n8n/node-engine-compatibility`<br><sub>packages/@n8n/node-engine-compatibility</sub> | `^build` | `@n8n/engine` in `packages/@n8n/node-engine-compatibility/src/v1-workflow-converter.ts` → `dist/index.d.ts` (+3 more workspace `dist` reads: `n8n-workflow`, `n8n-core`, `n8n-nodes-base`)<br>**proof incomplete** — unresolved specifier(s) `n8n-nodes-base/nodes/NoOp/NoOp.node`; edge stays |
| `@n8n/performance`<br><sub>packages/testing/performance</sub> | `^build` | `n8n-workflow` in `packages/testing/performance/benchmarks/workflow-graph/traversal.bench.ts` → `./dist/esm/index.d.ts` (+1 more workspace `dist` reads: `@n8n/expression-runtime`) |
| `@n8n/playwright-janitor`<br><sub>packages/testing/janitor</sub> | `^build` | `@n8n/rules-engine` in `packages/testing/janitor/src/types.ts` → `./dist/index.d.ts` (+1 more workspace `dist` reads: `@n8n/test-impact`) |
| `@n8n/rest-api-client`<br><sub>packages/frontend/@n8n/rest-api-client</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/rest-api-client/vite.config.ts` → `./dist/frontend.d.ts` (+6 more workspace `dist` reads: `@n8n/constants`, `@n8n/utils`, `n8n-workflow`, `@n8n/api-types`, `@n8n/permissions`, `@n8n/i18n`) |
| `@n8n/rules-engine`<br><sub>packages/testing/rules-engine</sub> | `^build` | `@n8n/di` in `packages/testing/rules-engine/src/ast/imports.test.ts` → `dist/di.d.ts` |
| `@n8n/scheduler`<br><sub>packages/@n8n/scheduler</sub> | `^build` | `@n8n/constants` in `packages/@n8n/scheduler/src/core/provisioning/types.ts` → `dist/index.d.ts` (+2 more workspace `dist` reads: `n8n-workflow`, `@n8n/utils`) |
| `@n8n/stores`<br><sub>packages/frontend/@n8n/stores</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/frontend/@n8n/stores/vite.config.ts` → `./dist/frontend.d.ts` (+8 more workspace `dist` reads: `@n8n/api-types`, `@n8n/composables`, `@n8n/frontend-constants`, `@n8n/rest-api-client`, `n8n-workflow`, `@n8n/constants`, `@n8n/permissions`, `@n8n/i18n`) |
| `@n8n/task-runner`<br><sub>packages/@n8n/task-runner</sub> | `^build` | `@n8n/utils/errors/ensure-error` in `packages/@n8n/task-runner/src/task-runner.ts` → `./dist/errors/ensure-error.d.mts` (+4 more workspace `dist` reads: `n8n-core`, `n8n-workflow`, `@n8n/config`, `@n8n/di`) |
| `@n8n/telemetry`<br><sub>packages/@n8n/telemetry</sub> | `^build` | `@n8n/utils/redaction/pii-patterns` in `packages/@n8n/telemetry/src/redaction.ts` → `./dist/redaction/pii-patterns.d.mts` |
| `@n8n/utils`<br><sub>packages/@n8n/utils</sub> | `^build` | `@n8n/vitest-config/frontend` in `packages/@n8n/utils/vite.config.ts` → `./dist/frontend.d.ts` (+1 more workspace `dist` reads: `@n8n/constants`) |
| `@n8n/workflow-sdk`<br><sub>packages/@n8n/workflow-sdk</sub> | `^build` | `n8n-workflow` in `packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts` → `./dist/esm/index.d.ts` (+2 more workspace `dist` reads: `@n8n/utils`, `@n8n/constants`) |
| `n8n`<br><sub>packages/cli</sub> | `^build` | `@n8n/config` in `packages/cli/test/unit/utils/health-endpoint.util.test.ts` → `dist/index.d.ts` (+31 more workspace `dist` reads: `@n8n/backend-test-utils`, `@n8n/typeorm`, `n8n-core`, `@n8n/db`, `n8n-workflow`, `@n8n/api-types`, `@n8n/di`, `@n8n/backend-common`, `@n8n/backend-network`, `@n8n/utils`, `@n8n/decorators`, `@n8n/constants`, `@n8n/permissions`, `@n8n/client-oauth2`, `@n8n/task-runner`, `@n8n/errors`, `@n8n/instance-ai`, `@n8n/agents`, `@n8n/engine`, `@n8n/blob-storage`, `@n8n/node-engine-compatibility`, `@n8n/n8n-nodes-langchain`, `@n8n/scheduler`, `@n8n/ai-utilities`, `@n8n/syslog-client`, `@n8n/expression-runtime`, `@n8n/ai-workflow-builder`, `@n8n/mcp-browser`, `@n8n/workflow-sdk`, `@n8n/mcp-apps`, `@n8n/chat-hub`)<br>**proof incomplete** — unresolved specifier(s) `n8n-nodes-base/credentials/Ftp.credentials`, `n8n-core/test/utils`; edge stays |
| `n8n-core`<br><sub>packages/core</sub> | `^build` | `@n8n/di` in `packages/core/test/utils.ts` → `dist/di.d.ts` (+11 more workspace `dist` reads: `@n8n/utils`, `n8n-workflow`, `@n8n/backend-common`, `@n8n/backend-network`, `@n8n/constants`, `@n8n/errors`, `@n8n/blob-storage`, `@n8n/config`, `@n8n/decorators`, `@n8n/client-oauth2`, `@n8n/typeorm`) |
| `n8n-editor-ui`<br><sub>packages/frontend/editor-ui</sub> | `^build` | cold run without `^build` fails with `Cannot find module` for `@n8n/stores`, `@n8n/api-types`, `@n8n/i18n` and `@n8n/rest-api-client`: the `paths` entries for these use the `"@n8n/x*": [".../x/src*"]` form, whose bare-name substitution lands on a directory and is not resolved. The edge stays. |
| `n8n-node-dev`<br><sub>packages/node-dev</sub> | `^build` | `@n8n/di` in `packages/node-dev/src/Build.ts` → `dist/di.d.ts` (+2 more workspace `dist` reads: `n8n-core`, `n8n-workflow`) |
| `n8n-nodes-base`<br><sub>packages/nodes-base</sub> | `^build` | `n8n-workflow` in `packages/core/nodes-testing/test-data-node.ts` → `./dist/esm/index.d.ts` (+9 more workspace `dist` reads: `@n8n/di`, `@n8n/decorators`, `@n8n/utils`, `n8n-core`, `@n8n/backend-network`, `@n8n/config`, `@n8n/errors`, `@n8n/imap`, `@n8n/client-oauth2`) |
| `n8n-playwright`<br><sub>packages/testing/playwright</sub> | `^build` | `@n8n/api-types` in `packages/testing/playwright/utils/source-control-helper.ts` → `dist/index.d.ts` (+7 more workspace `dist` reads: `n8n-workflow`, `@n8n/permissions`, `@n8n/db`, `@n8n/workflow-sdk`, `@n8n/constants`, `@n8n/utils`, `@n8n/test-impact`)<br>**proof incomplete** — unresolved specifier(s) `n8n-containers/services/types`; edge stays |
| `n8n-workflow`<br><sub>packages/workflow</sub> | `^build` | `@n8n/vitest-config/node` in `packages/workflow/vitest.config.ts` → `./dist/node.d.ts` (+6 more workspace `dist` reads: `@n8n/utils`, `@n8n/config`, `@n8n/errors`, `@n8n/expression-runtime`, `@n8n/tournament`, `@n8n/constants`) |

</details>

## How to test

### 1. Full type check from a clean cache

```console
$ pnpm reset
$ pnpm typecheck
```

```
$ pnpm reset
 Tasks:    70 successful, 70 total
Cached:    70 cached, 70 total
  Time:    10.091s >>> FULL TURBO
✅ Lightweight reset done!
$ pnpm typecheck
 Tasks:    140 successful, 140 total
Cached:    140 cached, 140 total
  Time:    1.203s >>> FULL TURBO

$ pnpm typecheck --force
 Tasks:    140 successful, 140 total
Cached:    0 cached, 140 total
  Time:    1m24.249s
```

`pnpm reset` ends with a full `pnpm build`, so it leaves every `dist` in place. It proves the
type check is green, but it cannot prove that a removed edge was unnecessary. The runs below
do that.

### 2. Full type check with every `dist` deleted and turbo cache reads disabled

```console
$ pnpm clean
$ pnpm exec turbo run typecheck --cache=local:w --concurrency=4
```

```
dist dirs before run:        1
$ pnpm exec turbo run typecheck --cache=local:w --concurrency=4
 Tasks:    140 successful, 140 total
Cached:    0 cached, 140 total
  Time:    2m4.556s
```

### 3. The 19 removed edges, with no build task in the graph

```console
$ pnpm clean
$ pnpm exec turbo run typecheck --filter=@n8n/cli --filter=@n8n/codemirror-lang --filter=@n8n/constants --filter=@n8n/crdt --filter=@n8n/di --filter=@n8n/errors --filter=@n8n/eslint-plugin-design-system --filter=@n8n/extension-sdk --filter=@n8n/frontend-vite-config --filter=@n8n/json-schema-to-zod --filter=@n8n/mcp-browser --filter=@n8n/n8n-benchmark --filter=@n8n/permissions --filter=@n8n/stylelint-config --filter=@n8n/syslog-client --filter=@n8n/test-impact --filter=@n8n/tournament --filter=@n8n/typeorm --filter=@n8n/vitest-config --cache=local:w
```

```
 Tasks:    19 successful, 19 total
Cached:    0 cached, 19 total
  Time:    2.282s
```

19 type checks, zero build tasks, zero `dist` directories in the tree.

### 4. The 5 narrowed edges, each against exactly its proven set

```console
$ pnpm clean && pnpm exec turbo run typecheck --filter=@n8n/design-system
$ pnpm clean && pnpm exec turbo run typecheck --filter=@n8n/frontend-module-insights --filter=@n8n/frontend-module-otel --filter=@n8n/frontend-module-instance-registry
$ pnpm clean && pnpm exec turbo run typecheck --filter=@n8n/storybook
```

```
--- design-system (proven set: n8n-workflow) ---
$ pnpm exec turbo run typecheck --filter=@n8n/design-system
 Tasks:    15 successful, 15 total
Cached:    0 cached, 15 total
  Time:    18.912s 
--- frontend modules (proven set: @n8n/permissions, @n8n/vitest-config, n8n-workflow) ---
$ pnpm exec turbo run typecheck --filter=@n8n/frontend-module-insights --filter=@n8n/frontend-module-otel --filter=@n8n/frontend-module-instance-registry
 Tasks:    18 successful, 18 total
Cached:    0 cached, 18 total
  Time:    22.801s 
--- storybook (proven set: @n8n/frontend-utils, @n8n/i18n, n8n-workflow) ---
$ pnpm exec turbo run typecheck --filter=@n8n/storybook
 Tasks:    17 successful, 17 total
Cached:    0 cached, 17 total
  Time:    14.988s
```

Each group is run on its own clean tree, and the union of the group's proven sets equals the
proven set of every member, so no member can pass on another member's build output.

## Review findings

Two automated review findings, both P3, both about extra work rather than correctness.
Both test static imports only. A cold run settles each one: green means the edge goes,
red means the edge stays. Both came back red, so both edges stay.

### 1. `@n8n/frontend-module-instance-registry` — not applied

The finding: the package declares neither `@n8n/permissions` nor `n8n-workflow`, so the two
edges are a copy of the other two frontend modules; set `dependsOn` to
`["@n8n/vitest-config#build"]`.

A declared-dependency test is the wrong test here. Both `dist` reads come from files that
enter the program through tsconfig `paths`, not through this package's own imports:
`@n8n/api-types/src/**` and `@n8n/stores/src/useRootStore.ts`. Turbo accepts a `<pkg>#build`
edge for any package in the workspace, declared dependency or not.

The suggested list on a cold tree:

```console
$ pnpm clean
$ pnpm exec turbo run typecheck --filter=@n8n/frontend-module-instance-registry --cache=local:w
```

```
@n8n/frontend-module-instance-registry:typecheck: ../../../@n8n/api-types/src/agent-builder-tool-node-types.ts(5,8): error TS2307: Cannot find module 'n8n-workflow' or its corresponding type declarations.
@n8n/frontend-module-instance-registry:typecheck: ../../../@n8n/api-types/src/agents/dto.ts(1,27): error TS2307: Cannot find module 'n8n-workflow' or its corresponding type declarations.
@n8n/frontend-module-instance-registry:typecheck: ../../../@n8n/api-types/src/api-keys.ts(1,34): error TS2307: Cannot find module '@n8n/permissions' or its corresponding type declarations.
@n8n/frontend-module-instance-registry:typecheck: ../../../@n8n/api-types/src/dto/project/change-user-role-in-project.dto.ts(1,45): error TS2307: Cannot find module '@n8n/permissions' or its corresponding type declarations.
  ... 71 errors in total
 Tasks:    1 successful, 2 total
Cached:    0 cached, 2 total
  Time:    7.663s
```

Both edges are confirmed. The list in this PR stays.

### 2. `@n8n/storybook` — not applied

The finding: `typecheck` resolves `@n8n/i18n` from source through the `paths` in
`tsconfig.app.json`, so `@n8n/i18n#build` is unnecessary.

The project file is right. `"typecheck": "vue-tsc --noEmit -p tsconfig.app.json"`, and that
file does contain `"@n8n/i18n*": ["../i18n/src*"]`. The mapping still does not resolve a bare
`@n8n/i18n`, because the star matches the empty string and the substitution lands on the
directory `../i18n/src`. The import falls through to `node_modules`, and therefore to `dist`.

The suggested list on a cold tree:

```console
$ pnpm clean
$ pnpm exec turbo run typecheck --filter=@n8n/storybook --cache=local:w
```

```
@n8n/storybook:typecheck: .storybook/preview.ts(8,30): error TS2307: Cannot find module '@n8n/i18n' or its corresponding type declarations.
@n8n/storybook:typecheck: ../../editor-ui/src/features/shared/toolsConnection/DefaultDetailBody.vue(4,25): error TS2307: Cannot find module '@n8n/i18n' or its corresponding type declarations.
@n8n/storybook:typecheck: ../../editor-ui/src/features/shared/toolsConnection/McpDetailBody.vue(4,25): error TS2307: Cannot find module '@n8n/i18n' or its corresponding type declarations.
  ... 9 errors in total
 Tasks:    15 successful, 16 total
Cached:    0 cached, 16 total
  Time:    10.704s
```

The edge is confirmed. The list in this PR stays.

This run also isolates the cause, and it is the same one that keeps `n8n-editor-ui` on
`^build`. Change only the `paths` entry to the exact-file form and keep the reduced edge
list, and the same cold run is green:

```console
# tsconfig.app.json: "@n8n/i18n*": ["../i18n/src*"]
#              ->    "@n8n/i18n": ["../i18n/src/index.ts"] + "@n8n/i18n/*": ["../i18n/src/*"]
$ pnpm clean
$ pnpm exec turbo run typecheck --filter=@n8n/storybook --cache=local:w
```

```
 Tasks:    16 successful, 16 total
Cached:    0 cached, 16 total
  Time:    12.447s
```

That tsconfig change is not in this PR. It is a source change with a different risk, and it
is tracked as the follow-up described under "What did not change, and why".

## Related Linear tickets, Github issues, and Community forum posts

N8N-384 — audit the `typecheck` to `^build` dependency in `turbo.json`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. <!-- the rule is documented in turbo.json next to the tasks it governs -->
- [x] Tests included. <!-- a build-graph change has no unit-test layer; the four verification runs above are the test -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


