### PR TITLE
fix(Microsoft Excel Node): Accept personal OneDrive workbook IDs in the By ID field

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/common.descriptions.ts
@@ -20,11 +20,15 @@ export const workbookRLC: INodeProperties = {
 			displayName: 'By ID',
 			name: 'id',
 			type: 'string',
+			placeholder: 'e.g. 01A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P7',
 			validation: [
 				{
 					type: 'regex',
 					properties: {
-						regex: '[a-zA-Z0-9]{2,}',
+						// A work account returns `01A2B3…`; a personal one `<driveId>!<itemId>`, where
+						// the separator arrives as `!` or percent-encoded as `%21`. The pattern is
+						// anchored by the validator, so it must cover both shapes.
+						regex: '[a-zA-Z0-9]{2,}((!|%21)[a-zA-Z0-9]+)*',
 						errorMessage: 'Not a valid Workbook ID',
 					},
 				},
@@ -52,6 +56,7 @@ export const worksheetRLC: INodeProperties = {
 			displayName: 'By ID',
 			name: 'id',
 			type: 'string',
+			placeholder: 'e.g. {00000000-0001-0000-0000-000000000000}',
 			validation: [
 				{
 					type: 'regex',
@@ -84,6 +89,7 @@ export const tableRLC: INodeProperties = {
 			displayName: 'By ID',
 			name: 'id',
 			type: 'string',
+			placeholder: 'e.g. {21EAB2B0-DD1A-4E5B-9931-1C4D8A0D7A31}',
 			validation: [
 				{
 					type: 'regex',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/common.descriptions.ts
@@ -26,9 +26,11 @@ export const workbookRLC: INodeProperties = {
 					type: 'regex',
 					properties: {
 						// A work account returns `01A2B3…`; a personal one `<driveId>!<itemId>`, where
-						// the separator arrives as `!` or percent-encoded as `%21`. The pattern is
-						// anchored by the validator, so it must cover both shapes.
-						regex: '[a-zA-Z0-9]{2,}((!|%21)[a-zA-Z0-9]+)*',
+						// the separator arrives as `!` or percent-encoded as `%21`. Graph documents
+						// the ID only as opaque, so the class stays permissive and rejects just the
+						// characters that would change the request path. The validator anchors the
+						// pattern, so it must cover a whole ID.
+						regex: '[a-zA-Z0-9\\-_]{2,}((!|%21)[a-zA-Z0-9\\-_]+)*',
 						errorMessage: 'Not a valid Workbook ID',
 					},
 				},

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/test/actions/common.descriptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/test/actions/common.descriptions.test.ts
@@ -25,19 +25,19 @@ const issuesFor = (property: INodeProperties, value: string) =>
 describe('Microsoft Excel resource locators, By ID mode', () => {
 	describe('Workbook', () => {
 		it.each([
-			['a work account item ID', '016LYZ3HUDUGG5UN54ANFKEOW3472JHUX3'],
-			['a personal account item ID', 'F6B9FC11B50FF84A!s65efa4c5cf3f44f9a9c92f993b244006'],
-			['a legacy personal account item ID', 'F6B9FC11B50FF84A!123'],
-			['a percent-encoded separator', 'F6B9FC11B50FF84A%21s65efa4c5cf3f44f9a9c92f993b244006'],
+			['a work account item ID', '01ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'],
+			['a personal account item ID', 'A1B2C3D4E5F60718!s0123456789abcdef0123456789abcdef'],
+			['a legacy personal account item ID', 'A1B2C3D4E5F60718!123'],
+			['a percent-encoded separator', 'A1B2C3D4E5F60718%21s0123456789abcdef0123456789abcdef'],
 		])('accepts %s', (_label, value) => {
 			expect(issuesFor(workbookRLC, value)).toEqual({});
 		});
 
 		it.each([
-			['a path separator', 'F6B9FC11B50FF84A/children'],
+			['a path separator', 'A1B2C3D4E5F60718/children'],
 			['parent directory traversal', '../drives'],
-			['a trailing separator', 'F6B9FC11B50FF84A!'],
-			['a space', 'F6B9FC11 B50FF84A'],
+			['a trailing separator', 'A1B2C3D4E5F60718!'],
+			['a space', 'A1B2C3D4E5 F60718'],
 		])('rejects %s', (_label, value) => {
 			expect(issuesFor(workbookRLC, value)).toEqual({
 				workbook: ['Not a valid Workbook ID'],

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/test/actions/common.descriptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/test/actions/common.descriptions.test.ts
@@ -29,6 +29,8 @@ describe('Microsoft Excel resource locators, By ID mode', () => {
 			['a personal account item ID', 'A1B2C3D4E5F60718!s0123456789abcdef0123456789abcdef'],
 			['a legacy personal account item ID', 'A1B2C3D4E5F60718!123'],
 			['a percent-encoded separator', 'A1B2C3D4E5F60718%21s0123456789abcdef0123456789abcdef'],
+			// Graph documents the ID as opaque, so a base64url-shaped one must pass too.
+			['a hyphen and an underscore', 'A1B2-C3D4_E5F60718!s0123-4567_89abcdef'],
 		])('accepts %s', (_label, value) => {
 			expect(issuesFor(workbookRLC, value)).toEqual({});
 		});

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/test/actions/common.descriptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/test/actions/common.descriptions.test.ts
@@ -1,0 +1,63 @@
+import type { INode, INodeProperties } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
+
+import { tableRLC, workbookRLC, worksheetRLC } from '../../actions/common.descriptions';
+
+const node: INode = {
+	id: 'test-node',
+	name: 'Test Excel Node',
+	type: 'n8n-nodes-base.microsoftExcel',
+	typeVersion: 2,
+	position: [0, 0],
+	parameters: {},
+};
+
+const issuesFor = (property: INodeProperties, value: string) =>
+	NodeHelpers.getParameterIssues(
+		property,
+		{ [property.name]: { __rl: true, mode: 'id', value } },
+		'',
+		node,
+		null,
+	).parameters ?? {};
+
+// getParameterIssues anchors a mode's regex with `^…$`, so each pattern must match a whole ID.
+describe('Microsoft Excel resource locators, By ID mode', () => {
+	describe('Workbook', () => {
+		it.each([
+			['a work account item ID', '016LYZ3HUDUGG5UN54ANFKEOW3472JHUX3'],
+			['a personal account item ID', 'F6B9FC11B50FF84A!s65efa4c5cf3f44f9a9c92f993b244006'],
+			['a legacy personal account item ID', 'F6B9FC11B50FF84A!123'],
+			['a percent-encoded separator', 'F6B9FC11B50FF84A%21s65efa4c5cf3f44f9a9c92f993b244006'],
+		])('accepts %s', (_label, value) => {
+			expect(issuesFor(workbookRLC, value)).toEqual({});
+		});
+
+		it.each([
+			['a path separator', 'F6B9FC11B50FF84A/children'],
+			['parent directory traversal', '../drives'],
+			['a trailing separator', 'F6B9FC11B50FF84A!'],
+			['a space', 'F6B9FC11 B50FF84A'],
+		])('rejects %s', (_label, value) => {
+			expect(issuesFor(workbookRLC, value)).toEqual({
+				workbook: ['Not a valid Workbook ID'],
+			});
+		});
+
+		it('reports an empty ID as missing, because the field is required', () => {
+			expect(issuesFor(workbookRLC, '')).toEqual({
+				workbook: ['Parameter "Workbook" is required.', 'Not a valid Workbook ID'],
+			});
+		});
+	});
+
+	describe('Sheet and Table', () => {
+		it('accepts a Sheet ID', () => {
+			expect(issuesFor(worksheetRLC, '{00000000-0001-0000-0000-000000000000}')).toEqual({});
+		});
+
+		it('accepts a Table ID', () => {
+			expect(issuesFor(tableRLC, '{21EAB2B0-DD1A-4E5B-9931-1C4D8A0D7A31}')).toEqual({});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The Workbook "By ID" field rejected a valid Microsoft Graph item ID with `Not a valid Workbook ID`. The field blocked the node, so no execution record was created and the request never reached Microsoft.

The mode pattern was `[a-zA-Z0-9]{2,}`, and the validator anchors a mode pattern with `^…$` (`packages/workflow/src/node-helpers.ts:1406`). A work or school account returns an alphanumeric ID, which passes. A personal account returns `<driveId>!<itemId>`, so the `!` separator failed the whole match.

This PR widens the pattern to `[a-zA-Z0-9\-_]{2,}((!|%21)[a-zA-Z0-9\-_]+)*`. It accepts both ID families and the `%21` encoded separator that the OneDrive web URL uses. Graph documents the ID only as an opaque string, so the class also allows `-` and `_` and rejects just the characters that would change the request path: a path separator, `..`, a space and a dangling separator. `!` is an RFC 3986 sub-delim, so Graph accepts it unencoded in a path and no transport change is needed. The PR also adds placeholder examples to the Workbook, Sheet and Table ID fields.

## How to test

You need a **personal** Microsoft account. A work or school account returns IDs without a `!`, so it cannot show the difference.

1. Put an `.xlsx` workbook in the root of your OneDrive.
2. Add a Microsoft OneDrive node. Set Resource to `Folder`, Operation to `Get Children`, and Folder ID to `root`. Run the node.
3. Copy the `id` of your workbook from the output.
4. Add a Microsoft Excel node with a credential for the same account. Set Resource to `Table` and Operation to `Append`.
5. Set the Workbook field to "By ID" and paste the id.
6. The field shows no error. Open the Sheet dropdown, and it lists the worksheets.

On `master`, step 5 shows `Not a valid Workbook ID` and the node cannot run.

The unit test covers the accepted and rejected ID shapes:

```bash
cd packages/nodes-base && pnpm test nodes/Microsoft/Excel/v2/test/actions/common.descriptions.test.ts
```

## Result

The Microsoft OneDrive node returns the workbook ID. The personal account ID has a `!` separator:

<img width="1307" height="190" alt="Screenshot 2026-09-11 at 16 24 49" src="https://github.com/user-attachments/assets/a7367780-d18f-42ac-a5f5-0fc6c085a965" />

The Excel node accepts that ID, and the Sheet list loads:

<img width="724" height="485" alt="Screenshot 2026-09-11 at 16 27 25" src="https://github.com/user-attachments/assets/fabfcc48-f2a2-4c55-810e-99954ef8263d" />
<img width="711" height="308" alt="Screenshot 2026-09-11 at 16 37 02" src="https://github.com/user-attachments/assets/a7c23667-65fd-4b47-82c8-464856254349" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-445

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
