### PR TITLE
fix(core): Make MCP workflow inputs compatible with ChatGPT custom apps

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/workflow-inputs.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/workflow-inputs.test.ts
@@ -1,3 +1,4 @@
+import { shapeToStandardSchema } from '../tool-schema.util';
 import { workflowInputsSchema } from '../tools/workflow-inputs';
 
 describe('workflowInputsSchema', () => {
@@ -9,6 +10,26 @@ describe('workflowInputsSchema', () => {
 		expect(workflowInputsSchema.parse({ webhookData: { body: { x: 1 } } })).toEqual({
 			webhookData: { method: 'GET', body: { x: 1 } },
 		});
+	});
+
+	test('advertises inputs as one object instead of a union', () => {
+		const schema = shapeToStandardSchema({ inputs: workflowInputsSchema });
+		const json = schema['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
+		const inputs = (json as { properties?: Record<string, unknown> }).properties?.inputs;
+
+		expect(inputs).toMatchObject({
+			type: 'object',
+			properties: {
+				chatInput: { type: 'string' },
+				formData: { type: 'object' },
+				webhookData: { type: 'object' },
+			},
+		});
+		expect(JSON.stringify(inputs)).not.toContain('anyOf');
+	});
+
+	test('requires exactly one payload key', () => {
+		expect(workflowInputsSchema.safeParse({}).success).toBe(false);
 	});
 
 	test('rejects leftover type', () => {

--- a/packages/cli/src/modules/mcp/tools/workflow-inputs.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-inputs.ts
@@ -44,11 +44,19 @@ export const webhookWorkflowInputSchema = z
 	})
 	.strict();
 
-export const workflowInputsSchema = z.union([
-	chatWorkflowInputSchema,
-	formWorkflowInputSchema,
-	webhookWorkflowInputSchema,
-]);
+export const workflowInputsSchema = z
+	.object({
+		chatInput: chatWorkflowInputSchema.shape.chatInput.optional(),
+		formData: formWorkflowInputSchema.shape.formData.optional(),
+		webhookData: webhookWorkflowInputSchema.shape.webhookData.optional(),
+	})
+	.strict()
+	.refine(
+		(inputs) =>
+			[inputs.chatInput, inputs.formData, inputs.webhookData].filter((value) => value !== undefined)
+				.length === 1,
+		{ message: 'Provide exactly one of chatInput, formData, or webhookData' },
+	);
 
 export type WorkflowInputs = z.infer<typeof workflowInputsSchema>;
 


### PR DESCRIPTION
## Summary

ChatGPT custom apps could not use `execute_workflow` for workflows that require trigger input.

### Before

n8n advertised `inputs` as a strict union of three objects: one each for chat, form, and webhook workflows. ChatGPT converted these alternatives into separate variants and added a `type` field to identify the selected variant.

For example, ChatGPT could send this webhook payload:

```json
{
  "inputs": {
    "type": "webhook",
    "webhookData": {
      "body": {}
    }
  }
}
```

n8n rejected the added `type` field because each object in the union was strict. The request failed validation before the workflow started.

### After

n8n now advertises `inputs` as one strict object with three optional fields:

- `chatInput`
- `formData`
- `webhookData`

A runtime check requires the caller to provide exactly one of these fields. The published schema no longer contains the `anyOf` alternatives that caused ChatGPT to add `type`.

The existing validation remains strict. n8n still rejects empty input, multiple input types, unknown fields, and invalid webhook fields.

## How to test

From `packages/cli`, run:

```sh
pnpm exec vitest run src/modules/mcp/__tests__/execute-workflow.tool.test.ts src/modules/mcp/__tests__/workflow-inputs.test.ts
```

All 42 tests should pass. The regression test also confirms that the published `inputs` schema is one object without `anyOf`.

To verify the integration manually:

1. Connect a ChatGPT custom app to the n8n MCP server.
2. Select a workflow that uses a Chat Trigger, Form Trigger, or Webhook Trigger.
3. Call `execute_workflow` with the input required by that trigger.
4. Confirm that the call reaches n8n without failing because of an added `inputs.type` field.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes https://github.com/n8n-io/n8n/issues/38512
- https://linear.app/n8n/issue/GHC-9452

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([[conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Documentation is not affected by this internal schema compatibility fix.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)