### PR TITLE
fix(Remove Duplicates Node): Prevent node from getting stuck when reaching maximum history size

### DIFF
--- a/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/RemoveDuplicatesV2.node.ts
+++ b/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/RemoveDuplicatesV2.node.ts
@@ -89,11 +89,7 @@ export class RemoveDuplicatesV2 implements INodeType {
 						) as number;
 						const maxEntriesNum = Number(maxEntries);
 
-						const currentProcessedDataCount = await this.helpers.getProcessedDataCount(scope, {
-							mode: 'entries',
-							maxEntries,
-						});
-						if (currentProcessedDataCount + items.length > maxEntriesNum) {
+						if (items.length > maxEntriesNum) {
 							throw new NodeOperationError(
 								this.getNode(),
 								'The number of items to be processed exceeds the maximum history size. Please increase the history size or reduce the number of items to be processed.',
@@ -123,7 +119,7 @@ export class RemoveDuplicatesV2 implements INodeType {
 
 						if (maxEntriesNum > 0 && processedDataCount / maxEntriesNum > 0.5) {
 							this.addExecutionHints({
-								message: `Some duplicates may be not be removed since you're approaching the maximum history size (${maxEntriesNum} items). You can raise this limit using the ‘history size’ option.`,
+								message: `Some duplicates may not be removed since you're approaching the maximum history size (${maxEntriesNum} items). You can raise this limit using the ‘history size’ option.`,
 								location: 'outputPane',
 							});
 						}

--- a/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/RemoveDuplicatesV2.node.ts
+++ b/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/RemoveDuplicatesV2.node.ts
@@ -89,17 +89,17 @@ export class RemoveDuplicatesV2 implements INodeType {
 						) as number;
 						const maxEntriesNum = Number(maxEntries);
 
-						if (items.length > maxEntriesNum) {
+						const distinctKeys = Object.keys(itemMapping);
+						if (distinctKeys.length > maxEntriesNum) {
 							throw new NodeOperationError(
 								this.getNode(),
 								'The number of items to be processed exceeds the maximum history size. Please increase the history size or reduce the number of items to be processed.',
 							);
 						}
-						const itemsProcessed = await this.helpers.checkProcessedAndRecord(
-							Object.keys(itemMapping),
-							scope,
-							{ mode: 'entries', maxEntries },
-						);
+						const itemsProcessed = await this.helpers.checkProcessedAndRecord(distinctKeys, scope, {
+							mode: 'entries',
+							maxEntries,
+						});
 						const processedDataCount = await this.helpers.getProcessedDataCount(scope, {
 							mode: 'entries',
 							maxEntries,

--- a/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/test/RemoveDuplicates.test.ts
+++ b/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/test/RemoveDuplicates.test.ts
@@ -1,8 +1,13 @@
+import {
+	NodeOperationError,
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeTypeBaseDescription,
+} from 'n8n-workflow';
+import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
-import type { IExecuteFunctions, INodeExecutionData, INodeTypeBaseDescription } from 'n8n-workflow';
 
 import { RemoveDuplicatesV2 } from '../RemoveDuplicatesV2.node';
-import type { Mock } from 'vitest';
 
 describe('RemoveDuplicatesV2', () => {
 	let node: RemoveDuplicatesV2;
@@ -100,6 +105,59 @@ describe('RemoveDuplicatesV2', () => {
 		expect(result[1]).toHaveLength(1);
 		expect(result[0][0].json).toEqual({ id: 1, name: 'John' });
 		expect(result[0][1].json).toEqual({ id: 3, name: 'Doe' });
+	});
+
+	it('should continue processing when total processed data count reaches history size', async () => {
+		const items: INodeExecutionData[] = [
+			{ json: { id: 101, name: 'Item 1' } },
+			{ json: { id: 102, name: 'Item 2' } },
+		];
+
+		(executeFunctions.getInputData as Mock).mockReturnValue(items);
+		(executeFunctions.getNodeParameter as Mock).mockImplementation(
+			(paramName: string, itemIndex: number) => {
+				if (paramName === 'operation') return 'removeItemsSeenInPreviousExecutions';
+				if (paramName === 'logic') return 'removeItemsWithAlreadySeenKeyValues';
+				if (paramName === 'dedupeValue' && itemIndex === 0) return 101;
+				if (paramName === 'dedupeValue' && itemIndex === 1) return 102;
+				if (paramName === 'options.scope') return 'node';
+				if (paramName === 'options.historySize') return 10;
+			},
+		);
+		// Simulate history already reaching capacity (10 items stored)
+		executeFunctions.helpers.getProcessedDataCount = vi.fn().mockReturnValue(10);
+		(executeFunctions.helpers.checkProcessedAndRecord as Mock).mockReturnValue({
+			new: [101, 102],
+			processed: [],
+		});
+
+		const result = await node.execute.call(executeFunctions);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toHaveLength(2);
+		expect(result[1]).toHaveLength(0);
+		expect(result[0][0].json).toEqual({ id: 101, name: 'Item 1' });
+		expect(result[0][1].json).toEqual({ id: 102, name: 'Item 2' });
+	});
+
+	it('should throw NodeOperationError if input batch size exceeds history size', async () => {
+		const items: INodeExecutionData[] = [
+			{ json: { id: 1 } },
+			{ json: { id: 2 } },
+			{ json: { id: 3 } },
+		];
+
+		(executeFunctions.getInputData as Mock).mockReturnValue(items);
+		(executeFunctions.getNodeParameter as Mock).mockImplementation((paramName: string) => {
+			if (paramName === 'operation') return 'removeItemsSeenInPreviousExecutions';
+			if (paramName === 'logic') return 'removeItemsWithAlreadySeenKeyValues';
+			if (paramName === 'options.scope') return 'node';
+			if (paramName === 'options.historySize') return 2;
+		});
+
+		await expect(node.execute.call(executeFunctions)).rejects.toThrow(NodeOperationError);
+		await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+			'The number of items to be processed exceeds the maximum history size. Please increase the history size or reduce the number of items to be processed.',
+		);
 	});
 
 	it('should clean database when managing key values', async () => {

--- a/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/test/RemoveDuplicates.test.ts
+++ b/packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/test/RemoveDuplicates.test.ts
@@ -139,7 +139,7 @@ describe('RemoveDuplicatesV2', () => {
 		expect(result[0][1].json).toEqual({ id: 102, name: 'Item 2' });
 	});
 
-	it('should throw NodeOperationError if input batch size exceeds history size', async () => {
+	it('should throw NodeOperationError if distinct dedupe keys in input exceed history size', async () => {
 		const items: INodeExecutionData[] = [
 			{ json: { id: 1 } },
 			{ json: { id: 2 } },
@@ -147,16 +147,54 @@ describe('RemoveDuplicatesV2', () => {
 		];
 
 		(executeFunctions.getInputData as Mock).mockReturnValue(items);
-		(executeFunctions.getNodeParameter as Mock).mockImplementation((paramName: string) => {
-			if (paramName === 'operation') return 'removeItemsSeenInPreviousExecutions';
-			if (paramName === 'logic') return 'removeItemsWithAlreadySeenKeyValues';
-			if (paramName === 'options.scope') return 'node';
-			if (paramName === 'options.historySize') return 2;
-		});
+		(executeFunctions.getNodeParameter as Mock).mockImplementation(
+			(paramName: string, itemIndex: number) => {
+				if (paramName === 'operation') return 'removeItemsSeenInPreviousExecutions';
+				if (paramName === 'logic') return 'removeItemsWithAlreadySeenKeyValues';
+				if (paramName === 'dedupeValue') return items[itemIndex].json.id;
+				if (paramName === 'options.scope') return 'node';
+				if (paramName === 'options.historySize') return 2;
+			},
+		);
 
 		await expect(node.execute.call(executeFunctions)).rejects.toThrow(NodeOperationError);
 		await expect(node.execute.call(executeFunctions)).rejects.toThrow(
 			'The number of items to be processed exceeds the maximum history size. Please increase the history size or reduce the number of items to be processed.',
+		);
+	});
+
+	it('should process batch when total items exceed history size but distinct dedupe keys do not', async () => {
+		const items: INodeExecutionData[] = [
+			{ json: { id: 1, type: 'A' } },
+			{ json: { id: 2, type: 'A' } },
+			{ json: { id: 3, type: 'B' } },
+			{ json: { id: 4, type: 'B' } },
+		];
+
+		(executeFunctions.getInputData as Mock).mockReturnValue(items);
+		(executeFunctions.getNodeParameter as Mock).mockImplementation(
+			(paramName: string, itemIndex: number) => {
+				if (paramName === 'operation') return 'removeItemsSeenInPreviousExecutions';
+				if (paramName === 'logic') return 'removeItemsWithAlreadySeenKeyValues';
+				if (paramName === 'dedupeValue') return items[itemIndex].json.type;
+				if (paramName === 'options.scope') return 'node';
+				if (paramName === 'options.historySize') return 2;
+			},
+		);
+		executeFunctions.helpers.getProcessedDataCount = vi.fn().mockReturnValue(2);
+		(executeFunctions.helpers.checkProcessedAndRecord as Mock).mockReturnValue({
+			new: ['A', 'B'],
+			processed: [],
+		});
+
+		const result = await node.execute.call(executeFunctions);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toHaveLength(4);
+		expect(result[1]).toHaveLength(0);
+		expect(executeFunctions.helpers.checkProcessedAndRecord).toHaveBeenCalledWith(
+			['A', 'B'],
+			'node',
+			{ mode: 'entries', maxEntries: 2 },
 		);
 	});
 


### PR DESCRIPTION
## Summary

In the **Remove Duplicates** node (`packages/nodes-base/nodes/Transform/RemoveDuplicates/v2/RemoveDuplicatesV2.node.ts`) with operation **Remove Items Processed in Previous Executions** (`removeItemsSeenInPreviousExecutions`) and logic **removeItemsWithAlreadySeenKeyValues**:

Previously, the node checked whether `currentProcessedDataCount + items.length > maxEntriesNum` before execution, throwing:
> *"The number of items to be processed exceeds the maximum history size. Please increase the history size or reduce the number of items to be processed."*

Because `currentProcessedDataCount` is the cumulative count of historical records already stored from previous executions, any node reaching its configured `historySize` (default 10,000, or user-configured e.g. 10) permanently crashed on every subsequent execution, even when processing a single item.

### Root Cause & Fix
1. The underlying deduplication engine (`DeduplicationHelper` in `packages/cli/src/deduplication/deduplication-helper.ts`) is designed as a sliding-window FIFO buffer that evicts the oldest items via `splice(0, length - maxEntries)` when capacity is exceeded.
2. The node's execution hints explicitly notify the user about this FIFO sliding-window behavior:
   > *"Some duplicates may not be removed since you're approaching the maximum history size..."*
3. The pre-check erroneously treated `historySize` as a lifetime item cap for the node rather than validating incoming batch keys against the history capacity.
4. Furthermore, as addressed per `NODE-5945`, incoming items in a batch frequently contain duplicate keys. The deduplication helper persists the distinct keys (`Object.keys(itemMapping)`), not the raw item count. Therefore, the batch guard compares `distinctKeys.length > maxEntriesNum`, ensuring batches with more rows than history size but fewer distinct dedupe keys process smoothly through the sliding-window helper.
5. This PR:
   - Replaces the cumulative count check with `if (distinctKeys.length > maxEntriesNum)`, validating that the distinct keys to be recorded in a single batch do not exceed the history capacity.
   - Eliminates the redundant `getProcessedDataCount` database query call before processing.
   - Corrects the typo in the execution hint (`"may be not be removed"` -> `"may not be removed"`).
   - Adds unit regression tests covering executions when history capacity is full, when distinct keys exceed history size, and when raw item count exceeds history size but distinct keys do not.

## How to test

1. Run the unit test suite:
   ```bash
   pnpm --filter n8n-nodes-base test nodes/Transform/RemoveDuplicates/v2/test/RemoveDuplicates.test.ts
   ```
2. Verify with workflow:
   - Create a workflow: Manual Trigger -> Code node generating 4 items -> Remove Duplicates node with `historySize: 10` and Value to Dedupe On set to `{{ $json.id }}`.
   - Execute the workflow 3+ times.
   - **Before:** Fails on execution 3 with `NodeOperationError: The number of items to be processed exceeds the maximum history size.`
   - **After:** Executes smoothly across runs without error, maintaining a rolling history buffer of up to 10 items.
3. Verify batch with repeated keys:
   - Create a workflow with 20 items sharing 2 distinct keys and `historySize: 5`.
   - Executes cleanly and tracks the 2 keys.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #38475
- https://linear.app/n8n/issue/GHC-9449
- https://linear.app/n8n/issue/NODE-5945

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
