### PR TITLE
refactor(editor): Add `defineFrontendModule()` and make it the canonical descriptor form (no-changelog)

### DIFF
--- a/packages/@n8n/module-cli/frontend-module-guide.md
+++ b/packages/@n8n/module-cli/frontend-module-guide.md
@@ -147,16 +147,29 @@ value, export that value here.
 
 ```ts
 // src/my-feature.module.ts
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 
-export const MyFeatureModule: FrontendModuleDescription = {
+export const MyFeatureModule = defineFrontendModule({
 	// Must match the backend module id: both gate off `/rest/module-settings`.
 	id: 'my-feature',
 	name: 'My Feature',
 	description: 'What this module does',
 	icon: 'box',
-};
+});
 ```
+
+Declare every descriptor with `defineFrontendModule()`. It is the canonical form.
+It returns the object that you give it, and it changes no behaviour. It gives you
+two things:
+
+- One seam. The SDK gets one function to attach validation or a dev-mode check
+  to. Ten annotated object literals give it none.
+- Inference. Each field keeps its literal type, so `MyFeatureModule.id` reads as
+  `'my-feature'` and not as `string`.
+
+Do not annotate the descriptor also. `defineFrontendModule()` checks the object
+against `FrontendModuleDescription`, and the annotation makes the types wide
+again.
 
 The `id` field is critical. `settingsStore.isModuleActive(id)` reads the `activeModules` list from
 the backend. An id with no backend twin is never active. A route that uses the module availability

--- a/packages/@n8n/module-cli/src/frontend.test.mjs
+++ b/packages/@n8n/module-cli/src/frontend.test.mjs
@@ -133,6 +133,15 @@ describe('createFrontend', () => {
 			expect(readFileSync(join(packageDir, `src/${NAME}.store.ts`), 'utf8')).toContain(
 				"defineStore('myFeature'",
 			);
+
+			// `defineFrontendModule()` is the canonical descriptor form: it is the SDK's
+			// one seam for validation and dev-mode checks. A scaffold that emits a bare
+			// annotated object starts every new module outside that seam.
+			const descriptor = readFileSync(join(packageDir, `src/${NAME}.module.ts`), 'utf8');
+			expect(descriptor).toContain(
+				"import { defineFrontendModule } from '@n8n/frontend-module-sdk';",
+			);
+			expect(descriptor).toContain('export const MyFeatureModule = defineFrontendModule({');
 		});
 
 		it('registers the plugins a design-system consumer needs, and declares them', () => {

--- a/packages/@n8n/module-cli/src/templates/frontend/module.ts.template
+++ b/packages/@n8n/module-cli/src/templates/frontend/module.ts.template
@@ -1,4 +1,4 @@
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 
 /**
  * Keep this file import-light: types and the SDK only. Views load lazily
@@ -6,7 +6,7 @@ import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
  * referenced inside route guards or handlers, never at module scope — a
  * top-level store import pulls the whole module in even when it is disabled.
  */
-export const {{PascalName}}Module: FrontendModuleDescription = {
+export const {{PascalName}}Module = defineFrontendModule({
 	// Must match the backend module id: both gate off `/rest/module-settings`.
 	id: '{{name}}',
 	name: '{{TitleName}}',
@@ -26,4 +26,4 @@ export const {{PascalName}}Module: FrontendModuleDescription = {
 
 	// The SDK types the fields below, but no host in the shell reads them yet.
 	// A value here does nothing at runtime: locales, shortcuts, banners, setup.
-};
+});

--- a/packages/frontend/@n8n/frontend-module-sdk/README.md
+++ b/packages/frontend/@n8n/frontend-module-sdk/README.md
@@ -2,18 +2,53 @@
 
 The frontend module contract and registries for n8n editor modules.
 
-This package owns the `FrontendModuleDescription` descriptor type plus the modal
-and resource registries that features register against. The editor shell keeps
-the wiring (`moduleInitializer`) that drives the two-phase lifecycle; this
-package only defines the contract and the registry state.
+This package owns the `FrontendModuleDescription` descriptor type, the
+`defineFrontendModule()` helper that declares one, plus the modal and resource
+registries that features register against. The editor shell keeps the wiring
+(`moduleInitializer`) that drives the two-phase lifecycle; this package only
+defines the contract and the registry state.
 
 It is a source-only package (no build step): consumers resolve it from `src`
 via the editor-ui Vite alias and `tsconfig` paths, and `src/index.ts` is the
 only public entry point.
 
 ```ts
-import { modalRegistry, registerResource, type FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule, modalRegistry, registerResource } from '@n8n/frontend-module-sdk';
 ```
+
+## Declaring a module
+
+`defineFrontendModule()` is the canonical descriptor form. Use it for every
+module, in the shell and in a module package alike.
+
+```ts
+export const MyFeatureModule = defineFrontendModule({
+	// Must match the backend module id: both gate off `/rest/module-settings`.
+	id: 'my-feature',
+	name: 'My Feature',
+	description: 'What this module does',
+	icon: 'box',
+});
+```
+
+The helper is the identity function at runtime. It returns the object that it
+gets. It does not wrap, clone, or freeze it, so a getter-backed field such as
+`available` stays lazy.
+
+Two reasons to prefer it over a `: FrontendModuleDescription` annotation:
+
+- **One seam.** The SDK gets one function to attach descriptor validation or a
+  dev-mode check to, instead of declaration sites it cannot see.
+- **Inference.** `const T` keeps the literal type of each field, so
+  `MyFeatureModule.id` is `'my-feature'` and not `string`.
+
+Do not use both. An annotation on top of the helper widens the types again.
+
+Keep the descriptor file import-light: types and the SDK at module scope only.
+Load a view with `async () => await import('./views/X.vue')`, and read a store
+inside a route guard, a push handler, or `setup`. The shell manifest imports
+every descriptor eagerly, so a top-level store import pulls the module into the
+boot chunk even when the module is off.
 
 ## Push handlers
 

--- a/packages/frontend/@n8n/frontend-module-sdk/src/defineFrontendModule.test.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/defineFrontendModule.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+
+import { defineFrontendModule } from './defineFrontendModule';
+import type { FrontendModuleDescription } from './types/descriptor';
+
+describe('defineFrontendModule', () => {
+	it('should return the same object it was given', () => {
+		const descriptor = {
+			id: 'identity',
+			name: 'Identity',
+			description: 'A descriptor passed straight through',
+			icon: 'box',
+		};
+
+		expect(defineFrontendModule(descriptor)).toBe(descriptor);
+	});
+
+	it('should not freeze, seal, or clone the descriptor', () => {
+		const module: FrontendModuleDescription = defineFrontendModule({
+			id: 'mutable',
+			name: 'Mutable',
+			description: 'A descriptor that stays writable',
+			icon: 'box',
+			resources: [{ key: 'mutable', displayName: 'Mutable' }],
+		});
+
+		expect(Object.isFrozen(module)).toBe(false);
+		expect(Object.isSealed(module)).toBe(false);
+		expect(Object.isExtensible(module)).toBe(true);
+
+		// The shell reads a descriptor through the contract type, and registration
+		// order lets a host append. Nothing the helper does may prevent that.
+		module.resources?.push({ key: 'added', displayName: 'Added' });
+		expect(module.resources).toHaveLength(2);
+	});
+
+	it('should keep a getter lazy instead of reading it', () => {
+		let reads = 0;
+		const module = defineFrontendModule({
+			id: 'lazy',
+			name: 'Lazy',
+			description: 'A descriptor with a getter-backed field',
+			icon: 'box',
+			get settingsPages() {
+				reads += 1;
+				return [];
+			},
+		});
+
+		expect(reads).toBe(0);
+		expect(module.settingsPages).toHaveLength(0);
+		expect(reads).toBe(1);
+	});
+
+	it('should keep the literal type of each field', () => {
+		const module = defineFrontendModule({
+			id: 'literal',
+			name: 'Literal',
+			description: 'A descriptor whose literal types survive',
+			icon: 'box',
+		});
+
+		expectTypeOf(module.id).toEqualTypeOf<'literal'>();
+		expectTypeOf(module.name).toEqualTypeOf<'Literal'>();
+		expectTypeOf(module.icon).toEqualTypeOf<'box'>();
+	});
+
+	it('should narrow optional fields a descriptor declares', () => {
+		const module = defineFrontendModule({
+			id: 'narrow',
+			name: 'Narrow',
+			description: 'A descriptor declaring one optional surface',
+			icon: 'box',
+			commands: [{ id: 'narrow.open', title: 'Open Narrow' }],
+		});
+
+		// An annotated descriptor widens this to `CommandBarEntry[] | undefined`.
+		expectTypeOf(module.commands).not.toBeUndefined();
+		expectTypeOf(module).toExtend<FrontendModuleDescription>();
+	});
+
+	it('should type-check a descriptor against the contract', () => {
+		// @ts-expect-error `id` is required.
+		defineFrontendModule({ name: 'No id', description: '', icon: 'box' });
+
+		// @ts-expect-error `icon` must be a string.
+		defineFrontendModule({ id: 'typed', name: 'Typed', description: '', icon: 42 });
+
+		// @ts-expect-error `routes` must hold route records.
+		defineFrontendModule({ id: 'typed', name: 'Typed', description: '', icon: 'box', routes: [1] });
+	});
+
+	it('should keep array element types narrow under `const` inference', () => {
+		const module = defineFrontendModule({
+			id: 'narrow-elements',
+			name: 'Narrow elements',
+			description: 'A descriptor whose array elements keep their literal types',
+			icon: 'box',
+			resources: [{ key: 'thing', displayName: 'Thing' }],
+		});
+
+		expectTypeOf(module.resources[0].key).toEqualTypeOf<'thing'>();
+		expect(module.resources[0].key).toBe('thing');
+	});
+
+	it('should type a route guard from the contract', () => {
+		const module = defineFrontendModule({
+			id: 'guarded',
+			name: 'Guarded',
+			description: 'A descriptor whose guard parameter is typed by the contract',
+			icon: 'box',
+			routes: [
+				{
+					path: '/guarded',
+					component: async () => await Promise.resolve({}),
+					beforeEnter: (to) => {
+						expectTypeOf(to.params).not.toBeAny();
+						return true;
+					},
+				},
+			],
+		});
+
+		expect(module.routes).toHaveLength(1);
+	});
+});

--- a/packages/frontend/@n8n/frontend-module-sdk/src/defineFrontendModule.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/defineFrontendModule.ts
@@ -1,0 +1,29 @@
+import type { FrontendModuleDescription } from './types/descriptor';
+
+/**
+ * Declares a frontend module descriptor.
+ *
+ * Identity at runtime: it returns the object it was given. It does not wrap,
+ * clone, or freeze it, so a descriptor declared through it behaves exactly as a
+ * descriptor declared with a type annotation.
+ *
+ * What it adds is a seam and inference. The seam gives the SDK one place to
+ * attach validation or a dev-mode check later, instead of ten declaration sites
+ * it cannot see. The inference keeps each field's literal type — `MyModule.id`
+ * reads as `'my-feature'`, not `string` — which an annotation widens away.
+ *
+ * Use it for every descriptor. An annotated descriptor still satisfies the type,
+ * but it is not the canonical form.
+ *
+ * ```ts
+ * export const MyFeatureModule = defineFrontendModule({
+ *   id: 'my-feature',
+ *   name: 'My Feature',
+ *   description: 'What this module does',
+ *   icon: 'box',
+ * });
+ * ```
+ */
+export function defineFrontendModule<const T extends FrontendModuleDescription>(module: T): T {
+	return module;
+}

--- a/packages/frontend/@n8n/frontend-module-sdk/src/index.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export type * from './types';
 
+export { defineFrontendModule } from './defineFrontendModule';
 export { assertUniqueRouteNames } from './routeNames';
 
 export * as modalRegistry from './registries/modalRegistry';

--- a/packages/frontend/editor-ui/src/app/modules.manifest.ts
+++ b/packages/frontend/editor-ui/src/app/modules.manifest.ts
@@ -11,7 +11,20 @@ import { InsightsModule } from '@n8n/frontend-module-insights/insights.module';
 import { PromotionsModule } from '@/features/integrations/promotions.ee/module.descriptor';
 
 /**
- * Hard-coding modules list until we have a dynamic way to load modules.
+ * The static list is the design, not a placeholder (design §9). n8n self-hosted
+ * ships one artifact, and module availability is enforced by the backend — the
+ * `licenseFlag` plus the `isModuleActive` route middleware — so a disabled
+ * module's code on disk is inert bytes, not a leak. Fetching module bundles at
+ * runtime would buy nothing and cost real failure modes: a chunk 404 after a
+ * rolling deploy, a second vue/pinia instance, and boot ordering that races
+ * `/rest/module-settings` against pre-mount route registration.
+ *
+ * Build-time per-module chunks are the open question, not runtime loading. Once
+ * every descriptor is import-light, this array can become a static map of
+ * dynamic imports and Vite emits one chunk per module. That is decided at
+ * wave-2 exit, with bundle-analysis data.
+ *
+ * Add a module here through the scaffolder (`pnpm n8n-module-sdk create`).
  */
 export const modules: FrontendModuleDescription[] = [
 	DataTableModule,

--- a/packages/frontend/editor-ui/src/features/agents/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/agents/module.descriptor.ts
@@ -1,5 +1,5 @@
 import { VIEWS } from '@/app/constants';
-import { type FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 import {
 	AGENTS_LIST_VIEW,
 	AGENT_BUILDER_VIEW,
@@ -25,7 +25,7 @@ const AgentSessionsListView = async (): Promise<unknown> =>
 const AgentSessionTimelineView = async (): Promise<unknown> =>
 	await import('@/features/agents/views/AgentSessionTimelineView.vue');
 
-export const AgentsModule: FrontendModuleDescription = {
+export const AgentsModule = defineFrontendModule({
 	id: 'agents',
 	name: 'Agents',
 	description: 'Build and manage AI agents',
@@ -122,4 +122,4 @@ export const AgentsModule: FrontendModuleDescription = {
 			displayName: 'Agent',
 		},
 	],
-};
+});

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
@@ -1,4 +1,4 @@
-import { type FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 import {
 	CHAT_VIEW,
 	CHAT_CONVERSATION_VIEW,
@@ -23,7 +23,7 @@ const ChatPersonalAgentsView = async () =>
 const SettingsChatHubView = async () =>
 	await import('@/features/ai/chatHub/SettingsChatHubView.vue');
 
-export const ChatModule: FrontendModuleDescription = {
+export const ChatModule = defineFrontendModule({
 	id: 'chat-hub',
 	name: 'Chat',
 	description: 'Chat with LLM models or your n8n AI agents.',
@@ -205,4 +205,4 @@ export const ChatModule: FrontendModuleDescription = {
 			},
 		},
 	],
-};
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
@@ -1,5 +1,5 @@
 import { i18n } from '@n8n/i18n';
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 import { VIEWS } from '@/app/constants';
 import { INSTANCE_AI_MODALS } from './modals';
 import {
@@ -49,7 +49,7 @@ const InstanceAiEmptyView = async () => await import('./InstanceAiEmptyView.vue'
 const InstanceAiThreadView = async () => await import('./InstanceAiThreadView.vue');
 const SettingsInstanceAiView = async () => await import('./views/SettingsInstanceAiView.vue');
 
-export const InstanceAiModule: FrontendModuleDescription = {
+export const InstanceAiModule = defineFrontendModule({
 	id: 'instance-ai',
 	name: 'n8n Assistant',
 	description: 'Chat with your n8n instance.',
@@ -215,4 +215,4 @@ export const InstanceAiModule: FrontendModuleDescription = {
 			},
 		},
 	],
-};
+});

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/module.descriptor.ts
@@ -1,5 +1,5 @@
 import { useI18n } from '@n8n/i18n';
-import { type FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 import { EXPOSE_ALL_WORKFLOWS_TO_MCP_MODALS } from '@/experiments/exposeAllWorkflowsToMcp/modals';
 import { SURFACE_MCP_TO_NEW_CLOUD_USERS_MODALS } from '@/experiments/surfaceMcpToNewCloudUsers/modals';
 import { MCP_JSON_NUDGE_MODALS } from '@/experiments/mcpJsonNudge/modals';
@@ -23,7 +23,7 @@ const SettingsMCPAgentsView = async () =>
 const SettingsMCPClientsView = async () =>
 	await import('@/features/ai/mcpAccess/SettingsMCPClientsView.vue');
 
-export const MCPModule: FrontendModuleDescription = {
+export const MCPModule = defineFrontendModule({
 	id: 'mcp',
 	name: 'MCP Server',
 	description: 'Access your n8n instance through MCP clients',
@@ -107,4 +107,4 @@ export const MCPModule: FrontendModuleDescription = {
 		...EXPOSE_ALL_WORKFLOWS_TO_MCP_MODALS,
 		...MCP_JSON_NUDGE_MODALS,
 	],
-};
+});

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectFilter.slot.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectFilter.slot.test.ts
@@ -7,6 +7,7 @@ import { screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { reactive } from 'vue';
 import type { Component } from 'vue';
+import type { RouteRecordRaw } from 'vue-router';
 
 import { createComponentRenderer } from '@/__tests__/render';
 import { defaultSettings, mockedStore } from '@n8n/frontend-test-utils';
@@ -50,7 +51,11 @@ const moduleSettings: FrontendModuleSettings = {
 
 /** The dashboard as the shell reaches it: the descriptor's lazy route component. */
 const loadDashboard = async (): Promise<Component> => {
-	const child = InsightsModule.routes?.[0]?.children?.[0];
+	// Read the routes through the contract type. `defineFrontendModule()` keeps the
+	// descriptor's literal types, so the inferred record narrows to the one route
+	// shape insights declares — `RouteRecordRaw` is the shape the shell registers.
+	const routes: RouteRecordRaw[] = InsightsModule.routes ?? [];
+	const child = routes[0]?.children?.[0];
 	const loader = child?.components?.default ?? child?.component;
 	if (typeof loader !== 'function') throw new Error('insights dashboard route component missing');
 	const loaded = (await (loader as () => Promise<{ default: Component }>)()) as {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/module.descriptor.ts
@@ -1,5 +1,5 @@
 import { useI18n } from '@n8n/i18n';
-import { type FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 import {
 	DATA_TABLE_DETAILS,
 	DATA_TABLE_VIEW,
@@ -16,7 +16,7 @@ const DataTableView = async () => await import('@/features/core/dataTable/DataTa
 const DataTableDetailsView = async () =>
 	await import('@/features/core/dataTable/DataTableDetailsView.vue');
 
-export const DataTableModule: FrontendModuleDescription = {
+export const DataTableModule = defineFrontendModule({
 	id: 'data-table',
 	name: 'Data Table',
 	description: 'Manage and store data efficiently with the Data Table module.',
@@ -95,4 +95,4 @@ export const DataTableModule: FrontendModuleDescription = {
 			displayName: 'Data Table',
 		},
 	],
-};
+});

--- a/packages/frontend/editor-ui/src/features/integrations/promotions.ee/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/promotions.ee/module.descriptor.ts
@@ -1,4 +1,4 @@
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 
 import { VIEWS } from '@/app/constants';
 import { usePromotionsEnabled } from '@/features/shared/promotions/usePromotionsEnabled';
@@ -15,7 +15,7 @@ const SETTINGS_SCOPES = [
 	'gitConnection:delete',
 ] as const;
 
-export const PromotionsModule: FrontendModuleDescription = {
+export const PromotionsModule = defineFrontendModule({
 	id: 'promotions',
 	name: 'Promotions',
 	description: 'Promote workflow changes between environments',
@@ -41,4 +41,4 @@ export const PromotionsModule: FrontendModuleDescription = {
 		},
 	],
 	modals: PROMOTIONS_MODALS,
-};
+});

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/module.descriptor.ts
@@ -1,4 +1,4 @@
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 
 import { VIEWS } from '@/app/constants';
 
@@ -8,7 +8,7 @@ import { WORKFLOW_REVIEW_REQUESTS_VIEW } from './constants';
 const WorkflowReviewRequestsView = async () =>
 	await import('./views/WorkflowReviewRequestsView.vue');
 
-export const WorkflowReviewsModule: FrontendModuleDescription = {
+export const WorkflowReviewsModule = defineFrontendModule({
 	id: 'workflow-reviews',
 	name: 'Workflow Reviews',
 	description: 'Cross-project workflow review inbox.',
@@ -31,4 +31,4 @@ export const WorkflowReviewsModule: FrontendModuleDescription = {
 			},
 		},
 	],
-};
+});

--- a/packages/modules/insights/frontend/src/insights.module.ts
+++ b/packages/modules/insights/frontend/src/insights.module.ts
@@ -1,10 +1,10 @@
 import { VIEWS } from '@n8n/frontend-constants/views';
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 import { RouterView } from 'vue-router';
 
 const InsightsDashboard = async () => await import('./components/InsightsDashboard.vue');
 
-export const InsightsModule: FrontendModuleDescription = {
+export const InsightsModule = defineFrontendModule({
 	id: 'insights',
 	name: 'Insights',
 	description: 'Provides insights and analytics features for projects.',
@@ -42,4 +42,4 @@ export const InsightsModule: FrontendModuleDescription = {
 			],
 		},
 	],
-};
+});

--- a/packages/modules/instance-registry/frontend/src/instance-registry.module.ts
+++ b/packages/modules/instance-registry/frontend/src/instance-registry.module.ts
@@ -1,4 +1,4 @@
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 
 /**
  * Store-only: this module contributes no UI surface, so registering it is a no-op —
@@ -6,10 +6,10 @@ import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
  * consume the store directly; the descriptor is what makes this a module the shell
  * knows about rather than a library it happens to import.
  */
-export const InstanceRegistryModule: FrontendModuleDescription = {
+export const InstanceRegistryModule = defineFrontendModule({
 	// Must match the backend module id: both gate off `/rest/module-settings`.
 	id: 'instance-registry',
 	name: 'Instance Registry',
 	description: 'Reports which instances are in this deployment and their health',
 	icon: 'server',
-};
+});

--- a/packages/modules/otel/frontend/src/otel.module.ts
+++ b/packages/modules/otel/frontend/src/otel.module.ts
@@ -1,4 +1,4 @@
-import type { FrontendModuleDescription } from '@n8n/frontend-module-sdk';
+import { defineFrontendModule } from '@n8n/frontend-module-sdk';
 import { useI18n } from '@n8n/i18n';
 import { useRBACStore } from '@n8n/stores/rbac.store';
 
@@ -9,7 +9,7 @@ import { OTEL_SETTINGS_VIEW } from './otel.constants';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 const SettingsOpenTelemetryView = async () => await import('./SettingsOpenTelemetryView.vue');
 
-export const OtelModule: FrontendModuleDescription = {
+export const OtelModule = defineFrontendModule({
 	id: 'otel',
 	name: 'OpenTelemetry',
 	description: 'Configure OpenTelemetry settings',
@@ -47,4 +47,4 @@ export const OtelModule: FrontendModuleDescription = {
 			},
 		},
 	],
-};
+});


### PR DESCRIPTION
## Summary

Add `defineFrontendModule()` to `@n8n/frontend-module-sdk` and make it the canonical form for a module descriptor.

```ts
export function defineFrontendModule<const T extends FrontendModuleDescription>(module: T): T {
	return module;
}
```

The function is the identity function at runtime. It returns the object it gets. It does not wrap, clone, or freeze it, so a getter-backed field such as `available` stays lazy. **No runtime behaviour changes.**

It gives two things a bare `: FrontendModuleDescription` annotation cannot:

- **One seam.** The SDK gets one function for descriptor validation or a dev-mode check. Before this change, there were ten declaration sites that the SDK cannot see.
- **Inference.** The `const` type parameter keeps the literal type of each field. `InsightsModule.id` is `'insights'` and not `string`.

### Changes

- **New:** `frontend-module-sdk/src/defineFrontendModule.ts`, exported from `src/index.ts`.
- **New:** `defineFrontendModule.test.ts` — 7 tests. Runtime identity, not frozen or sealed, a getter stays lazy, and `expectTypeOf` assertions that the literal types survive.
- **Adopted** in all ten descriptors: the seven `module.descriptor.ts` files in `editor-ui/src/features/`, and the three `*.module.ts` files in `packages/modules/{insights,otel,instance-registry}/frontend/`. Three lines in each file: the import, the declaration, and the closing brace.
- **Scaffolder:** `module.ts.template` writes the helper. One assertion is added to `frontend.test.mjs`, so a scaffold that does not write the helper fails.
- **Docs:** the "Entrypoint" section of the frontend module guide, and the SDK README.
- **`modules.manifest.ts`:** the comment "Hard-coding modules list until we have a dynamic way to load modules" is replaced with the rule. The static manifest is the design: the backend enforces module availability, so the code of a disabled module is inert on disk. Build-time per-module chunks stay an open question.

### One consequential detail

`const` inference is deep, so the route records of a descriptor narrow to the exact shape that the module declares. One existing consumer reads a route structurally and broke:

`ProjectFilter.slot.test.ts` read `InsightsModule.routes?.[0]?.children?.[0]?.components`. It now reads the routes through `RouteRecordRaw[]`, which is the shape that the shell registers. This is the only such site in the repository. This is the evidence that the narrowing is safe.

### Known trade-off

Generic inference does not do excess-property checking. `defineFrontendModule({ ..., icons: [] })` is accepted, but the annotated form rejected it. A field name with a spelling error is no longer a type error. An exactness constraint (`T extends Descriptor & Record<Exclude<keyof T, keyof Descriptor>, never>`) restores the check, but it gives errors that are difficult to read. It is not in this PR: it keeps the diff mechanical, and a runtime dev-mode check on unknown keys is a better fit for the new validation seam. This decision is recorded, not forgotten.

## How to test

The change is type-level and mechanical. There is no UI surface to look at.

1. Run the checks for the touched packages:

   ```bash
   pnpm turbo run typecheck lint test \
     --filter=@n8n/frontend-module-sdk \
     --filter=@n8n/frontend-module-insights \
     --filter=@n8n/frontend-module-otel \
     --filter=@n8n/frontend-module-instance-registry
   pnpm turbo run typecheck lint --filter=n8n-editor-ui
   cd packages/frontend/editor-ui && pnpm test
   cd packages/@n8n/module-cli && pnpm test
   ```

2. Confirm that the inference works. In any descriptor file, hover the exported constant. The `id` field must show its literal type, for example `'insights'`, and not `string`.

3. Confirm that the scaffolder writes the helper:

   ```bash
   pnpm n8n-module-sdk create demo-module --stack=frontend
   grep defineFrontendModule packages/modules/demo-module/frontend/src/demo-module.module.ts
   ```

4. Start the editor and confirm that the modules still register. No environment variable, license, or feature flag is necessary for the three packaged modules to load their descriptors. The routes of a module stay gated by `/rest/module-settings`, which is unchanged.

   ```bash
   pnpm dev
   ```

### Verification done locally

| Package | typecheck | lint | test |
| --- | --- | --- | --- |
| `@n8n/frontend-module-sdk` | pass | pass | pass — 102 tests |
| `n8n-editor-ui` | pass | pass, 0 errors | pass — 16947 tests in 1193 files |
| `@n8n/module-cli` | n/a | n/a | pass — 21 tests |
| `@n8n/frontend-module-insights` | pass | pass | pass — 132 tests |
| `@n8n/frontend-module-otel` | pass | pass | pass — 128 tests |
| `@n8n/frontend-module-instance-registry` | pass | pass | pass — 2 tests |

`format:check` (biome and prettier) is clean on all six packages.

### Rollback

Revert this PR. There is no runtime change to undo.

## Related Linear tickets, Github issues, and Community forum posts

- Wave 0 platform prerequisites: https://linear.app/n8n/issue/CAT-3680/wave-0-platform-prerequisites-for-frontend-modules
- Design origin: #14406 — this PR is pick-up 3 from that comparison.
- Tracked internally as N8N-388. Stage 2 of the chain (`setup(ctx)` wiring) touches the same descriptor files and is blocked until this PR merges.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
