### PR TITLE
fix(GraphQL Node): Stop a failed query from also filling the success output

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -557,6 +557,46 @@ export class GraphQL implements INodeType {
 				} else {
 					response = await this.helpers.request(requestOptions);
 				}
+				if (responseFormat !== 'string' && typeof response === 'string') {
+					try {
+						response = JSON.parse(response);
+					} catch (error) {
+						throw new NodeOperationError(
+							this.getNode(),
+							'Response body is not valid JSON. Change "Response Format" to "String"',
+							{ itemIndex },
+						);
+					}
+				}
+
+				// GraphQL reports failures with an `errors` array on an HTTP 200, so the check
+				// runs before the item is pushed. Pushing first left the item on the success
+				// output as well, and with "Continue (using error output)" both outputs then
+				// fired for the same input item.
+				let errorSource = response;
+				// parse error string messages
+				if (typeof errorSource === 'string' && errorSource.startsWith('{"errors":')) {
+					try {
+						const errorResponse = JSON.parse(errorSource) as IDataObject;
+						if (Array.isArray(errorResponse.errors)) {
+							errorSource = errorResponse;
+						}
+					} catch (e) {}
+				}
+				// throw from response object.errors[]
+				if (typeof errorSource === 'object' && errorSource.errors) {
+					let message = 'Unexpected error';
+					if (Array.isArray(errorSource.errors)) {
+						message = (errorSource.errors as IDataObject[])
+							.map((error) => error.message ?? error)
+							.join(', ');
+					} else if (typeof errorSource.errors === 'string') {
+						message = errorSource.errors;
+					}
+
+					throw new NodeApiError(this.getNode(), errorSource.errors as JsonObject, { message });
+				}
+
 				if (responseFormat === 'string') {
 					const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 					returnItems.push({
@@ -565,46 +605,11 @@ export class GraphQL implements INodeType {
 						},
 					});
 				} else {
-					if (typeof response === 'string') {
-						try {
-							response = JSON.parse(response);
-						} catch (error) {
-							throw new NodeOperationError(
-								this.getNode(),
-								'Response body is not valid JSON. Change "Response Format" to "String"',
-								{ itemIndex },
-							);
-						}
-					}
-
 					const executionData = this.helpers.constructExecutionMetaData(
 						this.helpers.returnJsonArray(response as IDataObject),
 						{ itemData: { item: itemIndex } },
 					);
 					returnItems.push(...executionData);
-				}
-
-				// parse error string messages
-				if (typeof response === 'string' && response.startsWith('{"errors":')) {
-					try {
-						const errorResponse = JSON.parse(response) as IDataObject;
-						if (Array.isArray(errorResponse.errors)) {
-							response = errorResponse;
-						}
-					} catch (e) {}
-				}
-				// throw from response object.errors[]
-				if (typeof response === 'object' && response.errors) {
-					let message = 'Unexpected error';
-					if (Array.isArray(response.errors)) {
-						message = (response.errors as IDataObject[])
-							.map((error) => error.message ?? error)
-							.join(', ');
-					} else if (typeof response.errors === 'string') {
-						message = response.errors;
-					}
-
-					throw new NodeApiError(this.getNode(), response.errors as JsonObject, { message });
 				}
 			} catch (error) {
 				if (!this.continueOnFail()) {

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -228,6 +228,58 @@ describe('GraphQL Node', () => {
 
 			await expect(node.execute.call(mockExecuteFunctions)).rejects.toBe(executionError);
 		});
+
+		it('should return only the error item when continuing on fail', async () => {
+			const mockExecuteFunctions = createMockExecuteFunctions({
+				query: 'query { foo }',
+			});
+			mockExecuteFunctions.continueOnFail.mockReturnValue(true);
+			mockExecuteFunctions.helpers.request.mockResolvedValue({
+				data: { foo: null },
+				errors: [{ message: 'Bad format' }],
+			});
+			const node = new GraphQL();
+
+			const [items] = await node.execute.call(mockExecuteFunctions);
+
+			expect(items).toEqual([
+				expect.objectContaining({ json: { error: 'Bad format' }, pairedItem: { item: 0 } }),
+			]);
+		});
+
+		it('should return only the error item for a string response format', async () => {
+			const mockExecuteFunctions = createMockExecuteFunctions({
+				query: 'query { foo }',
+				responseFormat: 'string',
+				dataPropertyName: 'data',
+			});
+			mockExecuteFunctions.continueOnFail.mockReturnValue(true);
+			mockExecuteFunctions.helpers.request.mockResolvedValue(
+				'{"errors":[{"message":"Bad format"}]}',
+			);
+			const node = new GraphQL();
+
+			const [items] = await node.execute.call(mockExecuteFunctions);
+
+			expect(items).toEqual([
+				expect.objectContaining({ json: { error: 'Bad format' }, pairedItem: { item: 0 } }),
+			]);
+		});
+
+		it('should still return the response when it holds no errors', async () => {
+			const mockExecuteFunctions = createMockExecuteFunctions({
+				query: 'query { foo }',
+			});
+			mockExecuteFunctions.continueOnFail.mockReturnValue(true);
+			mockExecuteFunctions.helpers.request.mockResolvedValue({ data: { foo: 'bar' } });
+			const node = new GraphQL();
+
+			const [items] = await node.execute.call(mockExecuteFunctions);
+
+			expect(items).toEqual([
+				expect.objectContaining({ json: { data: { foo: 'bar' } }, pairedItem: { item: 0 } }),
+			]);
+		});
 	});
 
 	describe('credential allowed domains', () => {


### PR DESCRIPTION
## Summary

GraphQL answers a failed query with HTTP 200 and an `errors` array in the body. The node pushed that body into `returnItems` as a success item and only afterwards threw on `errors`. The `catch` then pushed an error item for the same input item, so `returnItems` held both. With "On Error: Continue (using error output)" the execution engine sent one item down each output, and the success branch received `This is an item, but it's empty.`

The error check now runs before anything is pushed. Detection itself is unchanged:
- `Response Format: string` still looks for a body that starts with `{"errors":`, and still pushes the raw string when there is no error.
- Any other format still parses the body first and then reads `errors` off the object, so a partial response such as `{"data": …, "errors": […]}` is still caught.

The JSON parse for the non-string format moved above the check, which is what keeps the partial-response case working. Behaviour with "On Error: Stop workflow" is unchanged.

This reopens the work in #20360, which was closed for inactivity rather than on review. I rewrote the fix so the two problems the bots raised there do not apply: error detection for the `string` format is kept, and the narrow `startsWith('{"errors":')` test is kept rather than widened to a substring search.

Files:
- `packages/nodes-base/nodes/GraphQL/GraphQL.node.ts`
- `packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts`

## How to test

Automated:

```bash
cd packages/nodes-base
pnpm test nodes/GraphQL
```

To see the new tests fail without the fix, check out this branch, revert `GraphQL.node.ts` to `master`, keep the test file, and run the command again. The two "should return only the error item" tests fail because the array holds the success item as well.

Manual (the reporter's workflow):
1. GraphQL node, endpoint `https://swapi-graphql.netlify.app/graphql`, a query the endpoint rejects.
2. Set On Error to "Continue (using error output)" and wire both outputs.
3. Execute. Before: the error output holds the error and the success output holds an empty item. After: only the error output receives an item.
4. Run a valid query to confirm the success output still receives the response, with both `Response Format: JSON` and `Response Format: String`.

## Related Linear tickets, Github issues, and Community forum posts

fixes #20321

Supersedes #20360 (closed for inactivity).

## Review / Merge checklist

- [x] I have seen this code and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

**How far the testing goes, stated plainly:** unit tests **and** a manual run. I ran the new tests on this branch, then reverted the source change and ran them again to see them fail for the right reason. I then built this branch and executed the workflow above against the live `https://swapi-graphql.netlify.app/graphql` endpoint on a local instance, on a `master` build and on this branch, plus three non-regression cases. The before/after run data is in a comment on this PR.

AI tools did a meaningful part of this work (Claude Code); I reviewed every change and ran the tests.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk
