### PR TITLE
fix(core): Check community package updates against the configured registry

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
@@ -203,6 +203,8 @@ describe('CommunityPackagesLifecycleService', () => {
 
 		it('should run npm outdated when unverifiedEnabled is true', async () => {
 			communityPackagesConfig.unverifiedEnabled = true;
+			communityPackagesConfig.registry = 'https://registry.npmjs.org';
+			communityPackagesConfig.authToken = '';
 			communityPackagesService.getAllInstalledPackages.mockResolvedValue([installedPackage]);
 			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([
 				{ ...installedPackage, updateAvailable: '2.0.0' },
@@ -213,6 +215,25 @@ describe('CommunityPackagesLifecycleService', () => {
 			expect(mockedExecuteNpmCommand).toHaveBeenCalledWith(['outdated', '--json'], {
 				doNotHandleError: true,
 				cwd: '/tmp/n8n-nodes-download',
+				registry: 'https://registry.npmjs.org',
+				authToken: '',
+			});
+		});
+
+		it('should run npm outdated against the configured custom registry', async () => {
+			communityPackagesConfig.unverifiedEnabled = true;
+			communityPackagesConfig.registry = 'https://internal.example.com/api/npm/n8n';
+			communityPackagesConfig.authToken = 'secret-token';
+			communityPackagesService.getAllInstalledPackages.mockResolvedValue([installedPackage]);
+			communityPackagesService.matchPackagesWithUpdates.mockReturnValue([installedPackage]);
+
+			await lifecycle.listInstalledPackages();
+
+			expect(mockedExecuteNpmCommand).toHaveBeenCalledWith(['outdated', '--json'], {
+				doNotHandleError: true,
+				cwd: '/tmp/n8n-nodes-download',
+				registry: 'https://internal.example.com/api/npm/n8n',
+				authToken: 'secret-token',
 			});
 		});
 

--- a/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts
@@ -77,6 +77,10 @@ export class CommunityPackagesLifecycleService {
 				await executeNpmCommand(['outdated', '--json'], {
 					doNotHandleError: true,
 					cwd: this.instanceSettings.nodesDownloadDir,
+					// Install and pack resolve against the configured registry; this check must too,
+					// or an instance with no route to the public registry waits for a reply forever.
+					registry: this.communityPackagesConfig.registry,
+					authToken: this.communityPackagesConfig.authToken,
 				});
 			} catch (error) {
 				if (isNpmExecErrorWithStdout(error) && error.code === 1) {


### PR DESCRIPTION
## Summary

`GET /community-packages` shells out to `npm outdated --json` to find available updates. That call carried no `--registry` and no auth token, while `install` and `pack` on the same instance pass both from `N8N_COMMUNITY_PACKAGES_REGISTRY` / `N8N_COMMUNITY_PACKAGES_AUTH_TOKEN`.

On an instance that reaches only a private registry, `npm outdated` therefore resolved against npm's ambient default. The request had no route, so it waited instead of failing, the call repeated about once a minute, and the reverse proxy in front of n8n returned a 504. The Community Nodes page then listed nothing and gave no way to update or uninstall, although the packages were installed.

The update check now passes the same `registry` and `authToken` that install uses. `CommunityPackagesConfig` is already injected into this service, so no new wiring was needed. For a default instance the registry is `https://registry.npmjs.org`, which is npm's own default, so nothing changes there.

Files:
- `packages/cli/src/modules/community-packages/community-packages.lifecycle.service.ts`
- `packages/cli/src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts`

## How to test

Automated:

```bash
cd packages/cli
pnpm test src/modules/community-packages/__tests__/community-packages.lifecycle.service.test.ts
```

To see the new test fail without the fix, check out this branch, revert `community-packages.lifecycle.service.ts` to `master`, keep the test file, and run the command again. Two tests fail because the options object holds no `registry` and no `authToken`.

Manual:
1. Start a self-hosted instance with `N8N_COMMUNITY_PACKAGES_ENABLED=true`, `N8N_COMMUNITY_PACKAGES_REGISTRY=<private registry>` and `N8N_COMMUNITY_PACKAGES_AUTH_TOKEN=<token>`.
2. Install a community package from that registry.
3. Set `N8N_LOG_LEVEL=debug` and open Settings > Community Nodes.
4. Read the `Executing npm command` debug line for `outdated`. Before: `["outdated","--json"]`. After: it also carries `--registry=<private registry>` and the redacted `_authToken` flag, and the page lists the installed packages.

## Related Linear tickets, Github issues, and Community forum posts

fixes #35361

## Review / Merge checklist

- [x] I have seen this code and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

**How far the testing goes, stated plainly:** unit tests only. I ran the new tests on this branch, then reverted the source change and ran them again to see them fail for the right reason. I have **not** exercised this on a running n8n instance. The "How to test" steps above are written for a reviewer to follow; they are not a record of a run I performed.

AI tools did a meaningful part of this work (Claude Code); I reviewed every change and ran the tests.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk
