### PR TITLE
fix(Raindrop Node): Read every page of bookmarks

### DIFF
--- a/packages/nodes-base/nodes/Raindrop/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Raindrop/GenericFunctions.ts
@@ -51,3 +51,45 @@ export async function raindropApiRequest(
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
 }
+
+/** Raindrop caps a page of raindrops at 50 items. */
+const RAINDROPS_PER_PAGE = 50;
+
+/**
+ * Page through a paginated Raindrop collection. `limit` stops the paging early;
+ * omit it to read every page.
+ */
+export async function raindropApiRequestAllItems(
+	this: IExecuteFunctions,
+	method: IHttpRequestMethods,
+	endpoint: string,
+	qs: IDataObject,
+	body: IDataObject,
+	limit?: number,
+): Promise<IDataObject[]> {
+	const returnData: IDataObject[] = [];
+	const perpage = limit === undefined ? RAINDROPS_PER_PAGE : Math.min(limit, RAINDROPS_PER_PAGE);
+	let page = 0;
+	let pageLength = 0;
+
+	do {
+		const responseData = await raindropApiRequest.call(
+			this,
+			method,
+			endpoint,
+			{
+				...qs,
+				perpage,
+				page,
+			},
+			body,
+		);
+
+		const items = (responseData.items ?? []) as IDataObject[];
+		pageLength = items.length;
+		returnData.push(...items);
+		page++;
+	} while (pageLength === perpage && (limit === undefined || returnData.length < limit));
+
+	return limit === undefined ? returnData : returnData.slice(0, limit);
+}

--- a/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
+++ b/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
@@ -20,7 +20,7 @@ import {
 	userFields,
 	userOperations,
 } from './descriptions';
-import { raindropApiRequest } from './GenericFunctions';
+import { raindropApiRequest, raindropApiRequestAllItems } from './GenericFunctions';
 
 export class Raindrop implements INodeType {
 	description: INodeTypeDescription = {
@@ -165,13 +165,17 @@ export class Raindrop implements INodeType {
 
 						const collectionId = this.getNodeParameter('collectionId', i);
 						const endpoint = `/raindrops/${collectionId}`;
-						responseData = await raindropApiRequest.call(this, 'GET', endpoint, {}, {});
-						responseData = responseData.items;
-
-						if (!returnAll) {
-							const limit = this.getNodeParameter('limit', 0);
-							responseData = responseData.slice(0, limit);
-						}
+						// The endpoint answers one page at a time, so a single request returned
+						// only the first page however many bookmarks the collection held.
+						const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+						responseData = await raindropApiRequestAllItems.call(
+							this,
+							'GET',
+							endpoint,
+							{},
+							{},
+							limit,
+						);
 					} else if (operation === 'update') {
 						// ----------------------------------
 						//         bookmark: update

--- a/packages/nodes-base/nodes/Raindrop/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Raindrop/__tests__/GenericFunctions.test.ts
@@ -1,0 +1,109 @@
+import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { raindropApiRequestAllItems } from '../GenericFunctions';
+
+describe('Raindrop GenericFunctions', () => {
+	let mockExecuteFunctions: ReturnType<typeof mockDeep<IExecuteFunctions>>;
+
+	/** A page of `count` bookmarks, numbered from `from`. */
+	const page = (from: number, count: number) => ({
+		items: Array.from({ length: count }, (_, index) => ({ _id: from + index })),
+	});
+
+	/** Serve `total` bookmarks, honouring the `perpage` and `page` query parameters. */
+	const serve = (total: number) => {
+		mockExecuteFunctions.helpers.requestOAuth2.mockImplementation(async (_credentials, options) => {
+			const { perpage, page: pageIndex } = (options as { qs: IDataObject }).qs as {
+				perpage: number;
+				page: number;
+			};
+			const start = pageIndex * perpage;
+			return page(start, Math.max(0, Math.min(perpage, total - start)));
+		});
+	};
+
+	beforeEach(() => {
+		mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+	});
+
+	describe('raindropApiRequestAllItems', () => {
+		it('reads every page when no limit is given', async () => {
+			serve(130);
+
+			const items = await raindropApiRequestAllItems.call(
+				mockExecuteFunctions,
+				'GET',
+				'/raindrops/0',
+				{},
+				{},
+			);
+
+			expect(items).toHaveLength(130);
+			expect(items[0]).toEqual({ _id: 0 });
+			expect(items[129]).toEqual({ _id: 129 });
+		});
+
+		it('stops on the first short page', async () => {
+			serve(60);
+
+			const items = await raindropApiRequestAllItems.call(
+				mockExecuteFunctions,
+				'GET',
+				'/raindrops/0',
+				{},
+				{},
+			);
+
+			expect(items).toHaveLength(60);
+			expect(mockExecuteFunctions.helpers.requestOAuth2).toHaveBeenCalledTimes(2);
+		});
+
+		it('reads enough pages to satisfy a limit larger than one page', async () => {
+			serve(200);
+
+			const items = await raindropApiRequestAllItems.call(
+				mockExecuteFunctions,
+				'GET',
+				'/raindrops/0',
+				{},
+				{},
+				75,
+			);
+
+			expect(items).toHaveLength(75);
+			expect(items[74]).toEqual({ _id: 74 });
+		});
+
+		it('asks for no more than the limit when it fits in one page', async () => {
+			serve(200);
+
+			const items = await raindropApiRequestAllItems.call(
+				mockExecuteFunctions,
+				'GET',
+				'/raindrops/0',
+				{},
+				{},
+				5,
+			);
+
+			expect(items).toHaveLength(5);
+			expect(mockExecuteFunctions.helpers.requestOAuth2).toHaveBeenCalledTimes(1);
+		});
+
+		it('returns what exists when the collection is smaller than the limit', async () => {
+			serve(3);
+
+			const items = await raindropApiRequestAllItems.call(
+				mockExecuteFunctions,
+				'GET',
+				'/raindrops/0',
+				{},
+				{},
+				100,
+			);
+
+			expect(items).toHaveLength(3);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Raindrop/__tests__/Raindrop.node.test.ts
+++ b/packages/nodes-base/nodes/Raindrop/__tests__/Raindrop.node.test.ts
@@ -1,0 +1,84 @@
+import { returnJsonArray } from 'n8n-core';
+import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { Raindrop } from '../Raindrop.node';
+
+describe('Raindrop Node, bookmark: getAll', () => {
+	let mockExecuteFunctions: ReturnType<typeof mockDeep<IExecuteFunctions>>;
+
+	/**
+	 * Serve `total` bookmarks, honouring the `perpage` and `page` query parameters.
+	 * A request that sends neither gets Raindrop's own defaults: the first 25.
+	 */
+	const serve = (total: number) => {
+		mockExecuteFunctions.helpers.requestOAuth2.mockImplementation(async (_credentials, options) => {
+			const qs = ((options as { qs?: IDataObject }).qs ?? {}) as {
+				perpage?: number;
+				page?: number;
+			};
+			const perpage = qs.perpage ?? 25;
+			const page = qs.page ?? 0;
+			const start = page * perpage;
+			const count = Math.max(0, Math.min(perpage, total - start));
+			return { items: Array.from({ length: count }, (_, index) => ({ _id: start + index })) };
+		});
+	};
+
+	const setParameters = (parameters: IDataObject) => {
+		mockExecuteFunctions.getNodeParameter.mockImplementation(
+			(name, _itemIndex, fallback) => parameters[name] ?? fallback,
+		);
+	};
+
+	beforeEach(() => {
+		mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+		mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		mockExecuteFunctions.helpers.returnJsonArray.mockImplementation(returnJsonArray);
+	});
+
+	it('returns every bookmark when Return All is on', async () => {
+		serve(130);
+		setParameters({
+			resource: 'bookmark',
+			operation: 'getAll',
+			returnAll: true,
+			collectionId: 0,
+		});
+
+		const [items] = await new Raindrop().execute.call(mockExecuteFunctions);
+
+		expect(items).toHaveLength(130);
+		expect(items[129].json).toEqual({ _id: 129 });
+	});
+
+	it('returns a limit that is larger than one page', async () => {
+		serve(200);
+		setParameters({
+			resource: 'bookmark',
+			operation: 'getAll',
+			returnAll: false,
+			limit: 60,
+			collectionId: 0,
+		});
+
+		const [items] = await new Raindrop().execute.call(mockExecuteFunctions);
+
+		expect(items).toHaveLength(60);
+	});
+
+	it('returns the whole collection when it is smaller than the limit', async () => {
+		serve(7);
+		setParameters({
+			resource: 'bookmark',
+			operation: 'getAll',
+			returnAll: false,
+			limit: 100,
+			collectionId: 0,
+		});
+
+		const [items] = await new Raindrop().execute.call(mockExecuteFunctions);
+
+		expect(items).toHaveLength(7);
+	});
+});


### PR DESCRIPTION
## Summary

"Bookmark: Get Many" sent a single request to `/raindrops/{collectionId}`. That endpoint answers one page at a time, so the node only ever saw the first 25 bookmarks: "Return All" returned 25, and a Limit above 25 could not be met either, because the slice ran over a list that already held only 25 entries.

The operation now pages through the collection with Raindrop's `perpage` and `page` query parameters, in a new `raindropApiRequestAllItems` helper:
- **Return All on** — keep asking for pages of 50 (Raindrop's maximum) until a short page comes back.
- **Return All off** — ask for `min(limit, 50)` per page and stop as soon as the limit is met, so a small limit still costs one request.

Collections and Tags are untouched. Their endpoints return the whole list in one response, so the same single request is still correct for them.

Files:
- `packages/nodes-base/nodes/Raindrop/GenericFunctions.ts` — `raindropApiRequestAllItems`
- `packages/nodes-base/nodes/Raindrop/Raindrop.node.ts` — use it for `bookmark: getAll`
- `packages/nodes-base/nodes/Raindrop/__tests__/` — new tests

## How to test

Automated:

```bash
cd packages/nodes-base
pnpm test nodes/Raindrop
```

To see the node-level tests fail without the fix, check out this branch, revert `Raindrop.node.ts` to `master`, keep the test files, and run the command again. The mocked API applies Raindrop's own defaults when a request sends no paging parameters, so `master` produces:

```
× returns every bookmark when Return All is on
  AssertionError: expected [...] to have a length of 130 but got 25
× returns a limit that is larger than one page
  AssertionError: expected [...] to have a length of 60 but got 25
✓ returns the whole collection when it is smaller than the limit
```

The third one passes on `master` too, because a collection that fits in one page was never affected.

Manual (the reporter's steps):
1. Have more than 25 bookmarks.
2. Raindrop node, Resource: Bookmark, Operation: Get Many, Collection `0` (all collections), Return All on.
3. Execute. Before: 25 items. After: every bookmark.
4. Turn Return All off and set Limit to 60. Before: 25 items. After: 60.

## Related Linear tickets, Github issues, and Community forum posts

fixes #20156

Supersedes #20271 (closed for inactivity).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

AI tools did a meaningful part of this work (Claude Code); I reviewed and ran every change.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/38521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

