### PR TITLE
fix(editor): Don't group digits in number inputs and stop emitting them as strings

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.test.ts
@@ -415,6 +415,41 @@ describe('components/N8nInputNumber', () => {
 		});
 	});
 
+	describe('grouping', () => {
+		it('should render values above 999 without a grouping separator', () => {
+			const wrapper = render(InputNumber, {
+				props: {
+					modelValue: 1433,
+				},
+			});
+			const input = wrapper.container.querySelector('input');
+			expect(input).toHaveValue('1433');
+		});
+
+		it('should keep a typed value ungrouped on blur', async () => {
+			const wrapper = render(InputNumber, {
+				props: {
+					defaultValue: 0,
+				},
+			});
+			const input = wrapper.container.querySelector('input');
+			expect(input).toBeTruthy();
+			if (!(input instanceof HTMLInputElement)) {
+				throw new Error('Expected input element');
+			}
+
+			await userEvent.clear(input);
+			await userEvent.type(input, '1433');
+			await userEvent.tab();
+
+			await waitFor(() => {
+				expect(input).toHaveValue('1433');
+				const emitted = wrapper.emitted('update:modelValue');
+				expect(emitted?.[emitted.length - 1]).toEqual([1433]);
+			});
+		});
+	});
+
 	describe('stepSnapping', () => {
 		it('should snap typed value to step on blur when stepSnapping is true', async () => {
 			const wrapper = render(InputNumber, {

--- a/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputNumber/InputNumber.vue
@@ -58,10 +58,16 @@ defineExpose<InputNumberExposed>({ focus, blur, select });
 // Map precision to formatOptions - uses Intl.NumberFormatOptions
 // When no precision is set, use maximumFractionDigits: 20 (the max allowed by Intl.NumberFormat)
 // to preserve full decimal precision and avoid default rounding behavior
+// Grouping separators are always disabled: values such as ports, timeouts or IDs have to
+// stay readable as plain digits (1433, not 1,433)
 const formatOptions = computed<Intl.NumberFormatOptions>(() =>
 	props.precision !== undefined
-		? { maximumFractionDigits: props.precision, minimumFractionDigits: props.precision }
-		: { maximumFractionDigits: 20 },
+		? {
+				maximumFractionDigits: props.precision,
+				minimumFractionDigits: props.precision,
+				useGrouping: false,
+			}
+		: { maximumFractionDigits: 20, useGrouping: false },
 );
 
 const rootProps = useForwardPropsEmits(

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -622,6 +622,36 @@ describe('ParameterInput.vue', () => {
 		});
 	});
 
+	test('should emit a number parameter as a number and not as text input', async () => {
+		const { container, emitted } = renderComponent({
+			props: {
+				path: 'port',
+				parameter: createTestNodeProperties({
+					displayName: 'Port',
+					name: 'port',
+					type: 'number',
+					default: 1433,
+				}),
+				modelValue: 1433,
+			},
+		});
+
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+
+		await userEvent.clear(input);
+		await userEvent.type(input, '1234');
+		await userEvent.tab();
+
+		await waitFor(() =>
+			expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 1234 })]),
+		);
+
+		// `textInput` would be forwarded as a value update by the credential form,
+		// turning the number into a string
+		expect(emitted('textInput')).toBeUndefined();
+	});
+
 	test('should not reset the value of a multi-select with loadOptionsMethod on load', async () => {
 		mockNodeTypesState.getNodeParameterOptions = vi.fn(async () => [
 			{ name: 'ID', value: 'id' },

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -1248,7 +1248,12 @@ function onJsonPasswordFieldChange(value: string) {
 
 function onUpdateTextInput(value: string | number) {
 	valueChanged(value);
-	onTextInputChange(typeof value === 'string' ? value : String(value));
+	// `textInput` carries the raw text so consumers can react to a typed expression.
+	// Numbers must not be stringified here: the credential form treats `textInput` as a value
+	// update, which would persist a numeric field as a string (e.g. port "1433" instead of 1433).
+	if (typeof value === 'string') {
+		onTextInputChange(value);
+	}
 }
 
 const onUpdateTextInputDebounced = debounce(onUpdateTextInput, { debounceTime: 200 });


### PR DESCRIPTION
## Summary

Typing `1433` into the Port field of the Microsoft SQL credentials shows it as `1,433`, and saving makes the node fail with `The "config.options.port" property must be of type number.`

Turns out there are two independent causes, and neither is specific to that node.

**1. The grouping separator**

`N8nInputNumber` builds the `formatOptions` for reka-ui's `NumberField` without `useGrouping: false`, and `Intl.NumberFormat` groups by default, so anything above 999 is rendered with a thousands separator. `el-input-number` never did that, so this looks like a leftover from the reka migration. It hits every number input in the editor, e.g. the two timeout fields right below Port render as `15,000`.

**2. The number is persisted as a string**

`ParameterInput.onUpdateTextInput` emits the value twice:

```ts
function onUpdateTextInput(value: string | number) {
	valueChanged(value);                                                  // `update`    -> 1433
	onTextInputChange(typeof value === 'string' ? value : String(value)); // `textInput` -> "1433"
}
```

In the NDV, `textInput` is only used to notice a typed expression (`ParameterInputFull.onTextInput`). The credential form instead binds both events to the same handler (`ParameterInputExpanded.vue`: `@text-input="valueChanged"` and `@update="valueChanged"`), and `textInput` fires last, so the stringified value wins and the credential is saved with `port: "1433"`. tedious then refuses the config. With this change only strings go through `textInput`, which is all that consumer ever needed.

Worth noting that master already hides half of this for the MSSQL node: #37870 added `toOptionalNumber()` to `nodes/Microsoft/Sql/GenericFunctions.ts`, which coerces `"1433"` back into a number. The credential is still stored with the wrong type though, and every other node that reads a numeric credential still gets a string.

## How to test

1. Create or open Microsoft SQL credentials. Port shows `1433`, not `1,433`, and Connect/Request Timeout show `15000`, not `15,000`.
2. Change the port, save, reopen. The value stays a plain number, and the saved credential holds a number rather than a string.
3. Connecting no longer throws `The "config.options.port" property must be of type number.`
4. Any `number` parameter in the NDV behaves the same, without a separator.

Tests added on both sides: two in `InputNumber.test.ts` for the formatting, one in `ParameterInput.test.ts` asserting a number parameter emits `update` with a number and does not emit `textInput` at all. All three fail before the change.

## Related Linear tickets, Github issues, and Community forum posts

fixes #38363

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

