### PR TITLE
fix(Freshservice Node): Prevent a crash when the request fails before the API responds

### DIFF
--- a/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
@@ -13,10 +13,24 @@ import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 import type {
 	AddressFixedCollection,
 	FreshserviceCredentials,
+	FreshserviceErrorResponse,
 	LoadedResource,
 	LoadedUser,
 	RolesParameter,
 } from './types';
+
+/**
+ * Read the Freshservice error payload. The API does not always send one, and a
+ * transport-level failure (DNS, TLS, timeout) has no payload at all.
+ */
+function getFreshserviceError(error: unknown): FreshserviceErrorResponse | undefined {
+	if (typeof error !== 'object' || error === null) return undefined;
+
+	const body = (error as { error?: unknown }).error;
+	if (typeof body !== 'object' || body === null) return undefined;
+
+	return body as FreshserviceErrorResponse;
+}
 
 export async function freshserviceApiRequest(
 	this: IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions,
@@ -50,12 +64,15 @@ export async function freshserviceApiRequest(
 	try {
 		return await this.helpers.request(options);
 	} catch (error) {
-		if (error.error.description === 'Validation failed') {
-			const numberOfErrors = error.error.errors.length;
+		const freshserviceError = getFreshserviceError(error);
+		const validationErrors = freshserviceError?.errors;
+
+		if (freshserviceError?.description === 'Validation failed' && Array.isArray(validationErrors)) {
+			const numberOfErrors = validationErrors.length;
 			const message = 'Please check your parameters';
 
 			if (numberOfErrors === 1) {
-				const [validationError] = error.error.errors;
+				const [validationError] = validationErrors;
 				throw new NodeApiError(this.getNode(), error as JsonObject, {
 					message,
 					description: `For ${validationError.field}: ${validationError.message}`,

--- a/packages/nodes-base/nodes/Freshservice/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Freshservice/__tests__/GenericFunctions.test.ts
@@ -1,0 +1,64 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { freshserviceApiRequest } from '../GenericFunctions';
+
+describe('Freshservice GenericFunctions', () => {
+	const node: INode = {
+		id: 'ac1f4e1a-9b1c-4a2f-9f0a-2c2f1a1b9d3e',
+		name: 'Freshservice',
+		type: 'n8n-nodes-base.freshservice',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+
+	let mockExecuteFunctions: ReturnType<typeof mockDeep<IExecuteFunctions>>;
+
+	beforeEach(() => {
+		mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+		mockExecuteFunctions.getNode.mockReturnValue(node);
+		mockExecuteFunctions.getCredentials.mockResolvedValue({
+			apiKey: 'test-api-key',
+			domain: 'test-domain',
+		});
+	});
+
+	describe('freshserviceApiRequest', () => {
+		it('reports a validation error with the field and the message', async () => {
+			mockExecuteFunctions.helpers.request.mockRejectedValue({
+				error: {
+					description: 'Validation failed',
+					errors: [{ field: 'email', message: 'It is not a valid email' }],
+				},
+			});
+
+			await expect(
+				freshserviceApiRequest.call(mockExecuteFunctions, 'POST', '/tickets'),
+			).rejects.toMatchObject({
+				message: 'Please check your parameters',
+				description: 'For email: It is not a valid email',
+			});
+		});
+
+		it('throws a NodeApiError when the error has no payload', async () => {
+			mockExecuteFunctions.helpers.request.mockRejectedValue(new Error('socket hang up'));
+
+			const call = freshserviceApiRequest.call(mockExecuteFunctions, 'POST', '/tickets');
+
+			await expect(call).rejects.toBeInstanceOf(NodeApiError);
+			await expect(call).rejects.not.toBeInstanceOf(TypeError);
+		});
+
+		it('throws a NodeApiError when the validation payload has no errors array', async () => {
+			mockExecuteFunctions.helpers.request.mockRejectedValue({
+				error: { description: 'Validation failed' },
+			});
+
+			await expect(
+				freshserviceApiRequest.call(mockExecuteFunctions, 'POST', '/tickets'),
+			).rejects.toBeInstanceOf(NodeApiError);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Freshservice/types.ts
+++ b/packages/nodes-base/nodes/Freshservice/types.ts
@@ -30,3 +30,13 @@ export type AddressFixedCollection = {
 		addressFields: object;
 	};
 };
+
+export type FreshserviceValidationError = {
+	field?: string;
+	message?: string;
+};
+
+export type FreshserviceErrorResponse = {
+	description?: string;
+	errors?: FreshserviceValidationError[];
+};


### PR DESCRIPTION
## Summary

The Freshservice error handler read `error.error.description` with no check that the payload is there. The Freshservice API does not always send an error body, and a transport-level failure (DNS, TLS, timeout) has no body at all. In that case the handler itself threw `TypeError: Cannot read properties of undefined (reading 'description')`, which replaced the real cause and stopped the workflow.

The handler now reads the payload through a small type guard and also checks that `errors` is an array before it counts the entries. A payload that is present keeps the same messages as before, so the validation-error output does not change.

Files:
- `packages/nodes-base/nodes/Freshservice/GenericFunctions.ts` — read the error payload safely
- `packages/nodes-base/nodes/Freshservice/types.ts` — types for the error payload
- `packages/nodes-base/nodes/Freshservice/__tests__/GenericFunctions.test.ts` — new regression tests

## How to test

Automated:

```bash
cd packages/nodes-base
pnpm test nodes/Freshservice/__tests__/GenericFunctions.test.ts
```

To see the tests fail without the fix, check out this branch, revert `GenericFunctions.ts` and `types.ts` to `master`, keep the test file, and run the command again. Two of the three tests fail with `TypeError: Cannot read properties of undefined`.

Manual:
1. Add a Freshservice node, set Resource to Ticket and Operation to Create.
2. Point the credential domain at a host that does not answer (for example an unreachable subdomain), so the request fails before the API can send a body.
3. Execute the node. Before: `TypeError: Cannot read properties of undefined (reading 'description')`. After: the transport error is reported as a node API error.

## Related Linear tickets, Github issues, and Community forum posts

fixes #18296

## Review / Merge checklist

- [x] I have seen this code and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

**How far the testing goes, stated plainly:** unit tests only. I ran the new tests on this branch, then reverted the source change and ran them again to see them fail for the right reason. I have **not** exercised this on a running n8n instance. The "How to test" steps above are written for a reviewer to follow; they are not a record of a run I performed.

AI tools did a meaningful part of this work (Claude Code); I reviewed every change and ran the tests.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk
