### PR TITLE
ci: Shard E2E performance tests (no-changelog)

### DIFF
--- a/.github/workflows/test-e2e-performance-reusable.yml
+++ b/.github/workflows/test-e2e-performance-reusable.yml
@@ -18,6 +18,8 @@ jobs:
     with:
       test-mode: docker-artifact
       test-command: pnpm --filter=n8n-playwright test:performance
+      workers: '1'
+      pre-generated-matrix: '[{"shard":1,"images":""},{"shard":2,"images":""}]'
       currents-project-id: 'O9BJaN'
       artifact-prefix: performance
     secrets: inherit
@@ -43,13 +45,13 @@ jobs:
         with:
           pattern: performance-shard-*
           path: performance-artifacts
-          merge-multiple: true
+          merge-multiple: false
 
       - name: Run canvas perf sentinels
         run: |
-          RESULTS_PATH=$(find performance-artifacts -name 'test-results.json' -print -quit)
-          if [ -z "$RESULTS_PATH" ]; then
+          mapfile -t RESULTS_PATHS < <(find performance-artifacts -name 'test-results.json' -print)
+          if [ "${#RESULTS_PATHS[@]}" -eq 0 ]; then
             echo "::warning::No test-results.json found in performance artifacts — sentinel skipped."
             exit 0
           fi
-          node packages/testing/playwright/scripts/canvas-perf-sentinels.mjs "$RESULTS_PATH"
+          node packages/testing/playwright/scripts/canvas-perf-sentinels.mjs "${RESULTS_PATHS[@]}"

--- a/packages/testing/playwright/scripts/canvas-perf-sentinels.mjs
+++ b/packages/testing/playwright/scripts/canvas-perf-sentinels.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // Catastrophic-regression gate for canvas performance e2e benchmarks.
 //
-// Reads the Playwright JSON reporter output (test-results.json) and checks each
-// canvas-* metric against a small, fixed set of thresholds defined here. Exits
+// Reads one or more Playwright JSON reporter outputs (test-results.json) and
+// checks each canvas-* metric against a small, fixed set of thresholds. Exits
 // non-zero on any breach so the nightly job fails loudly. Trend / soft
 // regressions are intentionally NOT gated here — those flow through the QA
 // metrics webhook + PR comment, which tolerates the 15-30% wall-clock noise
@@ -53,9 +53,9 @@ const SENTINELS = [
 	},
 ];
 
-function findResultsPath() {
-	const explicit = process.argv[2];
-	if (explicit) return resolve(explicit);
+function findResultsPaths() {
+	const explicit = process.argv.slice(2);
+	if (explicit.length > 0) return explicit.map((path) => resolve(path));
 	const candidates = [
 		'test-results.json',
 		'packages/testing/playwright/test-results.json',
@@ -63,10 +63,10 @@ function findResultsPath() {
 	];
 	for (const candidate of candidates) {
 		const path = resolve(candidate);
-		if (existsSync(path)) return path;
+		if (existsSync(path)) return [path];
 	}
 	throw new Error(
-		`test-results.json not found. Looked in: ${candidates.join(', ')}. Pass an explicit path as argv[1].`,
+		`test-results.json not found. Looked in: ${candidates.join(', ')}. Pass one or more explicit paths.`,
 	);
 }
 
@@ -157,10 +157,13 @@ function emitSummary(lines) {
 }
 
 function main() {
-	const path = findResultsPath();
-	const raw = readFileSync(path, 'utf8');
-	const results = JSON.parse(raw);
-	const metrics = extractMetrics(results);
+	const paths = findResultsPaths();
+	const metrics = new Map();
+	for (const path of paths) {
+		const raw = readFileSync(path, 'utf8');
+		const results = JSON.parse(raw);
+		for (const [name, value] of extractMetrics(results)) metrics.set(name, value);
+	}
 	const ranTiers = tiersThatRan(metrics);
 
 	const breaches = [];


### PR DESCRIPTION
## Summary

Run the E2E performance suite across two CI shards.

Use one Playwright worker on each shard to avoid benchmark contention. Preserve each shard result artifact and aggregate all results before the canvas sentinel checks run.

## How to test

- Run `actionlint .github/workflows/test-e2e-performance-reusable.yml`.
- Run `pnpm lint` in `packages/testing/playwright`.
- Run `pnpm typecheck` in `packages/testing/playwright`.
- List both Playwright shards with `--project=performance --workers=1 --shard=1/2` and `--shard=2/2`.
- Run the canvas sentinel script with multiple result files from a completed nightly performance run.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

