### PR TITLE
ci: Fail the Poutine scan gate when the SARIF report is unusable

### DIFF
--- a/.github/workflows/sec-poutine-reusable.yml
+++ b/.github/workflows/sec-poutine-reusable.yml
@@ -29,12 +29,30 @@ jobs:
 
       - name: Fail on error-level findings
         run: |
-          # Check SARIF for error-level findings
-          if jq -e '.runs[].results[] | select(.level == "error")' results.sarif > /dev/null 2>&1; then
+          # The scan must leave a report behind. A missing or empty file means the scan
+          # did not finish, which is not the same as a clean result, so fail the job.
+          if [ ! -s results.sarif ]; then
+            echo "::error::Poutine wrote no results.sarif, so the scan result cannot be trusted"
+            exit 1
+          fi
+
+          # Check SARIF for error-level findings.
+          # jq -e exits 0 when it printed a result and 4 when the filter matched nothing.
+          # Any other code means jq could not read or parse the file.
+          status=0
+          jq -e '.runs[].results[] | select(.level == "error")' results.sarif > /dev/null 2>&1 || status=$?
+
+          if [ "$status" -eq 0 ]; then
             echo "::error::Poutine found error-level security findings:"
             jq -r '.runs[].results[] | select(.level == "error") | "  - \(.ruleId): \(.message.text)"' results.sarif
             exit 1
           fi
+
+          if [ "$status" -ne 4 ]; then
+            echo "::error::Could not read results.sarif (jq exited with $status)"
+            exit 1
+          fi
+
           echo "No error-level findings detected"
 
       - name: Upload SARIF results


### PR DESCRIPTION
## Summary

`.github/workflows/sec-poutine-reusable.yml` decided pass/fail from the exit code of a single `jq -e` call. jq uses different non-zero codes for "the filter matched nothing" and "I could not read or parse that file", but the `if` statement treated every non-zero code the same way. A `results.sarif` that was missing, empty or corrupt therefore printed `No error-level findings detected` and the job exited 0 — the same output as a genuinely clean scan. A Poutine run that crashed before writing its report passed the required security gate.

The step now does two things:
1. Requires a non-empty `results.sarif` before it parses anything. No report means the scan did not finish, which is not a clean result.
2. Keeps jq's exit code and accepts only the "no match" code as clean. Any other code fails the step and names the code.

A real clean scan and a real finding behave exactly as before.

Note on the exit codes, because the numbers in the issue are slightly off: with jq 1.7.1, `jq -e` returns **4** for a valid SARIF that holds no error-level result (not 1 — 1 is for a last output of `false` or `null`), **2** for a missing file and **5** for malformed JSON. The change keys off 4, and I measured all of these rather than taking them from the manual.

## How to test

CI: the gate runs on every call of this reusable workflow. A normal scan is unaffected.

Locally, I ran the old and the new step body against five fixtures. `bash -e` is used to match the shell GitHub Actions gives a `run:` block.

```bash
mkdir -p /tmp/poutine-gate && cd /tmp/poutine-gate
echo '{"runs":[{"results":[]}]}' > clean.sarif
echo '{"runs":[{"results":[{"level":"error","ruleId":"R1","message":{"text":"bad"}}]}]}' > findings.sarif
printf '' > empty.sarif
echo '{"runs": [' > malformed.sarif
# then copy each fixture to results.sarif and run the step body
```

| fixture | before | after |
| --- | --- | --- |
| valid SARIF, no error findings | exit 0, "No error-level findings detected" | exit 0, same message |
| valid SARIF with an error finding | exit 1, finding printed | exit 1, finding printed |
| empty `results.sarif` | **exit 0, "No error-level findings detected"** | exit 1, "wrote no results.sarif" |
| malformed JSON | **exit 0, "No error-level findings detected"** | exit 1, "Could not read results.sarif (jq exited with 5)" |
| `results.sarif` absent | **exit 0, "No error-level findings detected"** | exit 1, "wrote no results.sarif" |

`actionlint .github/workflows/sec-poutine-reusable.yml` passes.

## Related Linear tickets, Github issues, and Community forum posts

fixes #38018

## Review / Merge checklist

- [x] I have seen this code and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included — the repository has no harness for workflow shell steps.

**How far the testing goes, stated plainly:** I ran the old and the new step body by hand against the five fixtures in the table above and recorded the exit code and output of each, which is the whole behaviour this PR changes. I have not run the reusable workflow itself on GitHub.

AI tools did a meaningful part of this work (Claude Code); I reviewed every change and ran the tests.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk
