### PR TITLE
fix(Snowflake Node): Send failed statements to the error output

### DIFF
--- a/packages/nodes-base/nodes/Snowflake/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Snowflake/GenericFunctions.ts
@@ -212,3 +212,13 @@ export async function prepareQueryResults(
 	}
 	return returnData;
 }
+
+/**
+ * Build the item that "Continue (using error output)" and "Continue" send on,
+ * so a failed statement reports its cause instead of stopping the workflow.
+ */
+export function toErrorItem(error: unknown, itemIndex: number): INodeExecutionData {
+	const message = error instanceof Error ? error.message : String(error);
+
+	return { json: { error: message }, pairedItem: { item: itemIndex } };
+}

--- a/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
+++ b/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
@@ -18,6 +18,7 @@ import {
 	execute,
 	getConnectionOptions,
 	prepareQueryResults,
+	toErrorItem,
 	type SnowflakeCredential,
 } from './GenericFunctions';
 
@@ -286,38 +287,43 @@ export class Snowflake implements INodeType {
 				// ----------------------------------
 
 				for (let i = 0; i < items.length; i++) {
-					let query = this.getNodeParameter('query', i) as string;
+					try {
+						let query = this.getNodeParameter('query', i) as string;
 
-					for (const resolvable of getResolvables(query)) {
-						query = query.replace(resolvable, this.evaluateExpression(resolvable, i) as string);
-					}
-
-					const options = this.getNodeParameter('options', i, {});
-					const rawReplacement = options.queryReplacement;
-					let binds: snowflake.Bind[] = [];
-
-					if (rawReplacement !== undefined && rawReplacement !== '') {
-						if (typeof rawReplacement === 'string') {
-							binds = rawReplacement.split(',').map((entry) => entry.trim());
-						} else if (Array.isArray(rawReplacement)) {
-							binds = rawReplacement as snowflake.Bind[];
-						} else {
-							throw new NodeOperationError(
-								this.getNode(),
-								'Query Parameters must be a string of comma-separated values, or an array of values',
-								{ itemIndex: i },
-							);
+						for (const resolvable of getResolvables(query)) {
+							query = query.replace(resolvable, this.evaluateExpression(resolvable, i) as string);
 						}
-					}
 
-					const responseData = await execute(connection, query, binds, this.getNode());
-					const executionData = await prepareQueryResults.call(
-						this,
-						responseData as IDataObject[] | undefined,
-						i,
-						nodeVersion,
-					);
-					returnData = returnData.concat(executionData);
+						const options = this.getNodeParameter('options', i, {});
+						const rawReplacement = options.queryReplacement;
+						let binds: snowflake.Bind[] = [];
+
+						if (rawReplacement !== undefined && rawReplacement !== '') {
+							if (typeof rawReplacement === 'string') {
+								binds = rawReplacement.split(',').map((entry) => entry.trim());
+							} else if (Array.isArray(rawReplacement)) {
+								binds = rawReplacement as snowflake.Bind[];
+							} else {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Query Parameters must be a string of comma-separated values, or an array of values',
+									{ itemIndex: i },
+								);
+							}
+						}
+
+						const responseData = await execute(connection, query, binds, this.getNode());
+						const executionData = await prepareQueryResults.call(
+							this,
+							responseData as IDataObject[] | undefined,
+							i,
+							nodeVersion,
+						);
+						returnData = returnData.concat(executionData);
+					} catch (error) {
+						if (!this.continueOnFail()) throw error;
+						returnData.push(toErrorItem(error, i));
+					}
 				}
 			}
 
@@ -334,14 +340,21 @@ export class Snowflake implements INodeType {
 				const query = `INSERT INTO ${quotedTable} (${quotedColumns.join(',')}) VALUES (${columns.map(() => '?').join(',')})`;
 				const data = this.helpers.copyInputItems(items, columns);
 				const binds = data.map((element) => [...Object.values(element)]);
-				await execute(connection, query, binds as snowflake.Binds, this.getNode());
-				data.forEach((d, i) => {
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(d),
-						{ itemData: { item: i } },
-					);
-					returnData = returnData.concat(executionData);
-				});
+
+				try {
+					await execute(connection, query, binds as snowflake.Binds, this.getNode());
+					data.forEach((d, i) => {
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(d),
+							{ itemData: { item: i } },
+						);
+						returnData = returnData.concat(executionData);
+					});
+				} catch (error) {
+					if (!this.continueOnFail()) throw error;
+					// One statement inserts every item, so a failure applies to all of them.
+					returnData = returnData.concat(data.map((_d, i) => toErrorItem(error, i)));
+				}
 			}
 
 			if (operation === 'update') {
@@ -373,15 +386,18 @@ export class Snowflake implements INodeType {
 					return rowBinds;
 				});
 				for (let i = 0; i < binds.length; i++) {
-					await execute(connection, query, binds[i] as snowflake.Binds, this.getNode());
+					try {
+						await execute(connection, query, binds[i] as snowflake.Binds, this.getNode());
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(data[i]),
+							{ itemData: { item: i } },
+						);
+						returnData = returnData.concat(executionData);
+					} catch (error) {
+						if (!this.continueOnFail()) throw error;
+						returnData.push(toErrorItem(error, i));
+					}
 				}
-				data.forEach((d, i) => {
-					const executionData = this.helpers.constructExecutionMetaData(
-						this.helpers.returnJsonArray(d),
-						{ itemData: { item: i } },
-					);
-					returnData = returnData.concat(executionData);
-				});
 			}
 
 			return [returnData];

--- a/packages/nodes-base/nodes/Snowflake/__tests__/continueOnFail.test.ts
+++ b/packages/nodes-base/nodes/Snowflake/__tests__/continueOnFail.test.ts
@@ -1,0 +1,138 @@
+import type { IDataObject, IExecuteFunctions, INode, INodeExecutionData } from 'n8n-workflow';
+import snowflake from 'snowflake-sdk';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { Snowflake } from '../Snowflake.node';
+
+const mockExecute = vi.fn();
+const mockConnect = vi.fn();
+const mockDestroy = vi.fn();
+const mockConnection = { connect: mockConnect, execute: mockExecute, destroy: mockDestroy };
+
+const snowflakeCredentials = {
+	authentication: 'password',
+	account: 'test-account',
+	database: 'TEST_DB',
+	schema: 'PUBLIC',
+	warehouse: 'WH',
+	role: 'SYSADMIN',
+	clientSessionKeepAlive: false,
+	username: 'user',
+	password: 'pass',
+};
+
+const queryError = new Error('SQL compilation error: Object THIS does not exist');
+
+type CompleteCallback = (error: Error | null, stmt: undefined, rows: unknown[] | undefined) => void;
+
+beforeEach(() => {
+	vi.spyOn(snowflake, 'configure').mockImplementation(() => ({}) as never);
+	vi.spyOn(snowflake, 'createConnection').mockReturnValue(mockConnection as never);
+	mockConnect.mockImplementation((callback: (err: null) => void) => callback(null));
+	mockDestroy.mockImplementation((callback: (err: null) => void) => callback(null));
+});
+
+afterEach(() => vi.clearAllMocks());
+
+/** An IExecuteFunctions whose data helpers behave like the real ones. */
+function mockExecuteFunctions(items: INodeExecutionData[]) {
+	const executeFns = mockDeep<IExecuteFunctions>();
+
+	executeFns.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+	executeFns.getInputData.mockReturnValue(items);
+	executeFns.getCredentials.mockResolvedValue(snowflakeCredentials);
+	executeFns.helpers.copyInputItems.mockImplementation((inputItems, columns) =>
+		inputItems.map((item) =>
+			Object.fromEntries(columns.map((column) => [column, item.json[column]])),
+		),
+	);
+	executeFns.helpers.returnJsonArray.mockImplementation((data) =>
+		(Array.isArray(data) ? data : [data]).map((json) => ({ json: json as IDataObject })),
+	);
+	executeFns.helpers.constructExecutionMetaData.mockImplementation((data, { itemData }) =>
+		data.map((entry) => ({ ...entry, pairedItem: itemData })),
+	);
+
+	return executeFns;
+}
+
+describe('Snowflake, on error "Continue"', () => {
+	it('sends a failed query on as an error item instead of stopping the workflow', async () => {
+		mockExecute.mockImplementation(
+			({ sqlText, complete }: { sqlText: string } & { complete: CompleteCallback }) =>
+				sqlText.startsWith('ALTER SESSION')
+					? complete(null, undefined, [])
+					: complete(queryError, undefined, undefined),
+		);
+
+		const executeFns = mockExecuteFunctions([{ json: {} }]);
+		executeFns.continueOnFail.mockReturnValue(true);
+		executeFns.getNodeParameter.mockImplementation((name, _itemIndex, fallback) => {
+			if (name === 'authentication') return 'credentials';
+			if (name === 'operation') return 'executeQuery';
+			if (name === 'query') return 'SELECT * FROM THIS WILL ERROR';
+			return fallback;
+		});
+
+		const result = await new Snowflake().execute.call(executeFns);
+
+		expect(result).toEqual([[{ json: { error: queryError.message }, pairedItem: { item: 0 } }]]);
+		expect(mockDestroy).toHaveBeenCalled();
+	});
+
+	it('still throws when the node does not continue on fail', async () => {
+		mockExecute.mockImplementation(
+			({ sqlText, complete }: { sqlText: string } & { complete: CompleteCallback }) =>
+				sqlText.startsWith('ALTER SESSION')
+					? complete(null, undefined, [])
+					: complete(queryError, undefined, undefined),
+		);
+
+		const executeFns = mockExecuteFunctions([{ json: {} }]);
+		executeFns.continueOnFail.mockReturnValue(false);
+		executeFns.getNodeParameter.mockImplementation((name, _itemIndex, fallback) => {
+			if (name === 'authentication') return 'credentials';
+			if (name === 'operation') return 'executeQuery';
+			if (name === 'query') return 'SELECT * FROM THIS WILL ERROR';
+			return fallback;
+		});
+
+		await expect(new Snowflake().execute.call(executeFns)).rejects.toThrow(queryError.message);
+	});
+
+	it('keeps the rows that were updated and marks only the row that failed', async () => {
+		let updateStatements = 0;
+		mockExecute.mockImplementation(
+			({ sqlText, complete }: { sqlText: string } & { complete: CompleteCallback }) => {
+				if (sqlText.startsWith('ALTER SESSION')) return complete(null, undefined, []);
+				updateStatements += 1;
+				return updateStatements === 1
+					? complete(null, undefined, [])
+					: complete(queryError, undefined, undefined);
+			},
+		);
+
+		const executeFns = mockExecuteFunctions([
+			{ json: { id: 1, name: 'first' } },
+			{ json: { id: 2, name: 'second' } },
+		]);
+		executeFns.continueOnFail.mockReturnValue(true);
+		executeFns.getNodeParameter.mockImplementation((name, _itemIndex, fallback) => {
+			if (name === 'authentication') return 'credentials';
+			if (name === 'operation') return 'update';
+			if (name === 'table') return 'users';
+			if (name === 'updateKey') return 'id';
+			if (name === 'columns') return 'name';
+			return fallback;
+		});
+
+		const result = await new Snowflake().execute.call(executeFns);
+
+		expect(result).toEqual([
+			[
+				{ json: { id: 1, name: 'first' }, pairedItem: { item: 0 } },
+				{ json: { error: queryError.message }, pairedItem: { item: 1 } },
+			],
+		]);
+	});
+});


