### PR TITLE
fix: Hint the Microsoft OAuth2 scope format and link the Service Principal credential docs

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftEntraServicePrincipalApi.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftEntraServicePrincipalApi.credentials.ts
@@ -151,7 +151,7 @@ export class MicrosoftEntraServicePrincipalApi implements ICredentialType {
 
 	displayName = 'Microsoft Entra Service Principal';
 
-	documentationUrl = 'microsoftentra';
+	documentationUrl = 'microsoftentraserviceprincipal';
 
 	icon: Icon = 'file:icons/Microsoft.svg';
 

--- a/packages/nodes-base/credentials/MicrosoftOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftOAuth2Api.credentials.ts
@@ -105,6 +105,19 @@ export class MicrosoftOAuth2Api implements ICredentialType {
 			default: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 		},
 		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'string',
+			displayOptions: {
+				show: {
+					useDynamicClientRegistration: [false],
+				},
+			},
+			default: '',
+			placeholder: 'openid offline_access Sites.Selected',
+			hint: 'Separate the scopes with spaces. Include offline_access so n8n can refresh the access token. Include openid so n8n can identify the signed-in account. Then add the scopes the node needs. The Microsoft credential documentation lists them.',
+		},
+		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
 			type: 'hidden',

--- a/packages/nodes-base/credentials/test/MicrosoftEntraServicePrincipalApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftEntraServicePrincipalApi.credentials.test.ts
@@ -61,7 +61,7 @@ describe('MicrosoftEntraServicePrincipalApi Credential', () => {
 	it('should have correct static properties', () => {
 		expect(credential.name).toBe('microsoftEntraServicePrincipalApi');
 		expect(credential.displayName).toBe('Microsoft Entra Service Principal');
-		expect(credential.documentationUrl).toBe('microsoftentra');
+		expect(credential.documentationUrl).toBe('microsoftentraserviceprincipal');
 		expect(credential.icon).toBe('file:icons/Microsoft.svg');
 
 		const accessToken = credential.properties.find(

--- a/packages/nodes-base/credentials/test/MicrosoftOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftOAuth2Api.credentials.test.ts
@@ -77,4 +77,20 @@ describe('MicrosoftOAuth2Api Credential', () => {
 			expect(merged[start + 1].type).toBe('options');
 		});
 	});
+
+	describe('scope', () => {
+		it('should hint the scope format without saving a default', () => {
+			const merged: INodeProperties[] = [];
+			NodeHelpers.mergeNodeProperties(merged, new OAuth2Api().properties);
+			NodeHelpers.mergeNodeProperties(merged, microsoftOAuth2Api.properties);
+
+			const scope = merged.find((p) => p.name === 'scope');
+			expect(scope?.type).toBe('string');
+			expect(scope?.default).toBe('');
+			expect(scope?.placeholder).toBe('openid offline_access Sites.Selected');
+			expect(scope?.hint).toContain('offline_access');
+			expect(scope?.hint).toContain('openid');
+			expect(scope?.displayOptions?.show?.useDynamicClientRegistration).toEqual([false]);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

The generic Microsoft OAuth2 credential inherits a bare Scope field with no guidance, so users guess the string and land on tenant-wide scopes. The field now carries the placeholder `openid offline_access Sites.Selected` and a hint that names the two scopes every delegated flow needs and points to the Microsoft credential docs for the rest. The SharePoint example in the placeholder is deliberate; it is grey example text that is never saved, and a neutral example is a one-line change if reviewers prefer it. The default stays empty, so nothing is saved for the eleven nodes and the HTTP Request node that share the credential, and every child credential already overrides the field. The Microsoft Entra Service Principal credential linked its docs to the Entra ID OAuth2 page; it now links to its own page, which has been live since July.

## How to test

1. Create a Microsoft OAuth2 API credential and check that the Scope field shows the placeholder and the hint with no prefilled value.
2. Open a Microsoft Entra Service Principal credential and check that "Read our docs" opens the Service Principal page.
3. `cd packages/nodes-base && pnpm test credentials/test/MicrosoftOAuth2Api.credentials.test.ts credentials/test/MicrosoftEntraServicePrincipalApi.credentials.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-309

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (Sites.Selected guidance lands on the Microsoft credential page with n8n-docs#5194 after release.)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

