### PR TITLE
fix(core): Keep collecting insights after one un-attributable event

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
@@ -263,3 +263,75 @@ describe('calculateTimeSaved', () => {
 		expect(timeSaved).toBe(20);
 	});
 });
+
+describe('flushEvents with an insight that has no shared workflow', () => {
+	let insightsRawRepository: ReturnType<typeof mock<InsightsRawRepository>>;
+	let insightsMetadataRepository: ReturnType<typeof mock<InsightsMetadataRepository>>;
+	let sharedWorkflowRepository: ReturnType<typeof mock<SharedWorkflowRepository>>;
+	let service: InsightsCollectionService;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		insightsRawRepository = mock<InsightsRawRepository>();
+		insightsMetadataRepository = mock<InsightsMetadataRepository>();
+		sharedWorkflowRepository = mock<SharedWorkflowRepository>();
+		service = new InsightsCollectionService(
+			sharedWorkflowRepository,
+			insightsRawRepository,
+			insightsMetadataRepository,
+			mock<InsightsConfig>(),
+			mockLogger(),
+		);
+		service.init();
+
+		// Only "known-workflow" has an owner row, so "gone-workflow" gets no metadata.
+		sharedWorkflowRepository.find.mockResolvedValue([
+			mock<SharedWorkflow>({
+				workflowId: 'known-workflow',
+				projectId: 'project-id',
+				project: mock<Project>({ name: 'Project' }),
+				role: 'workflow:owner',
+			}),
+		]);
+		insightsMetadataRepository.findBy.mockResolvedValue([
+			mock<InsightsMetadata>({ workflowId: 'known-workflow', metaId: 1 }),
+		]);
+	});
+
+	afterEach(async () => {
+		await service.shutdown();
+		vi.useRealTimers();
+	});
+
+	const bufferEvent = (workflowId: string) =>
+		service['bufferedInsights'].add({
+			workflowId,
+			workflowName: workflowId,
+			timestamp: DateTime.utc().toJSDate(),
+			type: 'success',
+			value: 1,
+		});
+
+	test('saves the rest of the batch and empties the buffer', async () => {
+		bufferEvent('known-workflow');
+		bufferEvent('gone-workflow');
+
+		await service.flushEvents();
+
+		expect(insightsRawRepository.insert).toHaveBeenCalledTimes(1);
+		expect(insightsRawRepository.insert).toHaveBeenCalledWith([
+			expect.objectContaining({ metaId: 1 }),
+		]);
+		expect(service['bufferedInsights'].size).toBe(0);
+	});
+
+	test('does not re-buffer the event on the next flush', async () => {
+		bufferEvent('gone-workflow');
+
+		await service.flushEvents();
+		await service.flushEvents();
+
+		expect(service['bufferedInsights'].size).toBe(0);
+		expect(insightsRawRepository.insert).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/modules/insights/insights-collection.service.ts
+++ b/packages/cli/src/modules/insights/insights-collection.service.ts
@@ -4,12 +4,7 @@ import { OnLifecycleEvent, type WorkflowExecuteAfterContext } from '@n8n/decorat
 import { Service } from '@n8n/di';
 import { In } from '@n8n/typeorm';
 import { DateTime } from 'luxon';
-import {
-	IRun,
-	UnexpectedError,
-	type ExecutionStatus,
-	type WorkflowExecuteMode,
-} from 'n8n-workflow';
+import { IRun, type ExecutionStatus, type WorkflowExecuteMode } from 'n8n-workflow';
 
 import { InsightsMetadata } from '@/modules/insights/database/entities/insights-metadata';
 import { InsightsRaw } from '@/modules/insights/database/entities/insights-raw';
@@ -275,14 +270,17 @@ export class InsightsCollectionService {
 		}
 
 		const events: InsightsRaw[] = [];
+		const workflowIdsWithoutMetadata = new Set<string>();
 		for (const event of insightsRawToInsertBuffer) {
 			const insight = new InsightsRaw();
 			const metadata = this.cachedMetadata.get(event.workflowId);
 			if (!metadata) {
-				// could not find shared workflow for this insight (not supposed to happen)
-				throw new UnexpectedError(
-					`Could not find shared workflow for insight with workflowId ${event.workflowId}`,
-				);
+				// No shared workflow row, so the insight cannot be attributed to a project.
+				// Drop it instead of failing the batch: a throw here sends every event back
+				// into the buffer, and the next flush rebuilds the same batch, so one
+				// un-attributable event would stall collection until the process restarts.
+				workflowIdsWithoutMetadata.add(event.workflowId);
+				continue;
 			}
 			insight.metaId = metadata.metaId;
 			insight.type = event.type;
@@ -291,6 +289,14 @@ export class InsightsCollectionService {
 
 			events.push(insight);
 		}
+
+		if (workflowIdsWithoutMetadata.size > 0) {
+			this.logger.warn('Dropped insights for workflows with no shared workflow', {
+				workflowIds: [...workflowIdsWithoutMetadata],
+			});
+		}
+
+		if (events.length === 0) return;
 
 		this.logger.debug(`Inserting ${events.length} insights raw`);
 		await this.insightsRawRepository.insert(events);


### PR DESCRIPTION
## Summary

`saveInsightsMetadataAndRaw()` threw an `UnexpectedError` when an event's workflow had no `workflow:owner` row, so the insight could not be attributed to a project. The throw happened while building the insert list, before any row was written, and `flushEvents()` catches it and puts **the whole batch** back into the buffer. The next flush copies the whole buffer again, hits the same event, and throws again.

So one un-attributable event stopped insights collection for the rest of the process's life: the dashboard flatlines while executions run normally, and the buffer keeps growing. The comment on the throw said the case was not supposed to happen, and the graceful-shutdown flush goes through the same path, so buffered events were lost on shutdown as well.

The flush now drops an event it cannot attribute, collects the workflow ids and logs them once as a warning, and writes the rest of the batch. Dropping is the only option left for such an event — without an owner row there is no project to attribute it to — and it keeps one bad event from taking the whole pipeline down. A transient failure (the database being unreachable, for example) still re-buffers the batch and retries, which is the behaviour that path is for.

This is the same loop as #27607, where a fractional value made the insert fail deterministically. #29553 removed that particular trigger; this removes the remaining deterministic per-event throw.

Files:
- `packages/cli/src/modules/insights/insights-collection.service.ts`
- `packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts`

## How to test

Automated:

```bash
cd packages/cli
pnpm test src/modules/insights/__tests__/insights-collection.service.test.ts
```

To see the new tests fail without the fix, check out this branch, revert `insights-collection.service.ts` to `master`, keep the test file, and run the command again. Both new tests fail: nothing is inserted, and the buffer still holds the events.

Manual:
1. Start an instance with insights enabled and run a workflow so events buffer.
2. Put an event into the buffer for a workflow id that has no `shared_workflow` row with role `workflow:owner` (deleting the workflow between the run and the flush reproduces it).
3. Watch the flush. Before: `Error while saving insights metadata and raw data` on every flush interval, `insights_raw` gains no rows, and the buffer keeps growing. After: one `Dropped insights for workflows with no shared workflow` warning naming the id, the remaining events land in `insights_raw`, and the next flush starts from an empty buffer.

## Related Linear tickets, Github issues, and Community forum posts

fixes #37788

## Review / Merge checklist

- [x] I have seen this code and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

**How far the testing goes, stated plainly:** unit tests only. I ran the new tests on this branch, then reverted the source change and ran them again to see them fail for the right reason. I have **not** exercised this on a running n8n instance. The "How to test" steps above are written for a reviewer to follow; they are not a record of a run I performed.

AI tools did a meaningful part of this work (Claude Code); I reviewed every change and ran the tests.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk
