### PR TITLE
fix(core): Skip non-credential files in import:credentials --separate

### DIFF
--- a/packages/cli/src/commands/import/__tests__/credentials.test.ts
+++ b/packages/cli/src/commands/import/__tests__/credentials.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import '@/zod-alias-support';
+
+import { ImportCredentialsCommand } from '../credentials';
+
+describe('ImportCredentialsCommand', () => {
+	let inputDir: string;
+
+	const buildCommand = () => {
+		const command = new ImportCredentialsCommand();
+		const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+		// @ts-expect-error Protected property
+		command.logger = logger;
+		return { command, logger };
+	};
+
+	/** What `export:credentials --backup` writes for one credential. */
+	const credentialFile = (id: string) => ({
+		id,
+		name: `Credential ${id}`,
+		data: 'U2FsdGVkX1+encrypted',
+		type: 'httpHeaderAuth',
+	});
+
+	/** What `export:workflow --backup` writes for one workflow, into the same directory. */
+	const workflowFile = (id: string) => ({
+		id,
+		name: `Workflow ${id}`,
+		nodes: [],
+		connections: {},
+		active: false,
+	});
+
+	beforeEach(async () => {
+		inputDir = await mkdtemp(join(tmpdir(), 'n8n-import-credentials-'));
+	});
+
+	afterEach(async () => {
+		await rm(inputDir, { recursive: true, force: true });
+	});
+
+	const write = async (name: string, content: unknown) =>
+		await writeFile(join(inputDir, name), JSON.stringify(content), 'utf8');
+
+	describe('--separate', () => {
+		it('skips a workflow file that sits in the same directory', async () => {
+			await write('cred-1.json', credentialFile('cred-1'));
+			await write('xbNcOFBmxn4eb05i.json', workflowFile('xbNcOFBmxn4eb05i'));
+			const { command, logger } = buildCommand();
+
+			// @ts-expect-error Private method
+			const credentials = await command.readCredentials({ inputPath: inputDir, separate: true });
+
+			expect(credentials).toHaveLength(1);
+			expect(credentials[0]).toMatchObject({ id: 'cred-1', type: 'httpHeaderAuth' });
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Skipping invalid credential file'),
+			);
+		});
+
+		it('reads every credential file when the directory holds only credentials', async () => {
+			await write('cred-1.json', credentialFile('cred-1'));
+			await write('cred-2.json', credentialFile('cred-2'));
+			const { command, logger } = buildCommand();
+
+			// @ts-expect-error Private method
+			const credentials = await command.readCredentials({ inputPath: inputDir, separate: true });
+
+			expect(credentials).toHaveLength(2);
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -69,6 +69,18 @@ type ImportableCredentialProperty = Exclude<
 const isCredentialData = (data: unknown): data is ICredentialDataDecryptedObject =>
 	typeof data === 'object' && data !== null && !Array.isArray(data);
 
+/**
+ * A credential export always carries a `type` and a `data` field. The import
+ * directory usually also holds the workflow files that `export:workflow --backup`
+ * writes, and those must be skipped rather than inserted as credentials.
+ */
+const isExportedCredential = (content: unknown): content is Partial<CredentialsEntity> =>
+	typeof content === 'object' &&
+	content !== null &&
+	!Array.isArray(content) &&
+	typeof (content as { type?: unknown }).type === 'string' &&
+	(content as { data?: unknown }).data !== undefined;
+
 @Command({
 	name: 'import:credentials',
 	description: 'Import credentials',
@@ -353,9 +365,18 @@ export class ImportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 				absolute: true,
 			});
 
-			credentials = files.map((file) =>
-				jsonParse<Partial<CredentialsEntity>>(fs.readFileSync(file, { encoding: 'utf8' })),
-			);
+			credentials = [];
+
+			for (const file of files) {
+				const content = jsonParse<unknown>(fs.readFileSync(file, { encoding: 'utf8' }));
+
+				if (!isExportedCredential(content)) {
+					this.logger.warn(`Skipping invalid credential file: ${file}`);
+					continue;
+				}
+
+				credentials.push(content);
+			}
 		} else {
 			const credentialsUnchecked = jsonParse<Array<Partial<CredentialsEntity>>>(
 				fs.readFileSync(inputPath, { encoding: 'utf8' }),


### PR DESCRIPTION
## Summary

The CLI documentation's own example writes both backups into one directory:

```sh
n8n export:workflow    --backup --output=backups/latest/
n8n export:credentials --backup --output=backups/latest/
```

Restoring from that directory then behaves differently for the two importers. `import:workflow --separate` validates each file and skips the ones it cannot read as a workflow. `import:credentials --separate` read every `*.json` in the directory as a credential, so the workflow files went to the insert as well and the command aborted:

```text
SQLITE_CONSTRAINT: NOT NULL constraint failed: credentials_entity.data
```

Because the insert loop runs inside one lock, the abort left the real credentials unimported too.

The importer now checks each file for the `type` and `data` fields that a credential export always carries, skips the rest, and logs `Skipping invalid credential file: <path>` for each one — the same shape as the workflow importer's message. A directory that holds only credential files behaves exactly as before.

Files:
- `packages/cli/src/commands/import/credentials.ts`
- `packages/cli/src/commands/import/__tests__/credentials.test.ts` (new)

## How to test

Automated:

```bash
cd packages/cli
pnpm test src/commands/import/__tests__/credentials.test.ts
```

To see the new test fail without the fix, check out this branch, revert `credentials.ts` to `master`, keep the test file, and run the command again:

```text
× skips a workflow file that sits in the same directory
  AssertionError: expected [ { id: 'cred-1', … }, … ] to have a length of 1 but got 2
```

The second test passes on `master` too, because a directory of only credential files was never affected.

Manual (the reporter's steps):
1. On a source instance, export into one directory:
   `n8n export:workflow --backup --output=backups/latest/` and `n8n export:credentials --backup --output=backups/latest/`
2. On a fresh instance, run `n8n import:workflow --separate --input=backups/latest/` (already fine), then `n8n import:credentials --separate --input=backups/latest/`.
3. Before: exit 1 with `SQLITE_CONSTRAINT: NOT NULL constraint failed: credentials_entity.data`, and no credential imported. After: `Skipping invalid credential file: …` for each workflow file, and `Successfully imported 1 credential.`

## Related Linear tickets, Github issues, and Community forum posts

fixes #37814

## Review / Merge checklist

- [x] I have seen this code and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

**How far the testing goes, stated plainly:** unit tests only. I ran the new tests on this branch, then reverted the source change and ran them again to see them fail for the right reason. I have **not** exercised this on a running n8n instance. The "How to test" steps above are written for a reviewer to follow; they are not a record of a run I performed.

AI tools did a meaningful part of this work (Claude Code); I reviewed every change and ran the tests.

https://claude.ai/code/session_01Ax76YG2oRYYUvnYMdUdChk
