### PR TITLE
fix(YouTube Node): Apply the chosen privacy status when creating a playlist

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -498,12 +498,14 @@ export class YouTube implements INodeType {
 						const title = this.getNodeParameter('title', i) as string;
 						const options = this.getNodeParameter('options', i);
 
-						qs.part = 'snippet';
+						// The API reads privacyStatus from the status resource, so `part` must name it.
+						qs.part = 'snippet,status';
 
 						const body: IDataObject = {
 							snippet: {
 								title,
 							},
+							status: {},
 						};
 
 						if (options.tags) {
@@ -513,7 +515,12 @@ export class YouTube implements INodeType {
 
 						if (options.description) {
 							//@ts-ignore
-							body.snippet.privacyStatus = options.privacyStatus as string;
+							body.snippet.description = options.description as string;
+						}
+
+						if (options.privacyStatus) {
+							//@ts-ignore
+							body.status.privacyStatus = options.privacyStatus as string;
 						}
 
 						if (options.defaultLanguage) {

--- a/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts
@@ -69,9 +69,14 @@ describe('Test YouTube Node', () => {
 		beforeAll(() => {
 			youtubeNock
 				.post('/v3/playlists', {
-					snippet: { title: 'Playlist 1', privacyStatus: 'public', defaultLanguage: 'en' },
+					snippet: {
+						title: 'Playlist 1',
+						description: 'Description for Playlist 1.',
+						defaultLanguage: 'en',
+					},
+					status: { privacyStatus: 'public' },
 				})
-				.query({ part: 'snippet' })
+				.query({ part: 'snippet,status' })
 				.reply(200, playlists[0]);
 			youtubeNock
 				.put('/v3/playlists', {


### PR DESCRIPTION
## Summary

Creating a playlist always produced a private playlist, whatever the Privacy Status option said. Three things in the create branch worked against each other:

1. The value went into `snippet.privacyStatus`. The API reads it from the `status` resource — the update operation in the same file already writes `status.privacyStatus`.
2. The assignment sat under `if (options.description)`, so it only ran when a description happened to be set, and it wrote the wrong field. Description itself was therefore never sent at all.
3. `qs.part` named only `snippet`. The API ignores a resource that `part` does not name, so even a correctly placed `status.privacyStatus` would have been dropped.

The create branch now writes `status.privacyStatus`, writes `snippet.description` under its own condition, and sets `part` to `snippet,status`, which matches what the update operation sends.

Note on output: because `part` now includes `status`, a created playlist comes back with its `status` object as well. That is what makes the setting take effect, and it matches the shape the update operation already returns.

Files:
- `packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts`
- `packages/nodes-base/nodes/Google/YouTube/__test__/node/YouTube.node.test.ts`

## How to test

Automated:

```bash
cd packages/nodes-base
pnpm --filter n8n-nodes-base build   # the workflow harness loads the node from dist
pnpm test nodes/Google/YouTube
```

The nock interceptor for `POST /v3/playlists` in the Playlist suite is the regression test: it now requires `status: { privacyStatus: 'public' }`, `snippet.description`, and `part=snippet,status`. The workflow it runs already sets all three options.

To see it fail without the fix: revert `YouTube.node.ts` to `master`, rebuild, and run the test. The request is sent as `part=snippet` with `{"snippet":{"title":"Playlist 1","privacyStatus":"public","defaultLanguage":"en"}}`, nock does not match, and the suite fails with `Data for node "Playlist Create" is missing!`. I captured that payload from the old build before making the change.

Manual:
1. YouTube node, Resource: Playlist, Operation: Create.
2. Set a title, set Privacy Status to Public, and set a Description.
3. Execute, then open the playlist on YouTube. Before: private, with no description. After: public, with the description.

## Related Linear tickets, Github issues, and Community forum posts

fixes #16442

Supersedes #16451 (closed for inactivity), which fixed the privacy status the same way. This also repairs the Description option that the same broken condition was swallowing, and leaves `status` empty rather than defaulting it to `private`, so the API keeps ownership of the default.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

AI tools did a meaningful part of this work (Claude Code); I reviewed and ran every change.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk
