### PR TITLE
N8N-393: Correct the descriptor surface split in the frontend module guide

### DIFF
--- a/packages/@n8n/module-cli/frontend-module-guide.md
+++ b/packages/@n8n/module-cli/frontend-module-guide.md
@@ -168,21 +168,21 @@ shell imports.
 
 ## The descriptor contract
 
-`FrontendModuleDescription` (`@n8n/frontend-module-sdk/src/types/descriptor.ts`) declares twelve
+`FrontendModuleDescription` (`@n8n/frontend-module-sdk/src/types/descriptor.ts`) declares thirteen
 extension surfaces. The shell connects them at three different levels. Read the difference before
 you use a surface.
 
 ### Live — the shell registers these, and a reader shows them
 
-| Field                   | Register function              | Reader                                   |
-| ----------------------- | ------------------------------ | ---------------------------------------- |
-| `routes`                | `registerModuleRoutes`         | vue-router                               |
-| `projectTabs`           | `registerModuleProjectTabs`    | `ProjectHeader`                          |
-| `resources`             | `registerModuleResources`      | `ResourcesListLayout`                    |
-| `modals`                | `registerModuleModals`         | `DynamicModalLoader`                     |
-| `adHocModalKeyPrefixes` | `registerModuleModals`         | `modalRegistry` (keys minted at runtime) |
-| `settingsPages`         | `registerModuleSettingsPages`  | `SettingsSidebar`                        |
-| `pushHandlers`          | `registerModulePushHandlers`   | `useModulePushDispatcher`, in `App.vue`  |
+| Field                   | Register function               | Reader                                               |
+| ----------------------- | ------------------------------- | ---------------------------------------------------- |
+| `routes`                | `registerModuleRoutes`          | vue-router                                           |
+| `projectTabs`           | `registerModuleProjectTabs`     | `uiStore.moduleTabs`, in `ProjectHeader`             |
+| `modals`                | `registerModuleModals`          | `modalRegistry`, in `DynamicModalLoader`             |
+| `adHocModalKeyPrefixes` | `registerModuleModals`          | `modalRegistry.isAdHocKey`, in `ui.store`            |
+| `settingsPages`         | `registerModuleSettingsPages`   | `uiStore.settingsSidebarItems`, in `SettingsSidebar` |
+| `pushHandlers`          | `registerModulePushHandlers`    | `useModulePushDispatcher`, in `App.vue`              |
+| `parameterInputs`       | `registerModuleParameterInputs` | `useParameterInputContribution`, in `ParameterInput` |
 
 All the register functions are in `editor-ui/src/app/moduleInitializer/moduleInitializer.ts`.
 `main.ts` registers `routes` before the mount. `app/init/index.ts` registers the other surfaces
@@ -192,11 +192,30 @@ after the login.
 handler also stops the built-in handler of the shell for that push type. A handler from an
 inactive module would stop the built-in handler and give no message.
 
-### The shell registers this one, but nothing shows it
+`parameterInputs` has the opposite rule, on purpose. `registerModuleParameterInputs` does **not**
+gate on `isModuleActive`. A parameter input is a render primitive, and not a feature. A gated
+renderer would leave the parameter with nothing to draw it, which is a broken field and not a
+hidden feature. The backend enforces availability. One module owns one `parameter.type`, and a
+type that no module claims keeps the built-in branch of the shell.
 
-`registerModuleCommands` puts `commands` into `commandRegistry`. No command-bar host reads that
-registry. `features/shared/commandBar` still makes its list from its own `use*Commands`
-composables. The registry keeps your `commands` array, but the command bar never shows it.
+### The shell registers these two, but nothing shows them
+
+**`commands`.** `registerModuleCommands` puts your entries into `commandRegistry`. No command-bar
+host reads that registry. `features/shared/commandBar` still makes its list from its own
+`use*Commands` composables. The registry keeps your `commands` array, but the command bar never
+shows it.
+
+**`resources`.** `registerModuleResources` puts your metadata into `resourceRegistry`. No file
+reads it back: nothing in the repo calls `getResource`, `hasResource` or `getAllResourceKeys`.
+`ResourcesListLayout` does **not** import the SDK, so it never sees a module resource. (The
+`getResourceText` helper in that component is i18n, and is not the registry.)
+
+`ResourcesListLayout` renders the `resources` and `resourceKey` **props** that its caller gives
+it. A shell feature adds its resource to the `Resource` union with a type-level augmentation of
+`ModuleResources` in `@/Interface`; `features/core/dataTable/types.ts` and
+`features/agents/types.ts` do this. A module package cannot do the same, because the module
+tsconfig base gives no `@/*` path. So a packaged module has no supported route to that layout
+today. Render your own list until **CAT-3685** lands.
 
 ### Types-only — these do nothing at all
 
@@ -205,25 +224,35 @@ composables. The registry keeps your `commands` array, but the command bar never
 The SDK exports the types. No file in the shell reads them. A value that you set does nothing: no
 error, no warning, no behaviour.
 
-Do not use `commands` or the four types-only fields yet. **CAT-3685** tracks the remaining work.
-The descriptor that the CLI writes repeats this split in a comment, so you see it as you write.
+Do not use `commands`, `resources` or the four types-only fields yet. **CAT-3685** tracks the
+remaining work. The descriptor that the CLI writes repeats this split in a comment, so you see it
+as you write.
 
 **Note:** this is the most common cause of lost time for a new module author. The type accepts
-your `commands` array, and no component draws it.
+your `commands` or `resources` array, the shell puts it in a registry, and no component draws it.
 
 ### Route names are yours, and a check guards them
 
 A route name is global to the router. `router.addRoute` replaces a duplicate name and gives no
 warning. The route that loses then does not resolve.
 
-The central `VIEWS` enum of the shell made every name unique. A module cannot import `VIEWS`,
-because `VIEWS` is in `@/app/constants` — the shell. Declare your own constant, and export it from
-your `constants.ts` file:
+The central `VIEWS` enum made every name unique. A module **can** import it: `VIEWS` is in
+`@n8n/frontend-constants/views`, an L2 package, and not in `@/app/constants`. Declare
+`@n8n/frontend-constants` as a dependency and import the name you need:
+
+```ts
+import { VIEWS } from '@n8n/frontend-constants/views';
+```
+
+`packages/modules/insights/frontend/src/insights.module.ts` does this. A module may also declare
+its own route names instead, and export them from its `constants.ts` file:
 
 ```ts
 // src/my-feature.constants.ts
 export const MY_FEATURE_VIEW = 'my-feature';
 ```
+
+Either way works. `assertUniqueRouteNames` catches a collision in both.
 
 `assertUniqueRouteNames` (`@n8n/frontend-module-sdk`) gives that check back. `registerModuleRoutes`
 calls it before it adds a module route. It throws an error if a name is the same as a shell name
@@ -625,10 +654,10 @@ Keep `"license": "LicenseRef-n8n-sustainable-use"`. Do not add `private`.
 
 ## Future work
 
-1. **Five descriptor surfaces do not work yet.** `commands` goes into `commandRegistry`, but no
-   command-bar host reads that registry. `locales`, `shortcuts`, `banners` and `setup` are types,
-   and no file reads them (**CAT-3685**). Until that work lands, cross-feature code stays in the
-   shell.
+1. **Six descriptor surfaces do not work yet.** `commands` goes into `commandRegistry` and
+   `resources` goes into `resourceRegistry`, but no host reads either registry. `locales`,
+   `shortcuts`, `banners` and `setup` are types, and no file reads them (**CAT-3685**). Until that
+   work lands, cross-feature code stays in the shell.
 2. **No tool stops a deliberate cross-module import.** The ESLint `no-restricted-imports` rule is
    **CAT-3692**. The alias split stops an accident in a test run. The tsconfig base stops one at
    typecheck. `turbo boundaries` reports only an *undeclared* dependency. A declared dependency

--- a/packages/@n8n/module-cli/src/templates/frontend/module.ts.template
+++ b/packages/@n8n/module-cli/src/templates/frontend/module.ts.template
@@ -13,16 +13,22 @@ export const {{PascalName}}Module: FrontendModuleDescription = {
 	description: 'TODO: describe what this module does',
 	icon: 'box',
 
-	// The shell reads the fields below. Uncomment what this module contributes.
+	// The shell registers the fields below AND a reader shows them. Uncomment
+	// what this module contributes.
 	//
 	// routes: [ /* RouteRecordRaw[]; components must be lazy */ ],
 	// projectTabs: { overview: [], project: [], shared: [] },
-	// resources: [ /* ResourceMetadata[]; feeds ResourcesListLayout */ ],
 	// modals: [ /* ModalDefinition[]; rendered by DynamicModalLoader */ ],
 	// adHocModalKeyPrefixes: [ /* prefixes for modal keys minted at runtime */ ],
 	// settingsPages: [ /* IMenuItem[]; feeds SettingsSidebar */ ],
-	// pushHandlers: { /* keyed by push message type */ },
-	// commands: [ /* CommandBarEntry[] */ ],
+	// pushHandlers: { /* keyed by push message type; active modules only */ },
+	// parameterInputs: [ /* ParameterInputContribution[]; resolved by parameter.type */ ],
+
+	// The shell registers the two fields below, but NOTHING reads the registry
+	// yet, so a value here draws nothing (CAT-3685):
+	//   resources — no caller of getResource/hasResource/getAllResourceKeys;
+	//               ResourcesListLayout does not import the SDK.
+	//   commands  — the command bar still builds its own list.
 
 	// The SDK types the fields below, but no host in the shell reads them yet.
 	// A value here does nothing at runtime: locales, shortcuts, banners, setup.


### PR DESCRIPTION
## Summary

`packages/@n8n/module-cli/frontend-module-guide.md` misstated which descriptor surfaces work. A module author following the live table could ship a `resources` contribution that silently does nothing, and would not find `parameterInputs` at all.

Closes N8N-393.

## What I re-traced

I traced each descriptor field from its writer in `editor-ui/src/app/moduleInitializer/moduleInitializer.ts` to a reader, rather than taking the issue's brief on trust. There are seven register functions; `routes` runs pre-mount from `main.ts:53`, the other six post-login from `app/init/index.ts:239-245`.

| Field | Writer | Reader | Verdict |
| --- | --- | --- | --- |
| `routes` | `registerModuleRoutes` | `router.addRoute` | live |
| `projectTabs` | `registerModuleProjectTabs` | `uiStore.moduleTabs` → `ProjectHeader.vue:188` | live |
| `modals` | `registerModuleModals` | `modalRegistry` → `DynamicModalLoader.vue`, `ui.store.ts` | live |
| `adHocModalKeyPrefixes` | `registerModuleModals` | `modalRegistry.isAdHocKey` → `ui.store.ts:399` | live |
| `settingsPages` | `registerModuleSettingsPages` | `uiStore.settingsSidebarItems` → `useSettingsItems.ts:207` → `SettingsSidebar.vue` | live |
| `pushHandlers` | `registerModulePushHandlers` | `useModulePushDispatcher` → `App.vue:72` | live |
| `parameterInputs` | `registerModuleParameterInputs` | `useParameterInputContribution` → `ParameterInput.vue`, `ParameterInputFull.vue` | **live, was undocumented** |
| `commands` | `registerModuleCommands` | none | registered, unread |
| `resources` | `registerModuleResources` | none | **registered, unread — was listed live** |
| `locales` `shortcuts` `banners` `setup` | no writer | none | types-only |

## Evidence for the two corrections in the issue

**`resources` is not live.** A repo-wide grep for `getResource`, `hasResource` and `getAllResourceKeys` returns no frontend caller; every hit is an unrelated backend identifier (`packages/cli`, `@n8n/ai-utilities`, `@n8n/workflow-sdk`). `ResourcesListLayout.vue` does not import the SDK — its `getResourceText` comes from `useResourcesListI18n`, which is i18n and not the registry. That name similarity is likely how the error entered the guide.

I also chased what a module should do instead, because "unread" alone is not actionable. `ResourcesListLayout` renders the `resources` and `resourceKey` **props** its caller passes. A shell feature joins the `Resource` union by augmenting `ModuleResources` in `@/Interface` (`features/core/dataTable/types.ts`, `features/agents/types.ts`). A packaged module cannot: `tsconfig.frontend-module.json` declares no `@/*` path. So a module package has no supported route to that layout today, and the guide now says so.

**`parameterInputs` is live and was missing.** Added with its reader named. I also recorded the contract that `registerModuleParameterInputs` is deliberately *not* gated on `isModuleActive` — the inverse of the `pushHandlers` rule directly above it, and a trap if you assume the two behave alike.

## Three further errors found by the same trace

Not in the acceptance checks, but the same defect class in the same section, so I fixed them rather than leave known-false text next to corrected text:

1. **Surface count.** The descriptor declares **thirteen** optional surfaces, not twelve. Counted off `descriptor.ts`.
2. **The `VIEWS` claim was inverted.** The guide said a module *cannot* import `VIEWS` because it lives in `@/app/constants`. It is an enum in `@n8n/frontend-constants/src/views.ts`, `tsconfig.frontend-module.json:38` maps `@n8n/frontend-constants/*`, and `packages/modules/insights/frontend/src/insights.module.ts:1` imports it. Corrected, keeping the module-owned-constant option as the alternative it is.
3. **Future work item 1** said five dead surfaces; with `resources` it is six.

## Scaffold template

`src/templates/frontend/module.ts.template` carried the same error and also filed `commands` under "the shell reads the fields below". It now has three groups matching the guide: live (with `parameterInputs`), registered-but-unread (`resources`, `commands`, with the reason for each), and types-only.

## Verification

- Prettier 3.6.2 (the pinned version) is a byte-for-byte no-op on the guide — `**/*.md` is in `.prettierignore`. `.ts.template` matches neither the `prettier_check` nor the `biome_check` lefthook glob. The pre-commit hook was skipped because the binary is not installed in this environment, not because a check failed.
- The scaffolded descriptor still parses and exports `MyFeatureModule` after placeholder substitution.
- No test asserts the template comment text (`src/frontend.test.mjs` checks the package manifest, `index.ts`, store and icon output), so the edit is comment-only and safe.
- Docs-only change: no product behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

