### PR TITLE
fix(OpenAI Node): Report token usage for image operations

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/interfaces.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/interfaces.ts
@@ -85,23 +85,12 @@ export type ChatCompletion = {
 };
 
 /**
- * Shape of the responses returned by the `/images/generations` and `/images/edits`
- * endpoints. Note that the images API reports usage as `input_tokens` /
+ * Response shape of the `/images/generations` and `/images/edits` endpoints, including
+ * the `usage` block the images API returns. Note that it reports `input_tokens` /
  * `output_tokens`, unlike the Chat Completions naming (`prompt_tokens` /
  * `completion_tokens`) used by `ChatCompletion` above.
  */
-export type ImageResponse = {
-	data?: IDataObject[];
-	usage?: {
-		input_tokens: number;
-		output_tokens: number;
-		total_tokens?: number;
-		input_tokens_details?: {
-			text_tokens?: number;
-			image_tokens?: number;
-		};
-	};
-};
+export type ImageResponse = OpenAIClient.Images.ImagesResponse;
 
 export type ThreadMessage = {
 	id: string;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/interfaces.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/interfaces.ts
@@ -84,6 +84,25 @@ export type ChatCompletion = {
 	system_fingerprint: string;
 };
 
+/**
+ * Shape of the responses returned by the `/images/generations` and `/images/edits`
+ * endpoints. Note that the images API reports usage as `input_tokens` /
+ * `output_tokens`, unlike the Chat Completions naming (`prompt_tokens` /
+ * `completion_tokens`) used by `ChatCompletion` above.
+ */
+export type ImageResponse = {
+	data?: IDataObject[];
+	usage?: {
+		input_tokens: number;
+		output_tokens: number;
+		total_tokens?: number;
+		input_tokens_details?: {
+			text_tokens?: number;
+			image_tokens?: number;
+		};
+	};
+};
+
 export type ThreadMessage = {
 	id: string;
 	object: string;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/image/analyze.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/image/analyze.test.ts
@@ -10,6 +10,15 @@ import { execute } from '../../../../v2/actions/image/analyze.operation';
 vi.mock('../../../../helpers/binary-data');
 vi.mock('../../../../transport');
 
+const { accumulateTokenUsageMock } = vi.hoisted(() => ({
+	accumulateTokenUsageMock: vi.fn(),
+}));
+
+vi.mock('n8n-workflow', async (importOriginal) => ({
+	...(await importOriginal<typeof import('n8n-workflow')>()),
+	accumulateTokenUsage: accumulateTokenUsageMock,
+}));
+
 describe('Image Analyze Operation', () => {
 	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
 	let mockNode: INode;
@@ -917,6 +926,54 @@ describe('Image Analyze Operation', () => {
 					],
 				}),
 			});
+		});
+	});
+
+	describe('token usage reporting', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				const params = {
+					modelId: 'gpt-4o',
+					text: "What's in this image?",
+					inputType: 'url',
+					imageUrls: 'https://example.com/image1.jpg',
+					simplify: true,
+					options: {},
+				};
+				return params[paramName as keyof typeof params];
+			});
+		});
+
+		const baseResponse = {
+			id: 'response-123',
+			status: 'completed',
+			output: [
+				{
+					type: 'message',
+					role: 'assistant',
+					content: [{ type: 'output_text', text: 'A mountain lake.' }],
+				},
+			],
+		};
+
+		it('should report token usage when the API returns a usage object', async () => {
+			apiRequestSpy.mockResolvedValue({
+				...baseResponse,
+				usage: { input_tokens: 1120, output_tokens: 96, total_tokens: 1216 },
+			} as ChatResponse);
+
+			await execute.call(mockExecuteFunctions, 0);
+
+			expect(accumulateTokenUsageMock).toHaveBeenCalledTimes(1);
+			expect(accumulateTokenUsageMock).toHaveBeenCalledWith(mockExecuteFunctions, 1120, 96);
+		});
+
+		it('should not report token usage when the API omits it', async () => {
+			apiRequestSpy.mockResolvedValue(baseResponse as ChatResponse);
+
+			await execute.call(mockExecuteFunctions, 0);
+
+			expect(accumulateTokenUsageMock).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/image/edit.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/image/edit.operation.test.ts
@@ -26,6 +26,15 @@ vi.mock('form-data', () => {
 	return { default: MockFormData };
 });
 
+const { accumulateTokenUsageMock } = vi.hoisted(() => ({
+	accumulateTokenUsageMock: vi.fn(),
+}));
+
+vi.mock('n8n-workflow', async (importOriginal) => ({
+	...(await importOriginal<typeof import('n8n-workflow')>()),
+	accumulateTokenUsage: accumulateTokenUsageMock,
+}));
+
 describe('Image Edit Operation', () => {
 	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
 	let mockNode: INode;
@@ -734,6 +743,79 @@ describe('Image Edit Operation', () => {
 			expect(getBinaryDataFileSpy).toHaveBeenCalledTimes(2);
 			expect(getBinaryDataFileSpy).toHaveBeenNthCalledWith(1, mockExecuteFunctions, 0, 'image1');
 			expect(getBinaryDataFileSpy).toHaveBeenNthCalledWith(2, mockExecuteFunctions, 0, 'image2');
+		});
+	});
+
+	describe('token usage reporting', () => {
+		const mockBinaryFile = {
+			fileContent: Buffer.from('mock-image-data'),
+			contentType: 'image/png',
+			filename: 'data.png',
+		};
+
+		const mockEditedBinaryData = {
+			data: 'base64encodedimagedata',
+			mimeType: 'image/png',
+			fileName: 'data',
+		};
+
+		beforeEach(() => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				const params = {
+					model: 'gpt-image-1',
+					prompt: 'Add a rainbow to this landscape',
+					images: {
+						values: [{ binaryPropertyName: 'data' }],
+					},
+					n: 1,
+					size: '1024x1024',
+					quality: 'auto',
+					options: {},
+				};
+				return params[paramName as keyof typeof params];
+			});
+
+			getBinaryDataFileSpy.mockResolvedValue(mockBinaryFile);
+			(mockExecuteFunctions.helpers.binaryToBuffer as Mock).mockResolvedValue(
+				mockBinaryFile.fileContent,
+			);
+			(mockExecuteFunctions.helpers.prepareBinaryData as Mock).mockResolvedValue(
+				mockEditedBinaryData,
+			);
+		});
+
+		it('should report token usage when the API returns a usage object', async () => {
+			apiRequestSpy.mockResolvedValue({
+				data: [{ b64_json: 'base64encodedimagedata' }],
+				usage: {
+					input_tokens: 350,
+					output_tokens: 4160,
+					total_tokens: 4510,
+					input_tokens_details: { text_tokens: 27, image_tokens: 323 },
+				},
+			});
+
+			await execute.call(mockExecuteFunctions, 0);
+
+			expect(accumulateTokenUsageMock).toHaveBeenCalledTimes(1);
+			expect(accumulateTokenUsageMock).toHaveBeenCalledWith(mockExecuteFunctions, 350, 4160);
+		});
+
+		it('should not report token usage when the API omits it, and still return the image', async () => {
+			apiRequestSpy.mockResolvedValue({
+				data: [{ b64_json: 'base64encodedimagedata' }],
+			});
+
+			const result = await execute.call(mockExecuteFunctions, 0);
+
+			expect(accumulateTokenUsageMock).not.toHaveBeenCalled();
+			expect(result).toEqual([
+				{
+					json: expect.objectContaining({ data: undefined }),
+					binary: { data: mockEditedBinaryData },
+					pairedItem: { item: 0 },
+				},
+			]);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/image/generate.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/image/generate.operation.test.ts
@@ -7,6 +7,15 @@ import type { Mocked } from 'vitest';
 
 vi.mock('../../../../transport');
 
+const { accumulateTokenUsageMock } = vi.hoisted(() => ({
+	accumulateTokenUsageMock: vi.fn(),
+}));
+
+vi.mock('n8n-workflow', async (importOriginal) => ({
+	...(await importOriginal<typeof import('n8n-workflow')>()),
+	accumulateTokenUsage: accumulateTokenUsageMock,
+}));
+
 describe('Image Generate Operation', () => {
 	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
 	let mockNode: INode;
@@ -262,6 +271,47 @@ describe('Image Generate Operation', () => {
 					body: expect.not.objectContaining({ dalleQuality: expect.anything() }),
 				}),
 			);
+		});
+	});
+
+	describe('token usage reporting', () => {
+		beforeEach(() => {
+			mockNode = makeNode(2.2);
+			mockExecuteFunctions.getNode.mockReturnValue(mockNode);
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(paramName: string, _i: unknown, _default: unknown, opts?: { extractValue?: boolean }) => {
+					if (paramName === 'modelId' && opts?.extractValue) return 'gpt-image-1';
+					const params = { prompt: 'a cute cat', options: {} };
+					return params[paramName as keyof typeof params];
+				},
+			);
+		});
+
+		it('should report token usage when the API returns a usage object', async () => {
+			apiRequestSpy.mockResolvedValue({
+				...b64Response,
+				usage: { input_tokens: 42, output_tokens: 1568, total_tokens: 1610 },
+			});
+
+			await execute.call(mockExecuteFunctions, 0);
+
+			expect(accumulateTokenUsageMock).toHaveBeenCalledTimes(1);
+			expect(accumulateTokenUsageMock).toHaveBeenCalledWith(mockExecuteFunctions, 42, 1568);
+		});
+
+		it('should not report token usage when the API omits it, and still return the image', async () => {
+			apiRequestSpy.mockResolvedValue(b64Response);
+
+			const result = await execute.call(mockExecuteFunctions, 0);
+
+			expect(accumulateTokenUsageMock).not.toHaveBeenCalled();
+			expect(result).toEqual([
+				{
+					json: expect.objectContaining({ data: undefined }),
+					binary: { data: mockBinaryData },
+					pairedItem: { item: 0 },
+				},
+			]);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/image/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/image/analyze.operation.ts
@@ -4,7 +4,7 @@ import type {
 	INodeExecutionData,
 	INodeProperties,
 } from 'n8n-workflow';
-import { NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
+import { accumulateTokenUsage, NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
 
 import type { ResponseInputImage } from 'openai/resources/responses/responses';
 import type { ChatContent, ChatResponse, ChatResponseRequest } from '../../../helpers/interfaces';
@@ -195,6 +195,10 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const response = (await apiRequest.call(this, 'POST', '/responses', {
 		body,
 	})) as ChatResponse;
+
+	if (response.usage) {
+		accumulateTokenUsage(this, response.usage.input_tokens, response.usage.output_tokens);
+	}
 
 	const simplify = this.getNodeParameter('simplify', i) as boolean;
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/image/edit.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/image/edit.operation.ts
@@ -6,9 +6,10 @@ import type {
 	INodeExecutionData,
 	INodeProperties,
 } from 'n8n-workflow';
-import { updateDisplayOptions } from 'n8n-workflow';
+import { accumulateTokenUsage, updateDisplayOptions } from 'n8n-workflow';
 
 import { getBinaryDataFile } from '../../../helpers/binary-data';
+import type { ImageResponse } from '../../../helpers/interfaces';
 import { apiRequest } from '../../../transport';
 import { modelRLC } from '../descriptions';
 
@@ -686,7 +687,11 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const response = (await apiRequest.call(this, 'POST', '/images/edits', {
 		option: { formData },
 		headers: formData.getHeaders(),
-	})) as IDataObject;
+	})) as ImageResponse;
+
+	if (response.usage) {
+		accumulateTokenUsage(this, response.usage.input_tokens, response.usage.output_tokens);
+	}
 
 	const returnData: INodeExecutionData[] = [];
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/image/generate.operation.ts
@@ -4,8 +4,9 @@ import type {
 	INodeExecutionData,
 	IDataObject,
 } from 'n8n-workflow';
-import { NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
+import { accumulateTokenUsage, NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
 
+import type { ImageResponse } from '../../../helpers/interfaces';
 import { apiRequest } from '../../../transport';
 import { imageGenerateOptions, imageGenerateOptionsRLC, modelRLC } from '../descriptions';
 
@@ -113,7 +114,15 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		...options,
 	};
 
-	const { data } = await apiRequest.call(this, 'POST', '/images/generations', { body });
+	const response = (await apiRequest.call(this, 'POST', '/images/generations', {
+		body,
+	})) as ImageResponse;
+	const { data, usage } = response;
+
+	if (usage) {
+		accumulateTokenUsage(this, usage.input_tokens, usage.output_tokens);
+	}
+
 	if (response_format === 'url') {
 		return ((data as IDataObject[]) || []).map((entry) => ({
 			json: entry,
@@ -122,7 +131,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	} else {
 		const returnData: INodeExecutionData[] = [];
 
-		for (const entry of data) {
+		for (const entry of data ?? []) {
 			const binaryData = await this.helpers.prepareBinaryData(
 				Buffer.from(entry.b64_json as string, 'base64'),
 				'data',


### PR DESCRIPTION
Closes #38482

### n8n Forum Post

https://community.n8n.io/t/i-like-to-include-the-tokens-consumed-when-generating-edit-images-via-openai-api-in-the-token-eval-metrics/313721

## Summary

`accumulateTokenUsage()` is what populates the `promptTokens` / `completionTokens` metadata that n8n surfaces in **Evaluations** and insights. Across the whole v2 OpenAI action set, exactly one operation called it:

```
$ grep -rl accumulateTokenUsage v2/actions/*/*.ts
v2/actions/text/response.operation.ts
```

So an image generation reports **0 tokens** even though the API returns a `usage` object. This is visible to anyone running n8n's Evaluations over an image workflow: run durations move, the token columns stay empty, and there is no way to tell "the AI step never ran" apart from "it ran and produced something degraded".

## What was wrong, per file

| File | Endpoint | Before |
|---|---|---|
| `image/analyze.operation.ts` | `/responses` | Casts to `ChatResponse`, **the same type the text operation uses**, which already declares `usage` — simply never reported |
| `image/edit.operation.ts` | `/images/edits` | Cast to `IDataObject`; the return item is built from binary metadata only, so `usage` is dropped inside the function |
| `image/generate.operation.ts` | `/images/generations` | `usage` discarded at the destructure: `const { data } = await apiRequest(...)` |

`analyze` is the clearest case — same endpoint, same response type as `text/response.operation.ts`, which does report usage.

## Approach

Mirrors the existing reference implementation in `text/response.operation.ts`:

```ts
if (response.usage) {
	accumulateTokenUsage(this, response.usage.input_tokens, response.usage.output_tokens);
}
```

Adds an `ImageResponse` type in `helpers/interfaces.ts` for the two images endpoints. The images and Responses APIs report `input_tokens` / `output_tokens`, whereas the `usage` block already in that file uses the older Chat Completions naming (`prompt_tokens` / `completion_tokens`) — hence a separate type rather than a reuse. `input_tokens_details` is typed even though unused here, because it is what lets a user see that `input_fidelity: high` is what inflated their input tokens.

Every call site is guarded with `if (response.usage)`. DALL·E responses and custom OpenAI-compatible endpoints may omit `usage` entirely, and the existing test fixtures (which have no `usage`) must keep passing — that is the regression signal.

## Tests

Six new cases, two per operation, added to the existing test files rather than new ones:

1. mocked response **with** `usage` → `accumulateTokenUsage` called exactly once with `(input_tokens, output_tokens)`
2. mocked response **without** `usage` → not called, and the operation still returns its normal binary/json output

```
✓ nodes/vendors/OpenAi/test/v2/actions/image/generate.operation.test.ts (14 tests)
✓ nodes/vendors/OpenAi/test/v2/actions/image/edit.operation.test.ts (14 tests)
✓ nodes/vendors/OpenAi/test/v2/actions/image/analyze.test.ts (20 tests)

Test Files  3 passed (3)
     Tests  48 passed (48)
```

Also verified against the whole `nodes/vendors/OpenAi` suite: 143 passing before this change, 149 after, with no newly failing test. `biome check` and `eslint` are clean on the changed files, and `tsc --noEmit` reports no error in any file touched here.

## Out of scope

`video/generate.operation.ts` polls a job (`/videos` → `/videos/{id}`). Where usage belongs across a poll cycle is a design question rather than a three-line guard, so it is better as a follow-up.

## Related, not included here

While investigating I hit a separate, reproducible bug worth a maintainer's eye, which I'm happy to file as its own issue:

`isGPTImage = model.includes('gpt-image')` (`edit.operation.ts`) is true for the `gpt-image-2.5-*` models, so `input_fidelity` is sent to them — and those models reject it with **400 Bad Request**. The image-edit operation is therefore unusable with `gpt-image-2.5-flare` / `gpt-image-2.5-sunburst` whenever the *Input Fidelity* option is set. Confirmed empirically against the live API on node typeVersion 2.3.

Model *availability* needs no change: `imageGenerateModelSearch` filters on `includes('dall-e') || includes('gpt-image')`, which already matches every current model — verified against a live credential, returning `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2.5-flare`, `gpt-image-2.5-sunburst` and the dated variants.
