### PR TITLE
build(editor): N8N-398 Enforce the frontend module import boundary in ESLint (no-changelog)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ a new import (or an inline `eslint-disable` of the rule) fails CI.
 
 ### ESLint configuration layers
 
-Rule policy lives in four shared configs in `@n8n/eslint-config`, and a package
+Rule policy lives in five shared configs in `@n8n/eslint-config`, and a package
 config picks exactly one:
 
 | layer | subpath | for |
@@ -275,6 +275,7 @@ config picks exactly one:
 | `baseConfig` | `@n8n/eslint-config/base` | runtime-agnostic libraries |
 | `backendConfig` | `@n8n/eslint-config/backend` | anything that runs on Node; adds the network and encryption boundaries |
 | `frontendConfig` | `@n8n/eslint-config/frontend` | Vue packages |
+| `frontendModuleConfig` | `@n8n/eslint-config/frontend-module` | `packages/modules/*/frontend`; adds `frontendConfig` plus the module boundary (no sibling module, no `@/` shell import) |
 | `nodesConfig` | `@n8n/eslint-config/nodes` | `n8n-nodes-base` and `@n8n/nodes-langchain`; adds the node and credential file rules |
 
 A package config may add `ignores`, an additive plugin config, a block that

--- a/packages/@n8n/eslint-config/package.json
+++ b/packages/@n8n/eslint-config/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/configs/frontend.d.js",
       "default": "./dist/configs/frontend.js"
     },
+    "./frontend-module": {
+      "types": "./dist/configs/frontend-module.d.js",
+      "default": "./dist/configs/frontend-module.js"
+    },
     "./nodes": {
       "types": "./dist/configs/nodes.d.js",
       "default": "./dist/configs/nodes.js"

--- a/packages/@n8n/eslint-config/src/configs/frontend-module.test.ts
+++ b/packages/@n8n/eslint-config/src/configs/frontend-module.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Linter } from 'eslint';
+import tsParser from '@typescript-eslint/parser';
+import typescriptPlugin from '@typescript-eslint/eslint-plugin';
+import { frontendModuleConfig } from './frontend-module.js';
+
+/**
+ * The patterns of the boundary read with gitignore semantics, where `*` stops at a `/` and a rule
+ * that matches a parent path wins over a later `!` on a child. A subpath therefore needs its own
+ * ban line and its own negation line. These cases hold that behaviour.
+ */
+const SELF = '@n8n/frontend-module-otel';
+
+const moduleDir = mkdtempSync(join(tmpdir(), 'frontend-module-config-'));
+writeFileSync(join(moduleDir, 'package.json'), JSON.stringify({ name: SELF }));
+
+/** The boundary rule options, taken from the config the module packages use. */
+const options = frontendModuleConfig(moduleDir)
+	.map((entry) => entry.rules?.['@typescript-eslint/no-restricted-imports'])
+	.find((rule) => rule !== undefined);
+
+const linter = new Linter({ configType: 'flat' });
+
+const lint = (specifier: string) =>
+	linter.verify(`import { thing } from '${specifier}';`, {
+		plugins: { '@typescript-eslint': typescriptPlugin as never },
+		languageOptions: { parser: tsParser as never },
+		rules: { '@typescript-eslint/no-restricted-imports': options as never },
+	});
+
+describe('frontendModuleConfig', () => {
+	test.each([
+		['a sibling module', '@n8n/frontend-module-insights'],
+		['a subpath of a sibling module', '@n8n/frontend-module-insights/insights.module'],
+		['a deep subpath of a sibling module', '@n8n/frontend-module-insights/components/Chart.vue'],
+		['the shell alias', '@/app/stores/ui.store'],
+		['the shell alias at the root', '@/Interface'],
+	])('rejects %s', (_name, specifier) => {
+		const [message] = lint(specifier);
+
+		expect(message?.ruleId).toBe('@typescript-eslint/no-restricted-imports');
+		expect(message?.severity).toBe(2);
+	});
+
+	test.each([
+		['the SDK', '@n8n/frontend-module-sdk'],
+		['a subpath of the SDK', '@n8n/frontend-module-sdk/types/descriptor'],
+		['the package itself', SELF],
+		['a subpath of the package itself', `${SELF}/otel.module`],
+		['an L2 package', '@n8n/stores'],
+		['a relative path', './otel.store'],
+	])('accepts %s', (_name, specifier) => {
+		expect(lint(specifier)).toEqual([]);
+	});
+});

--- a/packages/@n8n/eslint-config/src/configs/frontend-module.ts
+++ b/packages/@n8n/eslint-config/src/configs/frontend-module.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import tseslint from 'typescript-eslint';
+import { frontendConfig } from './frontend.js';
+
+/**
+ * The boundary of a frontend module package, at error level.
+ *
+ * `packages/modules/<name>/frontend` is an L3 package. An L3 package imports only L0-L2. It does
+ * not import a sibling module, and it does not import the shell. Two other mechanisms stop an
+ * *accidental* import of a sibling: `frontendAliases()` leaves the sibling modules out of the Vite
+ * alias table, and `tsconfig.frontend-module.json` leaves them out of `paths`. Neither one is a
+ * boundary. `paths` is additive and an alias is a convenience, so a module that declares a sibling
+ * as a dependency gets a symlink from pnpm, and every check passes. This rule is the boundary.
+ *
+ * Two specifiers stay legal:
+ *
+ * - `@n8n/frontend-module-sdk` is L2, not a module. It carries the contribution points.
+ * - The package's own name. The module reads it from `package.json`, so a module that imports
+ *   itself through its own `exports` map (as the shell imports
+ *   `@n8n/frontend-module-insights/insights.module`) does not trip the rule.
+ */
+const SDK_PACKAGE = '@n8n/frontend-module-sdk';
+
+const SIBLING_MESSAGE =
+	'A module does not import another module. Move the shared value into an L2 package, such as @n8n/stores or @n8n/composables. If you cannot move it, the two features are one module. To reach the shell or another module, contribute through a descriptor surface of @n8n/frontend-module-sdk.';
+
+const SHELL_MESSAGE =
+	'@/ is the alias of the editor-ui shell. A module does not import the shell. The shell reaches a module through src/app/modules.manifest.ts, and a module reaches the shell through a descriptor surface of @n8n/frontend-module-sdk.';
+
+/** The name in the `package.json` next to the `eslint.config.mjs` that calls this. */
+const packageNameIn = (moduleDir: string): string => {
+	const manifest: unknown = JSON.parse(readFileSync(join(moduleDir, 'package.json'), 'utf8'));
+
+	if (
+		typeof manifest !== 'object' ||
+		manifest === null ||
+		typeof (manifest as { name?: unknown }).name !== 'string'
+	) {
+		throw new Error(`${join(moduleDir, 'package.json')} declares no name.`);
+	}
+
+	return (manifest as { name: string }).name;
+};
+
+/**
+ * The ESLint config of a frontend module package: `frontendConfig` plus the module boundary.
+ *
+ * Call it with the directory of the config file, so the rule can read the name of this package:
+ *
+ * ```js
+ * import { defineConfig } from 'eslint/config';
+ * import { frontendModuleConfig } from '@n8n/eslint-config/frontend-module';
+ *
+ * export default defineConfig(frontendModuleConfig(import.meta.dirname));
+ * ```
+ */
+export const frontendModuleConfig = (moduleDir: string) => {
+	const self = packageNameIn(moduleDir);
+
+	// `no-restricted-imports` matches a group with gitignore semantics, so `*` stops at a `/` and a
+	// later `!` line re-includes what an earlier line took. The bare name and the subpath therefore
+	// need one line each, and every negation comes after every ban.
+	const siblingModules = [
+		'@n8n/frontend-module-*',
+		'@n8n/frontend-module-*/*',
+		`!${SDK_PACKAGE}`,
+		`!${SDK_PACKAGE}/*`,
+		`!${self}`,
+		`!${self}/*`,
+	];
+
+	return tseslint.config(frontendConfig, {
+		rules: {
+			'@typescript-eslint/no-restricted-imports': [
+				'error',
+				{
+					patterns: [
+						{ group: siblingModules, message: SIBLING_MESSAGE },
+						{ group: ['@/*'], message: SHELL_MESSAGE },
+					],
+				},
+			],
+		},
+	});
+};