### PR DESCRIPTION
Fixes #36855

## Summary

The Snowflake node ran every statement with no `try`/`catch` around it, and it never read `continueOnFail()`. A failed query therefore stopped the workflow, whatever the "On Error" setting was: "Continue (using error output)" never sent anything to the error output, and "Continue" never produced an item that names the cause.

Each statement now reports its failure as an item (`{ json: { error: <message> } }` with the paired item), which is the shape the execution engine routes to the error output. When "On Error" is "Stop workflow", the node throws exactly as before.

Per operation:
- **Execute Query** — one item per input item, so a failed query marks only that item.
- **Insert** — one statement writes every item, so a failure marks all of them.
- **Update** — one statement per row. Rows that were written keep their normal output, and only the row that failed is marked. Before this change a failure in the middle of the loop dropped the output of the rows that had already been written.

Files:
- `packages/nodes-base/nodes/Snowflake/Snowflake.node.ts` — honour `continueOnFail()` in all three operations
- `packages/nodes-base/nodes/Snowflake/GenericFunctions.ts` — `toErrorItem()` helper
- `packages/nodes-base/nodes/Snowflake/__tests__/continueOnFail.test.ts` — new regression tests

## How to test

Automated:

```bash
cd packages/nodes-base
pnpm test nodes/Snowflake
```

To see the new tests fail without the fix, check out this branch, revert `Snowflake.node.ts` and `GenericFunctions.ts` to `master`, keep the test file, and run the command again. Two of the three new tests fail with `Error: SQL compilation error: Object THIS does not exist` thrown out of the node.

Manual (the reporter's steps):
1. Add a Snowflake node with working credentials, Operation = Execute Query.
2. Query: `SELECT * FROM THIS WILL ERROR;`
3. Set On Error to "Continue (using error output)".
4. Execute. Before: the workflow stops with the Snowflake error. After: the item goes to the error output with the Snowflake message in `error`.
5. Repeat with On Error = "Continue". The node now returns an item that holds the message.

## Related Linear tickets, Github issues, and Community forum posts

fixes #36855

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

AI tools did a meaningful part of this work (Claude Code); I reviewed and ran every change.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