--- a/packages/@n8n/module-cli/frontend-module-guide.md
+++ b/packages/@n8n/module-cli/frontend-module-guide.md
@@ -360,12 +360,43 @@ baseline in the repository (`.boundaries-baseline.json`). The count of issues ca
 dependency by design.
 
 The alias split changes an accidental import from a silent success into two clear failures. It
-does not stop a person who wants that import. An ESLint `no-restricted-imports` rule would stop
-it, and that rule **is not in the repository yet**. **CAT-3692** tracks it.
+does not stop a person who wants that import.
 
-Until that rule lands, the boundary is the responsibility of the reviewer. Reviewers, look for a
-new `@n8n/frontend-module-*` entry in the `dependencies` of a module. That entry is the only
-signal. After a module declares the dependency, every check passes.
+**The ESLint rule stops it, and the rule is in the repository.** The `eslint.config.mjs` of a
+module extends `frontendModuleConfig` from `@n8n/eslint-config/frontend-module`, which is
+`frontendConfig` plus `@typescript-eslint/no-restricted-imports` at **error** level:
+
+```js
+import { defineConfig } from 'eslint/config';
+import { frontendModuleConfig } from '@n8n/eslint-config/frontend-module';
+
+export default defineConfig(frontendModuleConfig(import.meta.dirname));
+```
+
+The CLI writes that file, so a new module gets the boundary with no manual step. Pass
+`import.meta.dirname`: the config reads the name from the `package.json` next to it, and lets the
+module import itself.
+
+The rule bans a bare specifier and a subpath, so `@n8n/frontend-module-insights` and
+`@n8n/frontend-module-insights/insights.module` both fail. Two specifiers stay legal:
+
+- `@n8n/frontend-module-sdk`. It is an L2 package, not a module.
+- The name of this package. The shell imports the insights descriptor as
+  `@n8n/frontend-module-insights/insights.module`, and a module may do the same with its own
+  `exports` map.
+
+The rule also bans `@/`, the alias of the editor-ui shell.
+
+```
+error  '@n8n/frontend-module-insights' import is restricted from being used by a pattern.
+       A module does not import another module. Move the shared value into an L2 package,
+       such as @n8n/stores or @n8n/composables. If you cannot move it, the two features are
+       one module. To reach the shell or another module, contribute through a descriptor
+       surface of @n8n/frontend-module-sdk
+```
+
+Do not add a suppression for this rule. If your module needs a value from a sibling, read the FAQ
+entry at the end of this guide.
 
 ## Stores
 
@@ -629,10 +660,9 @@ Keep `"license": "LicenseRef-n8n-sustainable-use"`. Do not add `private`.
    command-bar host reads that registry. `locales`, `shortcuts`, `banners` and `setup` are types,
    and no file reads them (**CAT-3685**). Until that work lands, cross-feature code stays in the
    shell.
-2. **No tool stops a deliberate cross-module import.** The ESLint `no-restricted-imports` rule is
-   **CAT-3692**. The alias split stops an accident in a test run. The tsconfig base stops one at
-   typecheck. `turbo boundaries` reports only an *undeclared* dependency. A declared dependency
-   clears all three. This rule must land before the second extraction.
+2. ~~**No tool stops a deliberate cross-module import.**~~ **Done (CAT-3692).**
+   `frontendModuleConfig` bans a sibling module and the `@/` shell alias at error level. See "The
+   no-cross-module rule" above.
 3. **Per-module i18n.** A module keeps its strings in the central `en.json` of `@n8n/i18n` today.
    The target is the `locales` descriptor field with per-module key types. The central `en.json` is
    the accepted alternative, but it must not become permanent.

--- a/packages/@n8n/module-cli/src/templates/frontend/README.md.template
+++ b/packages/@n8n/module-cli/src/templates/frontend/README.md.template
@@ -27,10 +27,10 @@ yet. Turbo builds them first; the bare pnpm form does not.
   `@n8n/frontend-module-*`, and never import `@/…` from the shell.
 - `@n8n/stores` and `@n8n/composables` are **subpath-only** — import
   `@n8n/stores/settings.store`, not `@n8n/stores`.
-- The no-cross-module rule is currently a convention: the shared tsconfig base
-  omits sibling modules from `paths`, which blocks an accidental import but not
-  a deliberate one (declaring the dependency makes it typecheck clean). The
-  ESLint rule that actually enforces it is CAT-3692.
+- The no-cross-module rule is enforced. `eslint.config.mjs` extends
+  `frontendModuleConfig` from `@n8n/eslint-config/frontend-module`, which bans a
+  sibling module and the `@/` shell alias at error level. Only
+  `@n8n/frontend-module-sdk` and this package's own name stay legal.
 
 ## Adding UI
 

--- a/packages/@n8n/module-cli/src/templates/frontend/eslint.config.mjs.template
+++ b/packages/@n8n/module-cli/src/templates/frontend/eslint.config.mjs.template
@@ -1,4 +1,4 @@
 import { defineConfig } from 'eslint/config';
-import { frontendConfig } from '@n8n/eslint-config/frontend';
+import { frontendModuleConfig } from '@n8n/eslint-config/frontend-module';
 
-export default defineConfig(frontendConfig);
+export default defineConfig(frontendModuleConfig(import.meta.dirname));

--- a/packages/modules/insights/frontend/README.md
+++ b/packages/modules/insights/frontend/README.md
@@ -37,10 +37,10 @@ yet. Turbo builds them first; the bare pnpm form does not.
   `@n8n/frontend-module-*`, and never import `@/…` from the shell.
 - `@n8n/stores` and `@n8n/composables` are **subpath-only** — import
   `@n8n/stores/settings.store`, not `@n8n/stores`.
-- The no-cross-module rule is currently a convention: the shared tsconfig base
-  omits sibling modules from `paths`, which blocks an accidental import but not
-  a deliberate one (declaring the dependency makes it typecheck clean). The
-  ESLint rule that actually enforces it is CAT-3692.
+- The no-cross-module rule is enforced. `eslint.config.mjs` extends
+  `frontendModuleConfig` from `@n8n/eslint-config/frontend-module`, which bans a
+  sibling module and the `@/` shell alias at error level. Only
+  `@n8n/frontend-module-sdk` and this package's own name stay legal.
 
 ## Adding UI
 

--- a/packages/modules/insights/frontend/eslint.config.mjs
+++ b/packages/modules/insights/frontend/eslint.config.mjs
@@ -1,7 +1,7 @@
-import { frontendConfig } from '@n8n/eslint-config/frontend';
+import { frontendModuleConfig } from '@n8n/eslint-config/frontend-module';
 import { defineConfig } from 'eslint/config';
 
-export default defineConfig(frontendConfig, {
+export default defineConfig(frontendModuleConfig(import.meta.dirname), {
 	/**
 	 * Suppressions inherited with the code, not granted to it.
 	 *

--- a/packages/modules/instance-registry/frontend/README.md
+++ b/packages/modules/instance-registry/frontend/README.md
@@ -21,7 +21,7 @@ yet. Turbo builds them first; the bare pnpm form does not.
   `@n8n/frontend-module-*`, and never import `@/…` from the shell.
 - `@n8n/stores` and `@n8n/composables` are **subpath-only** — import
   `@n8n/stores/settings.store`, not `@n8n/stores`.
-- The no-cross-module rule is currently a convention: the shared tsconfig base
-  omits sibling modules from `paths`, which blocks an accidental import but not
-  a deliberate one (declaring the dependency makes it typecheck clean). The
-  ESLint rule that actually enforces it is CAT-3692.
+- The no-cross-module rule is enforced. `eslint.config.mjs` extends
+  `frontendModuleConfig` from `@n8n/eslint-config/frontend-module`, which bans a
+  sibling module and the `@/` shell alias at error level. Only
+  `@n8n/frontend-module-sdk` and this package's own name stay legal.

--- a/packages/modules/instance-registry/frontend/eslint.config.mjs
+++ b/packages/modules/instance-registry/frontend/eslint.config.mjs
@@ -1,4 +1,4 @@
 import { defineConfig } from 'eslint/config';
-import { frontendConfig } from '@n8n/eslint-config/frontend';
+import { frontendModuleConfig } from '@n8n/eslint-config/frontend-module';
 
-export default defineConfig(frontendConfig);
+export default defineConfig(frontendModuleConfig(import.meta.dirname));

--- a/packages/modules/otel/frontend/README.md
+++ b/packages/modules/otel/frontend/README.md
@@ -36,7 +36,7 @@ Strings still live in the central `@n8n/i18n` `en.json` under
   and never import `@/…` from the shell.
 - `@n8n/stores` and `@n8n/composables` are **subpath-only** — import
   `@n8n/stores/settings.store`, not `@n8n/stores`.
-- The no-cross-module rule is currently a convention: the shared tsconfig base
-  omits sibling modules from `paths`, which blocks an accidental import but not
-  a deliberate one (declaring the dependency makes it typecheck clean). The
-  ESLint rule that actually enforces it is CAT-3692.
+- The no-cross-module rule is enforced. `eslint.config.mjs` extends
+  `frontendModuleConfig` from `@n8n/eslint-config/frontend-module`, which bans a
+  sibling module and the `@/` shell alias at error level. Only
+  `@n8n/frontend-module-sdk` and this package's own name stay legal.

--- a/packages/modules/otel/frontend/eslint.config.mjs
+++ b/packages/modules/otel/frontend/eslint.config.mjs
@@ -1,4 +1,4 @@
 import { defineConfig } from 'eslint/config';
-import { frontendConfig } from '@n8n/eslint-config/frontend';
+import { frontendModuleConfig } from '@n8n/eslint-config/frontend-module';
 
-export default defineConfig(frontendConfig);
+export default defineConfig(frontendModuleConfig(import.meta.dirname));

--- a/packages/testing/code-health/src/rules/lint-config-layering.rule.ts
+++ b/packages/testing/code-health/src/rules/lint-config-layering.rule.ts
@@ -10,10 +10,10 @@ import { findPackageJsonFiles, relativeDir } from '../utils/package-json-scanner
 
 const CONFIG_FILENAMES = ['eslint.config.mjs', 'eslint.config.js', 'eslint.config.cjs'];
 
-const LAYERS = ['base', 'backend', 'frontend', 'nodes'];
+const LAYERS = ['base', 'backend', 'frontend', 'frontend-module', 'nodes'];
 const LAYER_IMPORT = /^@n8n\/eslint-config\/([a-z-]+)$/;
 
-/** Retired export paths, replaced by the four layers. */
+/** Retired export paths, replaced by the shared layers. */
 const REMOVED_SUBPATHS = new Set(['node', 'encryption-boundary']);
 
 /**
@@ -33,7 +33,7 @@ const WEAK_SEVERITY = new Set(['off', 'warn', '0', '1']);
  *
  * The repo used to carry a rule table in each of 72 package configs, which is
  * how it ended up with the same override written 35 times and four rules
- * silently shadowed by a duplicate key. The four shared layers hold the policy
+ * silently shadowed by a duplicate key. The shared layers hold the policy
  * now, so a package config may pick a layer and scope exceptions to paths, but
  * it may not quietly re-decide a rule for its whole tree.
  *
@@ -109,7 +109,7 @@ export class LintConfigLayeringRule extends BaseRule<CodeHealthContext> {
 						line,
 						column,
 						`${packageName} imports '@n8n/eslint-config/${subpath}', which no longer exists.`,
-						'Use one of the four layers: base, backend, frontend or nodes. The boundary configs are part of backendConfig.',
+						'Use one of the five layers: base, backend, frontend, frontend-module or nodes. The boundary configs are part of backendConfig.',
 					),
 				);
 				continue;
@@ -124,7 +124,7 @@ export class LintConfigLayeringRule extends BaseRule<CodeHealthContext> {
 					1,
 					1,
 					`${packageName} does not extend a shared ESLint layer.`,
-					'Import baseConfig, backendConfig, frontendConfig or nodesConfig from @n8n/eslint-config and pass it to defineConfig.',
+					'Import baseConfig, backendConfig, frontendConfig, frontendModuleConfig or nodesConfig from @n8n/eslint-config and pass it to defineConfig.',
 				),
 			);
 		} else if (layerImports.length > 1) {
@@ -134,7 +134,7 @@ export class LintConfigLayeringRule extends BaseRule<CodeHealthContext> {
 					1,
 					1,
 					`${packageName} extends more than one shared layer (${layerImports.join(', ')}).`,
-					'Pick the single layer that matches the package. The backend layer already contains the base layer, and the nodes layer contains the backend layer.',
+					'Pick the single layer that matches the package. The backend layer already contains the base layer, the nodes layer contains the backend layer, and the frontend-module layer contains the frontend layer.',
 				),
 			);
 		}


### PR DESCRIPTION
## Summary

A frontend module package is L3. It imports only L0-L2. Until now no tool stopped a **deliberate** import of a sibling module or of the shell. The alias table (`frontendAliases()`) and the tsconfig base leave sibling modules out, but `paths` is additive: a module that declared a sibling as a dependency got a pnpm symlink, and every check passed. `turbo boundaries` accepts a declared dependency by design.

This PR adds the boundary.

**New layer `@n8n/eslint-config/frontend-module`** — `frontendConfig` plus `@typescript-eslint/no-restricted-imports` at **error** level:

- bans `@n8n/frontend-module-*`, bare and subpath (`@n8n/frontend-module-insights`, `.../insights.module`, `.../components/Chart.vue`)
- bans `@/`, the editor-ui shell alias
- keeps `@n8n/frontend-module-sdk` legal — it is L2, not a module
- keeps **the package's own name** legal, bare and subpath. The config reads the name from the `package.json` next to it, so a module that imports itself through its own `exports` map (as the shell imports `@n8n/frontend-module-insights/insights.module`) does not trip the rule.

The three module packages now extend it. The `@n8n/module-cli` template writes it, so a new module inherits the boundary from the scaffolder with no manual step.

Messages match the tone of the `extractedFeatures` messages in `editor-ui/eslint.config.mjs` and name the alternative:

```
error  '@n8n/frontend-module-insights' import is restricted from being used by a pattern.
       A module does not import another module. Move the shared value into an L2 package,
       such as @n8n/stores or @n8n/composables. If you cannot move it, the two features are
       one module. To reach the shell or another module, contribute through a descriptor
       surface of @n8n/frontend-module-sdk
```

## Why a fifth layer, and why it takes an argument

`lint-config-layering` requires a package config to extend exactly one shared layer, so `frontend-module` is registered as a layer rather than bolted on in each module config. `AGENTS.md` records it.

The argument is `import.meta.dirname`. The self-import allowance needs the package name, and reading it from the config's own directory keeps the name in one place and survives a rename.

The patterns read with gitignore semantics: `*` stops at a `/`, and a rule that matches a parent path wins over a later `!` on a child. The bare name and the subpath therefore need one ban line and one negation line each. `frontend-module.test.ts` holds that behaviour with 11 cases.

## Related issue

https://linear.app/n8n/issue/CAT-3692

## How to test

Green on the current tree, with **no suppression added**:

```
$ pnpm turbo lint --filter='./packages/modules/*/frontend'
 Tasks:    28 successful, 28 total
```

The rule firing on a deliberate violation in `packages/modules/otel/frontend`:

```
$ eslint src/__boundary-probe.ts
  2:1  error  '@n8n/frontend-module-insights' import is restricted ...   @typescript-eslint/no-restricted-imports
  3:1  error  '@n8n/frontend-module-insights/insights.module' ...        @typescript-eslint/no-restricted-imports
  5:1  error  '@/app/stores/ui.store' import is restricted ...           @typescript-eslint/no-restricted-imports

✖ 3 problems (3 errors, 0 warnings)
```

In the same file, `@n8n/frontend-module-sdk`, `@n8n/frontend-module-sdk/types/descriptor`, `@n8n/frontend-module-otel` and `@n8n/frontend-module-otel/otel.module` report nothing. The probe file is not committed.

Other checks:

- `pnpm --filter @n8n/eslint-config test` — 859 passed, 11 new
- `pnpm --filter @n8n/code-health test` — 195 passed
- `pnpm --filter=@n8n/code-health check` — 0 violations
- `pnpm --filter @n8n/module-cli test` — 21 passed
- `pnpm turbo lint typecheck --filter='./packages/modules/*/frontend' --filter=@n8n/eslint-config --filter=@n8n/code-health` — 34 successful

## Docs

`frontend-module-guide.md`: "The no-cross-module rule" now documents the shipped rule, and future-work item #2 is marked done. The same stale note is corrected in the three module READMEs and in the README template.

## Note for the reviewer, not in this PR

`pnpm boundaries:check` reports **155** issues against a baseline of **163** on this branch. Nothing here changes an import, so that gap is pre-existing drift on master. Locking the win in (`pnpm boundaries:baseline`) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

